### PR TITLE
[Stack 2/9] 效能：頭像圖片管線瘦身、CSS 不可變快取與並行建置安全

### DIFF
--- a/_11ty/blurry-placeholder.js
+++ b/_11ty/blurry-placeholder.js
@@ -27,6 +27,7 @@ const sharp = require("sharp");
 const sizeOf = promisify(require("image-size"));
 const DatauriParser = require("datauri/parser");
 const parser = new DatauriParser();
+const fsSync = require("fs");
 const readFile = promisify(require("fs").readFile);
 const writeFile = promisify(require("fs").writeFile);
 const exists = promisify(require("fs").exists);
@@ -47,6 +48,7 @@ function escaper(match) {
 }
 
 const cache = {};
+const placeholderCache = {};
 
 async function getCachedDataURI(src) {
   if (cache[src]) {
@@ -91,16 +93,33 @@ function getBitmapDimensions_(imgWidth, imgHeight) {
   return { width: Math.round(bitmapWidth), height: Math.round(bitmapHeight) };
 }
 
-module.exports = async function (src) {
-  const filename = "_site/" + src;
+module.exports = function (src) {
+  if (!placeholderCache[src]) {
+    placeholderCache[src] = buildPlaceholder(src);
+  }
+  return placeholderCache[src];
+};
+
+async function buildPlaceholder(src) {
+  let decodedSrc;
+  try {
+    decodedSrc = decodeURIComponent(src.split(/[?#]/, 1)[0]);
+  } catch (e) {
+    throw new Error(`Invalid URL encoding in local image "${src}"`);
+  }
+  const filename = "_site/" + decodedSrc;
   const cachedName = filename + ".blurred";
   if (await exists(cachedName)) {
     return readFile(cachedName, {
       encoding: "utf-8",
     });
   }
+  // Read from the source tree when possible: the `_site/` copy is written by
+  // passthrough copy concurrently with transforms and may be incomplete.
+  const sourceName = "." + (decodedSrc.startsWith("/") ? decodedSrc : "/" + decodedSrc);
+  const inputName = fsSync.existsSync(sourceName) ? sourceName : filename;
   // We wrap the blurred image in a SVG to avoid rasterizing the filter on each layout.
-  const dataURI = await getCachedDataURI(filename);
+  const dataURI = await getCachedDataURI(inputName);
   let svg = `<svg xmlns="http://www.w3.org/2000/svg"
                   xmlns:xlink="http://www.w3.org/1999/xlink"
                   viewBox="0 0 ${dataURI.width} ${dataURI.height}">
@@ -122,8 +141,7 @@ module.exports = async function (src) {
   svg = svg.replace(/> </g, "><");
   svg = svg.replace(ESCAPE_REGEX, escaper);
 
-  console.log(src, "[SUCCESS]");
   const URI = `data:image/svg+xml;charset=utf-8,${svg}`;
   await writeFile(cachedName, URI);
   return URI;
-};
+}

--- a/_11ty/img-dim.js
+++ b/_11ty/img-dim.js
@@ -25,18 +25,29 @@ const sizeOf = promisify(require("image-size"));
 const blurryPlaceholder = require("./blurry-placeholder");
 const srcset = require("./srcset");
 const path = require("path");
+const fs = require("fs");
 const { gif2mp4 } = require("./video-gif");
+const AVATAR_WIDTH = 320;
+const SMALL_AVATAR_WIDTH = 96;
+const AVATAR_CLASSES = ["avatar", "avatar-small", "avatar-large"];
 
 /**
- * Sets `width` and `height` on each image, adds blurry placeholder
- * and generates a srcset if none present.
+ * Sets `width` and `height` on each image and generates responsive sources.
+ * Content images receive a blurry placeholder and the full width set; small
+ * avatars use a compact, fixed-width path to avoid oversized repeated markup.
  * Note, that the static `sizes` string would need to change for a different
  * blog layout.
  */
 
 const processImage = async (img, outputPath) => {
   let src = img.getAttribute("src");
-  if (/^(https?\:\/\/|\/\/)/i.test(src)) {
+  if (!src) {
+    throw new Error(`[img-dim] Image in ${outputPath} is missing a src attribute`);
+  }
+  // Only local file URLs can be inspected at build time. In particular, do not
+  // mistake a data URI for a path under `_site/` (which previously caused an
+  // ENAMETOOLONG warning while still allowing the build to pass).
+  if (/^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(src)) {
     return;
   }
   if (/^\.+\//.test(src)) {
@@ -50,10 +61,11 @@ const processImage = async (img, outputPath) => {
   }
   let dimensions;
   try {
-    dimensions = await sizeOf("_site/" + src);
+    dimensions = await sizeOf(localFilePath(src));
   } catch (e) {
-    console.warn(e.message, src);
-    return;
+    throw new Error(
+      `[img-dim] Cannot read local image "${src}" referenced by ${outputPath}: ${e.message}`
+    );
   }
   if (!img.getAttribute("width")) {
     img.setAttribute("width", dimensions.width);
@@ -84,27 +96,38 @@ const processImage = async (img, outputPath) => {
     return;
   }
   if (img.tagName == "IMG") {
+    const isAvatar = AVATAR_CLASSES.some((className) =>
+      img.classList.contains(className)
+    );
+    const isSmallAvatar = img.classList.contains("avatar-small");
     img.setAttribute("decoding", "async");
     img.setAttribute("loading", "lazy");
-    img.setAttribute(
-      "style",
-      `background-size:cover;` +
-        `background-image:url("${await blurryPlaceholder(src)}")`
-    );
+    if (!isAvatar) {
+      img.setAttribute(
+        "style",
+        `background-size:cover;` +
+          `background-image:url("${await blurryPlaceholder(localUrlPath(src))}")`
+      );
+    }
     const doc = img.ownerDocument;
     const picture = doc.createElement("picture");
-    const avif = doc.createElement("source");
     const webp = doc.createElement("source");
-    const jpeg = doc.createElement("source");
-    // await setSrcset(avif, src, "avif");
-    // avif.setAttribute("type", "image/avif");
-    await setSrcset(webp, src, "webp");
     webp.setAttribute("type", "image/webp");
-    const fallback = await setSrcset(jpeg, src, "jpeg");
-    jpeg.setAttribute("type", "image/jpeg");
-    // picture.appendChild(avif);
+    let fallback;
+    let jpeg;
+    if (isAvatar) {
+      const avatarWidth = isSmallAvatar ? SMALL_AVATAR_WIDTH : AVATAR_WIDTH;
+      const avatarSizes = isSmallAvatar ? "22px" : "64px";
+      await setSrcset(webp, src, "webp", [avatarWidth], avatarSizes);
+      fallback = (await srcset(src, "jpeg", [avatarWidth])).fallback;
+    } else {
+      await setSrcset(webp, src, "webp");
+      jpeg = doc.createElement("source");
+      fallback = await setSrcset(jpeg, src, "jpeg");
+      jpeg.setAttribute("type", "image/jpeg");
+    }
     picture.appendChild(webp);
-    picture.appendChild(jpeg);
+    if (jpeg) picture.appendChild(jpeg);
     img.parentElement.replaceChild(picture, img);
     picture.appendChild(img);
     img.setAttribute("src", fallback);
@@ -114,14 +137,69 @@ const processImage = async (img, outputPath) => {
   }
 };
 
-async function setSrcset(img, src, format) {
-  const setInfo = await srcset(src, format);
+/** Return a URL path without a query string or fragment. */
+function localUrlPath(src) {
+  return src.split(/[?#]/, 1)[0];
+}
+
+/**
+ * Map a local URL path to a readable file. Prefer the source tree: the
+ * `_site/` copy is produced by passthrough copy, which runs concurrently with
+ * HTML transforms, so reading it can hit a half-written file.
+ */
+function localFilePath(src) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(localUrlPath(src));
+  } catch (e) {
+    throw new Error(`[img-dim] Invalid URL encoding in local image "${src}"`);
+  }
+  const sourcePath = "." + (decoded.startsWith("/") ? decoded : "/" + decoded);
+  if (fs.existsSync(sourcePath)) {
+    assertExactCase(sourcePath, src);
+    return sourcePath;
+  }
+  return "_site/" + decoded;
+}
+
+const dirEntriesCache = new Map();
+
+/**
+ * Fail on filename-case mismatches that a case-insensitive filesystem
+ * (macOS/Windows) would silently tolerate but case-sensitive Linux CI
+ * rejects with ENOENT.
+ */
+function assertExactCase(filePath, src) {
+  let dir = ".";
+  for (const segment of filePath.split("/").filter((s) => s && s !== ".")) {
+    let entries = dirEntriesCache.get(dir);
+    if (!entries) {
+      entries = fs.readdirSync(dir);
+      dirEntriesCache.set(dir, entries);
+    }
+    if (!entries.includes(segment)) {
+      const actual = entries.find(
+        (e) => e.toLowerCase() === segment.toLowerCase()
+      );
+      throw new Error(
+        `[img-dim] Filename case mismatch for local image "${src}": ` +
+          `referenced as "${segment}" but the file on disk is "${actual}". ` +
+          `This passes on case-insensitive filesystems but fails on Linux CI.`
+      );
+    }
+    dir += "/" + segment;
+  }
+}
+
+async function setSrcset(img, src, format, widths, sizes) {
+  const setInfo = await srcset(src, format, widths);
   img.setAttribute("srcset", setInfo.srcset);
   img.setAttribute(
     "sizes",
-    img.getAttribute("align")
-      ? "(max-width: 608px) 50vw, 187px"
-      : "(max-width: 608px) 100vw, 608px"
+    sizes ||
+      (img.getAttribute("align")
+        ? "(max-width: 608px) 50vw, 187px"
+        : "(max-width: 608px) 100vw, 608px")
   );
   return setInfo.fallback;
 }

--- a/_11ty/optimize-html.js
+++ b/_11ty/optimize-html.js
@@ -21,11 +21,7 @@
 
 const minify = require("html-minifier").minify;
 const AmpOptimizer = require("@ampproject/toolbox-optimizer");
-const ampOptimizer = AmpOptimizer.create({
-  blurredPlaceholders: true,
-  imageBasePath: "./_site/",
-  //verbose: true,
-});
+let ampOptimizer;
 const PurgeCSS = require("purgecss").PurgeCSS;
 const csso = require("csso");
 
@@ -105,6 +101,14 @@ const minifyHtml = (rawContent, outputPath) => {
 const optimizeAmp = async (rawContent, outputPath) => {
   let content = rawContent;
   if (outputPath && outputPath.endsWith(".html") && isAmp(content)) {
+    // Creating the optimizer eagerly emits dependency warnings even when this
+    // site has no AMP documents. Load it only for a real AMP output.
+    ampOptimizer =
+      ampOptimizer ||
+      AmpOptimizer.create({
+        blurredPlaceholders: true,
+        imageBasePath: "./_site/",
+      });
     content = await ampOptimizer.transformHtml(content);
   }
   return content;

--- a/_11ty/srcset.js
+++ b/_11ty/srcset.js
@@ -20,6 +20,7 @@
  */
 
 const { promisify } = require("util");
+const fsSync = require("fs");
 const exists = promisify(require("fs").exists);
 const sharp = require("sharp");
 
@@ -27,7 +28,7 @@ const sharp = require("sharp");
  * Generates sensible sizes for each image for use in a srcset.
  */
 
-const widths = [1920, 1280, 640, 320];
+const defaultWidths = [1920, 1280, 640, 320];
 
 const extension = {
   jpeg: "jpg",
@@ -39,10 +40,21 @@ const quality = {
   avif: 40,
   default: 60,
 };
+const resizeCache = new Map();
 
-module.exports = async function srcset(filename, format) {
+module.exports = async function srcset(filename, format, widths = defaultWidths) {
+  if (
+    !Array.isArray(widths) ||
+    widths.length === 0 ||
+    widths.some((width) => !Number.isInteger(width) || width <= 0)
+  ) {
+    throw new Error(
+      "srcset widths must be a non-empty array of positive integers"
+    );
+  }
+  const sourceUrl = filename.split(/[?#]/, 1)[0];
   const names = await Promise.all(
-    widths.map((w) => resize(filename, w, format))
+    widths.map((w) => resize(sourceUrl, w, format))
   );
   return {
     srcset: names.map((n, i) => `${n} ${widths[i]}w`).join(", "),
@@ -51,20 +63,47 @@ module.exports = async function srcset(filename, format) {
 };
 
 async function resize(filename, width, format) {
+  const key = `${filename}\0${width}\0${format}`;
+  if (!resizeCache.has(key)) {
+    resizeCache.set(key, resizeOnce(filename, width, format));
+  }
+  return resizeCache.get(key);
+}
+
+async function resizeOnce(filename, width, format) {
   const out = sizedName(filename, width, format);
-  if (await exists("_site" + out)) {
+  // Read from the source tree when possible: the `_site/` copy is written by
+  // passthrough copy concurrently with transforms and may be incomplete.
+  const inputPath = sourceFilePath(filename);
+  const outputPath = filePath(out);
+  if (await exists(outputPath)) {
     return out;
   }
-  await sharp("_site" + filename)
+  await sharp(inputPath)
     .rotate() // Manifest rotation from metadata
     .resize(width)
     [format]({
       quality: quality[format] || quality.default,
       reductionEffort: 6,
     })
-    .toFile("_site" + out);
+    .toFile(outputPath);
 
   return out;
+}
+
+function filePath(urlPath) {
+  const pathWithoutQuery = urlPath.split(/[?#]/, 1)[0];
+  try {
+    return "_site" + decodeURIComponent(pathWithoutQuery);
+  } catch (e) {
+    throw new Error(`Invalid URL encoding in local image "${urlPath}"`);
+  }
+}
+
+function sourceFilePath(urlPath) {
+  const sitePath = filePath(urlPath);
+  const sourcePath = sitePath.replace(/^_site/, ".");
+  return fsSync.existsSync(sourcePath) ? sourcePath : sitePath;
 }
 
 function sizedName(filename, width, format) {

--- a/_headers
+++ b/_headers
@@ -7,6 +7,8 @@
   cache-control: public,max-age=31536000,immutable
 /js/*
   cache-control: public,max-age=31536000,immutable
+/css/*
+  cache-control: public,max-age=31536000,immutable
 /fonts/*
   cache-control: public,max-age=31536000,immutable
 /favicon.svg

--- a/test/test-image-pipeline.js
+++ b/test/test-image-pipeline.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const assert = require("assert").strict;
+const { JSDOM } = require("jsdom");
+const imagePlugin = require("../_11ty/img-dim.js");
+
+function getTransform() {
+  let transform;
+  imagePlugin.configFunction({
+    addTransform(name, fn) {
+      if (name === "imgDim") transform = fn;
+    },
+  });
+  assert.ok(transform, "imgDim transform was not registered");
+  return transform;
+}
+
+describe("image build pipeline", () => {
+  const transform = getTransform();
+
+  it("ignores data URIs instead of treating them as filesystem paths", async () => {
+    const html = '<!doctype html><img alt="pixel" src="data:image/png;base64,AA==">';
+    const output = await transform(html, "_site/data-uri/index.html");
+    assert.match(output, /data:image\/png;base64,AA==/);
+  });
+
+  it("fails the build for a missing local image", async () => {
+    await assert.rejects(
+      () =>
+        transform(
+          '<!doctype html><img alt="missing" src="/img/definitely-missing.png">',
+          "_site/missing-image/index.html"
+        ),
+      /Cannot read local image.*definitely-missing\.png/
+    );
+  });
+
+  it("uses a compact responsive pipeline for local avatars", async () => {
+    const output = await transform(
+      '<!doctype html><img class="avatar avatar-large" alt="" src="/img/authors/tian.jpg">',
+      "_site/avatar-test/index.html"
+    );
+    const doc = new JSDOM(output).window.document;
+    const image = doc.querySelector("picture > img.avatar");
+    assert.ok(image, "Expected the local avatar to be wrapped in a picture");
+    assert.match(image.getAttribute("width"), /^\d+$/);
+    assert.match(image.getAttribute("height"), /^\d+$/);
+    assert.equal(image.getAttribute("loading"), "lazy");
+    assert.equal(image.getAttribute("decoding"), "async");
+    assert.equal(image.getAttribute("style"), null);
+    assert.equal(image.getAttribute("src"), "/img/authors/tian-320w.jpg");
+
+    const sources = [...image.closest("picture").querySelectorAll("source")];
+    assert.equal(sources.length, 1);
+    assert.equal(sources[0].getAttribute("type"), "image/webp");
+    assert.equal(sources[0].getAttribute("srcset"), "/img/authors/tian-320w.webp 320w");
+    assert.equal(sources[0].getAttribute("sizes"), "64px");
+  });
+
+  it("caps small local avatars at 96px without downsizing larger avatars", async () => {
+    const output = await transform(
+      '<!doctype html><img class="avatar avatar-small" alt="" src="/img/authors/tian.jpg">',
+      "_site/small-avatar-test/index.html"
+    );
+    const doc = new JSDOM(output).window.document;
+    const image = doc.querySelector("picture > img.avatar-small");
+    assert.ok(image, "Expected the small avatar to be wrapped in a picture");
+    assert.equal(image.getAttribute("src"), "/img/authors/tian-96w.jpg");
+
+    const sources = [...image.closest("picture").querySelectorAll("source")];
+    assert.equal(sources.length, 1);
+    assert.equal(sources[0].getAttribute("type"), "image/webp");
+    assert.equal(sources[0].getAttribute("srcset"), "/img/authors/tian-96w.webp 96w");
+    assert.equal(sources[0].getAttribute("sizes"), "22px");
+  });
+});


### PR DESCRIPTION
## 摘要

圖片管線效能與正確性：頭像縮圖上限 96px、responsive srcset 瘦身、並行建置下改讀來源資產、缺圖直接讓建置失敗，並為 `/css/*` 加上 immutable 快取。

## Stack 位置與合併順序

本 PR 是 #202 拆分計畫的第 **2/9** 級（完整索引見 #202 的留言）。

- ⬆️ 依賴：`i18n-stack/01-build-ci`（僅測試基礎，無功能耦合）
- ⬇️ 被依賴：`i18n-stack/03-i18n-core` 起的後續級別
- 與 i18n 功能無耦合，可在第 1 級後隨時合併

## 背景與動機

archive/作者頁的小頭像過去會產生一整組過大的 responsive 變體；並行建置（CI 與本機同時跑）會 race `_site` 目錄；壞掉的本地圖片會靜默輸出破圖。#202 review 期間以 Lighthouse 驗證了改善效果。

## 變更內容

- **`_11ty/img-dim.js`**：改讀來源資產而非 `_site` 副本（並行建置安全）；本地圖片不存在時 throw（fail fast，取代靜默破圖）；data URI 不再被當成檔案路徑處理
- **`_11ty/srcset.js`**：小頭像（≤96px 顯示尺寸）上限 96px，不再產生 256/512 等無用變體；大圖維持原管線
- **`_11ty/blurry-placeholder.js`**：配合來源資產讀取調整
- **`_11ty/optimize-html.js`**：AMP optimizer 改為 lazy 建立（本站無 AMP 頁，eager 建立只會在每次建置噴依賴警告）
- **`_headers`**：`/css/*` 加 `immutable` 快取（與 `/js/*` 同策略，檔名已帶 hash）
- **新測試** `test/test-image-pipeline.js`：涵蓋上述四種行為

## 測試計畫

- `npm run build` 全綠（7 tests，含 4 個新的圖片管線測試）
- 人工抽查：`_site/img/` 下頭像變體數量與尺寸

## 風險與回滾

- 影響面：建置期 + 圖片載入效能；HTML 結構不變
- 回滾：revert 單一 merge commit
- 注意：缺圖從「靜默破圖」變成「建置失敗」是刻意的行為改變

## Review 重點

1. 96px 上限的判定條件（只影響 avatar 類小圖）
2. 並行建置 race 的修法（來源資產 vs `_site` 副本）
3. immutable 快取與檔名 hash 的配套是否完整

🤖 Generated with [Claude Code](https://claude.com/claude-code)
