### PR TITLE
feat: fix nav-pagination btn color in dark and light mode

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1363,7 +1363,7 @@ ul#post-list li {
 .nav-pagination li a,
 .nav-pagination li span {
   font-size: 14px;
-  color: var(--fgColor);
+  color: #000;
   height: 32px;
   line-height: 32px;
   display: flex;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48955965/137058146-dbfd432d-719d-44d6-8723-871551b48c83.png)

修正下方頁碼的文字顏色顯現問題，目前下方 pagination 除了文字以外其他部分不受深淺模式影響，先把文字的與 mode 的關聯移除