### PR TITLE
[Stack 4/9] 翻譯工作流：check-translations 品質閘門與 translate-post 指令

### DIFF
--- a/.agents/skills/translate-post/SKILL.md
+++ b/.agents/skills/translate-post/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: translate-post
+description: 依專案根目錄 AGENTS.md 的翻譯規範，把繁中技術文章翻成指定語系的草稿譯文。使用者要求翻譯 posts/ 下的文章（如「翻譯 posts/tian/git-flow.md 成 en,ja」）時使用。
+---
+
+# translate-post
+
+請完整讀取並嚴格依照專案根目錄 `AGENTS.md` 的「文章翻譯規範」處理使用者指定的
+原文與語系。`AGENTS.md` 是唯一真相來源：先執行其「觸發方式與輸入驗證」節的
+檢查，再完成其中所有要求（合併 `translationTargets`、以守門腳本取得
+`sourceHash`、產出 `draft: true` 譯文、回譯校驗、檢查作者在地化簡介）。
+
+本檔沒有任何額外規則；若本檔與 `AGENTS.md` 有出入，以 `AGENTS.md` 為準。

--- a/.claude/commands/translate-post.md
+++ b/.claude/commands/translate-post.md
@@ -1,0 +1,12 @@
+---
+description: 依 AGENTS.md 將繁中技術文章翻成指定語系草稿
+argument-hint: <posts/作者/檔名.md> [語系,...]
+disable-model-invocation: true
+---
+
+請完整讀取並嚴格依照專案根目錄 `AGENTS.md` 的文章翻譯規範處理：
+
+    $ARGUMENTS
+
+`AGENTS.md` 是翻譯流程的唯一真相來源：先執行其「觸發方式與輸入驗證」節的檢查，
+再完成其中所有要求。本檔沒有任何額外規則。

--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,10 +1,12 @@
 .DS_Store
+.agents/
 .claude/
 .github/
 .netlify/
 _site/
 node_modules/
 package-lock.json
+AGENTS.md
 README.md
 page-list.njk
 _11ty/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# AGENTS.md — 文章翻譯規範（Translation Guide for Agents）
+
+這份檔案是「把一篇技術文章翻成多國語系」的**唯一真相來源**，供任何 AI 代理
+（Claude Code、Codex、Cursor、其他）依循。
+
+> 設計目標：零付費 API、不綁定特定廠商、保留人工審核、SEO 正確。
+> 站台的 i18n（路由、語言切換器、hreflang）已由模板處理，代理**只需產出符合規範的
+> Markdown 檔**即可。
+
+## 觸發方式與輸入驗證
+
+任何代理都能以一句話啟動流程，不需要工具專屬設定：
+
+> 依 AGENTS.md 翻譯 `posts/<author>/<slug>.md` 成 `<lang>[,<lang>...]`
+
+工具捷徑（皆為純別名，規範只在本檔）：
+
+- **Agent Skills 開放標準**（Codex CLI 等）：`.agents/skills/translate-post/`。
+- **Claude Code**：斜線指令 `/translate-post <檔案> [語系,...]`（`.claude/commands/`）。
+
+開始翻譯前，代理必須先驗證輸入，任一項不成立就停止並清楚說明，
+不得猜測路徑、猜測語系或修改任何檔案：
+
+1. 原文必須是存在的繁中檔案 `posts/<author>/<slug>.md`（不是 `.<lang>.md` 譯文）。
+2. 指定的語系必須列於 `_data/langs.json` 的非預設語系；未指定時使用全部
+   預設目標語系。
+3. 不得代使用者移除 `draft`、填寫人工審核欄位、提交或發佈內容。
+
+---
+
+## 任務
+
+把指定的**原文** `posts/<author>/<slug>.md`（繁體中文 `zh-TW`）翻譯成指定語系，
+每個語系各產出一個 `posts/<author>/<slug>.<lang>.md` 檔。
+
+- 預設目標語系：`en`（英文）、`ja`（日文）、`zh-CN`（簡體中文）。
+- 若使用者指定語系（如 `/translate-post posts/benben/foo.md en,ja`），只翻指定的。
+- 原文的 `translationTargets` 是預期譯文清單：首次翻譯時填入本次指定語系；未指定時
+  填入全部預設目標語系。之後新增語系要併入既有清單，不能覆蓋掉仍存在的譯文。
+- 語系清單以 `_data/langs.json` 為唯一來源（第一個元素是預設語系，其餘為翻譯
+  目標語系）；顯示名稱等 UI 字串定義於 `_data/i18n.json`。新增語系只需更新這兩個
+  檔案——`.eleventy.js`、`scripts/check-translations.js` 與測試會自動推導，
+  `i18n.json` 缺必要欄位時 build 會直接失敗提示。
+- 翻譯守門只會檢查已明確加入 i18n 的原文：frontmatter 同時具有 `lang: zh-TW` 與
+  `translationKey`。它會要求 `translationTargets` 列出的譯文存在；舊文章若未填此欄，
+  為向下相容會沿用「全部目標語系」的規則。未加入 i18n 的既有文章不受影響。
+
+---
+
+## 翻譯規則
+
+1. **只翻譯散文與 `title`。** 不要翻譯 `tags`、`author`、`date`、`layout`、程式碼、
+   URL、檔名。
+2. **程式碼一字不動。** Fenced code block（```` ``` ````）與 inline code
+   （`` `code` ``）的**內容完全保留原樣**，連同語言標註（如 ```` ```js ````）。
+   程式碼裡的「字串、變數名、註解」也不翻（註解可斟酌：技術教學常保留原文較清楚，
+   預設不翻；若使用者明確要求翻註解才翻）。
+3. **保留 Markdown 結構**：標題層級、清單、表格、連結語法、圖片、引用、HTML 標籤、
+   `<!-- summary -->` 摘要標記等一律保留；只替換其中的人類可讀文字。
+4. **連結與圖片路徑不變**（站內連結、圖片 URL 保持原樣）。
+5. **術語**：技術名詞採目標語社群慣用譯法；必要時保留英文原詞（可用「中文（English）」
+   形式）。語氣與原文一致、自然流暢，不要逐字硬翻。
+
+---
+
+## 產出檔案格式
+
+對每個目標語系 `<lang>`，寫出 `posts/<author>/<slug>.<lang>.md`，frontmatter 如下：
+
+```yaml
+---
+title: <翻譯後的標題>
+date: <與原文相同>
+tags: <與原文相同，不翻>
+author: <與原文相同>
+layout: layouts/post.njk
+lang: <lang>                       # 例如 en / ja / zh-CN
+sourceLang: zh-TW
+translationKey: <author>/<slug>    # 同一篇各語系共用，例如 benben/15-raycast-101
+permalink: /<lang>/posts/<author>/<slug>/   # 例如 /en/posts/benben/15-raycast-101/
+draft: true                        # 人工審核前不發佈，請勿自行移除
+sourceHash: <見下方，務必正確>
+image: <若原文有 image 則保留，否則省略>
+---
+```
+
+- `translationKey` = 原文相對 `posts/` 的路徑去掉副檔名，例如
+  `posts/benben/15-raycast-101.md` → `benben/15-raycast-101`。
+- `permalink` 結尾務必有斜線。
+- 內文接在 frontmatter 之後，即翻譯後的文章本體。
+- `draft: true` 的譯文不會進 production build，也暫時不需要 `publishedAt`。人工審核
+  通過後才可移除 `draft`，並且**必須**補上：
+
+```yaml
+reviewedBy: <審核者>
+reviewedAt: <YYYY-MM-DD>
+publishedAt: <YYYY-MM-DD>
+```
+
+pre-commit 會拒絕缺少或日期格式錯誤的已發佈譯文。
+
+### 日期欄位契約
+
+- `date`：原始作品的發布日；譯文必須逐字複製原文值，不能改成翻譯日期。
+- `publishedAt`：**這個語言版本**第一次正式公開的日期；非 draft 譯文必填，首次發布後
+  不因文章更新而改動。
+- `updatedAt`：這個語言版本有實質內容更新時才填或更新；必須不早於 `publishedAt`。
+- `reviewedAt`：人工審核日期，只供稽核，不能代替 `publishedAt` 或 `updatedAt`。
+
+既有 zh-TW 原文可省略 `publishedAt`，站台會沿用 `date`。現有 draft 譯文也不需要遷移，
+等實際發布時再加入 `publishedAt`；任何已填日期都必須是真實的 `YYYY-MM-DD` 日曆日期。
+
+### `sourceHash`（過期偵測用，務必正確）
+
+譯文必須記錄原文內文的雜湊，git 提交時的守門腳本會用它判斷譯文是否過期。
+**不要自己心算雜湊**，請執行下列指令取得，並把輸出原封貼進 frontmatter：
+
+```bash
+node scripts/check-translations.js --hash posts/<author>/<slug>.md
+```
+
+（此值是原文「標題與 frontmatter 之後內文」的 SHA-256；標題或內文之後若更新，
+雜湊會變，守門腳本即會要求重新翻譯。）
+
+### 原文也要補欄位（首次翻譯時）
+
+第一次翻某篇時，在**原文** frontmatter 補上下列三欄（已存在則更新，不要重複）：
+
+```yaml
+lang: zh-TW
+translationKey: <author>/<slug>
+translationTargets: [<本次要求的語系>]  # 例如 [en, ja]；未指定時為 [en, ja, zh-CN]
+```
+
+`translationTargets` 必須是 `_data/langs.json` 支援的非預設語系，並與實際譯文檔案一致。
+若之後新增語系，將它併入清單；只有刻意停止支援某語系時，才在同一個 commit 同時移除
+清單項目與該譯文檔案。這讓守門能區分「只要求部分語系」和「譯文被意外刪除」。
+
+任一譯文檔案存在時，繁中原文必須保留 `lang: zh-TW` 與 `translationKey`。若要刪除文章，
+必須在同一個 commit 刪除原文及所有譯文；守門會拒絕失去原文、無法再驗證 `sourceHash`
+的孤兒譯文。原文若設為 `draft: true`，其譯文也都必須維持 `draft: true`，不能單獨發佈。
+
+原文不需要 `permalink`（沿用 Eleventy 既有路由 `/posts/<author>/<slug>/`）、
+不需要 `draft`、不需要 `sourceHash`。
+
+---
+
+## 回譯校驗（交付前必做）
+
+寫完所有譯文後，把**每個譯文再翻回繁體中文**，與原文逐段對照，向使用者回報：
+
+- 語意是否一致、有無漏譯或多譯。
+- 技術術語是否正確、是否有歧義。
+- 程式碼區塊是否確實未被更動。
+
+這讓使用者能用看得懂的語言把關品質。回報為對話輸出即可，不需另存檔案。
+
+---
+
+## 完成後
+
+- 提醒使用者：譯文為 `draft: true`，**經人工審核後再移除** `draft`、填寫
+  `reviewedBy`、`reviewedAt` 與 `publishedAt` 才會發佈。
+- 檢查 `_data/metadata.json` 中該作者是否已有 `intro_<lang>`（如 `intro_en`）欄位；
+  沒有的話提醒使用者補上在地化簡介，否則譯文頁的作者簡介會顯示中文原文。
+- 本機預覽：`npm run serve`，草稿在 dev 模式可見；`npm run build`（production）不會輸出草稿。
+- 對外發佈內容建議經人工/法務或合規確認（公司規範）。

--- a/README.md
+++ b/README.md
@@ -89,6 +89,83 @@ css/main.css 所有的樣式都在裡面，有新增的都放在最下面
 - tags 採用 kabab case 來命名 e.g. back-end
 - 若遇到有連詞或分詞疑問，依循前者來決定 e.g. backend vs back-end，如果已經有人使用 backend 則使用 backend。
 
+## 多國語系翻譯
+
+文章可以翻成多國語系（預設 `en` / `ja` / `zh-CN`）。翻譯由 AI 代理執行，**不需付費 API**，
+規範集中在根目錄的 [`AGENTS.md`](./AGENTS.md)。
+
+### 怎麼翻一篇文章
+
+1. 用 Claude Code 跑斜線指令（假設原文是 `posts/peter/foo.md`）：
+
+   ```
+   /translate-post posts/peter/foo.md          # 翻成預設的 en, ja, zh-CN
+   /translate-post posts/peter/foo.md en,ja    # 只翻指定語系
+   ```
+
+   （非 Claude Code 的代理：直接請它「依 AGENTS.md 翻譯 posts/peter/foo.md」即可。）
+
+2. 代理會在原文的 `translationTargets` 記錄預期語系，產出
+   `posts/peter/foo.en.md` 等檔並標為 `draft: true`，再回報「回譯校驗」讓你用中文
+   檢查語意。指定 `en,ja` 時，守門只要求這兩個譯文。
+3. 本機預覽 `npm run serve`（草稿在 dev 模式可見），確認沒問題後才可移除譯文的
+   `draft: true`，並填入 `reviewedBy`、`reviewedAt` 與 `publishedAt`；欄位缺少或日期
+   不是有效的 `YYYY-MM-DD` 時，pre-commit 會拒絕發佈。
+
+### 其他作者如何加入多語系
+
+翻譯是**逐篇 opt-in**，未加入的文章完全不受影響。想讓自己的文章有譯文時：
+
+1. 跑 `/translate-post posts/<author>/<slug>.md`；代理會在原文 frontmatter 補
+   `lang: zh-TW`、`translationKey` 與 `translationTargets`，並產出指定語系的草稿譯文。
+2. 人工審核譯文後移除 `draft: true`，填入 `reviewedBy`、`reviewedAt` 與
+   `publishedAt`。
+3. （建議）在 `_data/metadata.json` 自己的作者條目加上 `intro_en`、`intro_ja`、
+   `intro_zh-CN`；譯文頁的作者簡介才會跟著在地化（缺少時顯示中文 `intro`）。
+
+### 譯文不會混進中文首頁或訂閱 Feed
+
+譯文有獨立路由（`/en/posts/...`）與語言切換器、`hreflang`；中文首頁、標籤頁與繁中
+Feed 只會列繁中文章。每個已有公開譯文的語系會同時提供 Atom 與 JSON Feed：
+
+- 繁中：`/feed/feed.xml`、`/feed/feed.json`（保留既有訂閱 URL）。
+- 其他語系：`/<lang>/feed/feed.xml`、`/<lang>/feed/feed.json`。
+
+頁面會透過 `<link rel="alternate">` 自動宣告當前語系的兩種 Feed；尚無公開譯文的語系
+不會產生空 Feed。兩種格式都依各語言版本的 `publishedAt`／`updatedAt` 顯示最近活動，
+並輸出 `_data/metadata.json` 中 `feed.limit` 指定的最新篇數。
+
+### 過期守門（pre-commit）
+
+提交時會自動檢查：被改動的原文或譯文若**缺少 `translationTargets` 指定的譯文**、
+**存在未列入清單的譯文**、**譯文已過期**（原文標題或內文變了）、譯文 `date` 與原文
+不同，或已發佈譯文缺少有效的 `publishedAt`／人工審核紀錄，就會擋下提交並提示你修正。
+`updatedAt` 若存在也必須有效且不早於 `publishedAt`。檢查一律讀取 Git 暫存區，不會被
+working tree 的未暫存內容影響。
+
+譯文不能脫離繁中原文獨立存在：刪除文章時要在同一個 commit 刪除所有語系；原文若是
+草稿，譯文也必須是草稿。這能避免無法再以 `sourceHash` 稽核、卻仍留在 production 的譯文。
+
+WIP 想先略過檢查：
+
+```bash
+SKIP_TRANSLATION_CHECK=1 git commit ...
+# 或
+git commit --no-verify
+```
+
+> 機制說明：守門腳本是 `scripts/check-translations.js`，透過專案既有的 `pre-commit`
+> 套件掛在 git hook（不需額外裝 Husky）。語系清單以 `_data/langs.json` 為唯一來源
+> （第一個元素是預設語系，其餘為翻譯目標；順序即切換器顯示順序），`.eleventy.js`、
+> 守門腳本與測試都由它推導。新增語系只需兩步：在 `_data/langs.json` 加語系代碼、
+> 在 `_data/i18n.json` 補該語系完整字串區塊（缺必要欄位時 build 會直接失敗提示）。
+
+### 導覽列語言切換器
+
+每頁導覽列都有全站語言切換器。**目前頁面有該語言版本**→ 可點連結；**沒有**→ 顯示為灰色
+停用並提示「此頁面尚無此語言版本」（不會產生壞連結）。等之後做了各語系首頁/列表頁
+（第二階段），這些停用項目會自動變成可點。
+
 ## 參考資源
 
 1. [Eleventy Documentation](https://www.11ty.dev/docs/collections/)

--- a/package.json
+++ b/package.json
@@ -14,14 +14,19 @@
     "js-build": "rollup -c rollup.config.js",
     "js-build-watch": "rollup -c rollup.config.js -w",
     "debug": "DEBUG=* eleventy && npm run test",
-    "test": "npm run test:site",
+    "test": "npm run test:site && npm run test:translations",
     "test:site": "node scripts/assert-site-built.js && mocha test/test*.js",
-    "test-watch": "mocha test/test*.js --watch"
+    "test-watch": "mocha test/test*.js --watch",
+    "check-translations": "node scripts/check-translations.js",
+    "check-translations:all": "node scripts/check-translations.js --all",
+    "test:translations": "node scripts/check-translations.test.js && npm run check-translations:all"
   },
   "pre-push": [
     "build"
   ],
-  "pre-commit": [],
+  "pre-commit": [
+    "check-translations"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/11ty/eleventy-base-blog.git"

--- a/scripts/check-translations.test.js
+++ b/scripts/check-translations.test.js
@@ -1,0 +1,687 @@
+#!/usr/bin/env node
+/**
+ * Minimal, dependency-free tests for the translation guard helpers.
+ * Run: npm run test:translations
+ */
+"use strict";
+
+const assert = require("assert");
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync, spawnSync } = require("child_process");
+const {
+  extractBody,
+  hashBody,
+  hashSource,
+  isTranslationPath,
+  translationPathFor,
+  sourcePathForTranslation,
+  frontmatterField,
+  frontmatterBoolean,
+  isTranslationManagedSource,
+  translationTargetsForSource,
+  publicationReviewIssue,
+  publicationVersionDateIssues,
+  publicationMetadataIssues,
+  sourceHashIssue,
+  TARGET_LANGS,
+} = require("./check-translations.js");
+
+const GUARD_SCRIPT = path.join(__dirname, "check-translations.js");
+
+// Git hook runners (the pre-commit/pre-push packages) export GIT_DIR and
+// GIT_INDEX_FILE to their children. If the integration tests inherit them,
+// every `git add` in the temporary repo silently rewrites the REAL repository's
+// index instead. Strip all GIT_* variables so the temp repos stay hermetic.
+const ISOLATED_ENV = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))
+);
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log("  ✓ " + name);
+}
+
+const SAMPLE = "---\ntitle: Hi\nlang: zh-TW\n---\n\nBody line one.\n";
+
+test("extractBody strips the leading frontmatter block", () => {
+  assert.strictEqual(extractBody(SAMPLE), "\nBody line one.\n");
+});
+
+test("extractBody returns input unchanged when there is no frontmatter", () => {
+  assert.strictEqual(extractBody("no frontmatter here"), "no frontmatter here");
+});
+
+test("hashBody is deterministic and hashes the body only", () => {
+  const expected = crypto
+    .createHash("sha256")
+    .update("\nBody line one.\n", "utf8")
+    .digest("hex");
+  assert.strictEqual(hashBody(SAMPLE), expected);
+  assert.strictEqual(hashBody(SAMPLE), hashBody(SAMPLE));
+});
+
+test("hashBody ignores frontmatter changes, reacts to body changes", () => {
+  const otherFm = "---\ntitle: Different\n---\n\nBody line one.\n";
+  assert.strictEqual(hashBody(otherFm), hashBody(SAMPLE)); // same body
+  const otherBody = "---\ntitle: Hi\n---\n\nBody line TWO.\n";
+  assert.notStrictEqual(hashBody(otherBody), hashBody(SAMPLE));
+});
+
+test("hashSource reacts to title and body changes but ignores copied metadata", () => {
+  const sameContent =
+    "---\ntitle: Hi\ndate: 2026-07-12\ntags: [javascript]\n---\n\nBody line one.\n";
+  const changedTitle = "---\ntitle: Hello\n---\n\nBody line one.\n";
+  const changedBody = "---\ntitle: Hi\n---\n\nBody line TWO.\n";
+
+  assert.strictEqual(hashSource(sameContent), hashSource(SAMPLE));
+  assert.notStrictEqual(hashSource(changedTitle), hashSource(SAMPLE));
+  assert.notStrictEqual(hashSource(changedBody), hashSource(SAMPLE));
+  assert.notStrictEqual(hashSource(SAMPLE), hashBody(SAMPLE));
+});
+
+test("isTranslationPath detects .<lang>.md but not source posts", () => {
+  assert.strictEqual(isTranslationPath("posts/tian/git-flow.en.md"), true);
+  assert.strictEqual(isTranslationPath("posts/tian/git-flow.zh-CN.md"), true);
+  assert.strictEqual(isTranslationPath("posts/tian/git-flow.ja.md"), true);
+  assert.strictEqual(isTranslationPath("posts/tian/git-flow.md"), false);
+});
+
+test("translationPathFor builds the sibling translation path", () => {
+  assert.strictEqual(
+    translationPathFor("posts/tian/git-flow.md", "en"),
+    "posts/tian/git-flow.en.md"
+  );
+});
+
+test("sourcePathForTranslation maps a translation back to its source", () => {
+  assert.strictEqual(
+    sourcePathForTranslation("posts/tian/git-flow.zh-CN.md"),
+    "posts/tian/git-flow.md"
+  );
+  assert.strictEqual(sourcePathForTranslation("posts/tian/git-flow.md"), null);
+});
+
+test("frontmatterField parses a quoted or bare value", () => {
+  const fm = 'sourceHash: abc123\nlang: "en"';
+  assert.strictEqual(frontmatterField(fm, "sourceHash"), "abc123");
+  assert.strictEqual(frontmatterField(fm, "lang"), "en");
+  assert.strictEqual(frontmatterField(fm, "missing"), null);
+});
+
+test("frontmatterBoolean matches the site's boolean and quoted draft contract", () => {
+  assert.strictEqual(frontmatterBoolean("draft: true", "draft"), true);
+  assert.strictEqual(frontmatterBoolean("draft: TRUE # WIP", "draft"), true);
+  assert.strictEqual(frontmatterBoolean("draft: False", "draft"), false);
+  assert.strictEqual(frontmatterBoolean('draft: "true" # WIP', "draft"), true);
+  assert.strictEqual(frontmatterBoolean("draft: 'true'", "draft"), true);
+  assert.strictEqual(frontmatterBoolean('draft: "TRUE"', "draft"), null);
+  assert.strictEqual(frontmatterBoolean("title: Example", "draft"), null);
+});
+
+test("only zh-TW sources with a translationKey opt into translation checks", () => {
+  assert.strictEqual(isTranslationManagedSource(SAMPLE), false);
+  assert.strictEqual(
+    isTranslationManagedSource(
+      "---\nlang: zh-TW\ntranslationKey: tian/example\n---\n\nBody\n"
+    ),
+    true
+  );
+  assert.strictEqual(
+    isTranslationManagedSource("---\nlang: en\ntranslationKey: tian/example\n---\n\nBody\n"),
+    false
+  );
+});
+
+test("translationTargets selects a supported subset and defaults legacy sources to all", () => {
+  assert.deepStrictEqual(translationTargetsForSource(SAMPLE), {
+    langs: TARGET_LANGS,
+    issue: null,
+  });
+  assert.deepStrictEqual(
+    translationTargetsForSource(
+      "---\nlang: zh-TW\ntranslationTargets: [ja, en] # requested locales\n---\n\nBody\n"
+    ),
+    { langs: ["en", "ja"], issue: null }
+  );
+});
+
+test("translationTargets rejects malformed, empty, duplicate, or unsupported lists", () => {
+  const source = (value) =>
+    translationTargetsForSource(
+      `---\nlang: zh-TW\ntranslationTargets: ${value}\n---\n\nBody\n`
+    ).issue;
+
+  assert.match(source("en,ja"), /inline YAML list/);
+  assert.match(source("[]"), /at least one/);
+  assert.match(source("[en, en]"), /duplicate/);
+  assert.match(source("[en, fr]"), /unsupported.*fr/);
+});
+
+test("published translations require an auditable human review", () => {
+  assert.strictEqual(publicationReviewIssue("draft: true"), null);
+  assert.strictEqual(publicationReviewIssue("draft: TRUE # WIP"), null);
+  assert.strictEqual(publicationReviewIssue('draft: "true"'), null);
+  assert.strictEqual(publicationReviewIssue("draft: false"), "not-reviewed");
+  assert.strictEqual(
+    publicationReviewIssue("draft: false\nreviewedBy: May\nreviewedAt: 2026-07-11"),
+    null
+  );
+});
+
+test("publication metadata separates original, review, publish, and update dates", () => {
+  const sourceDate = "2021-10-28";
+  assert.deepStrictEqual(
+    publicationMetadataIssues("draft: true\ndate: 2021-10-28", sourceDate),
+    []
+  );
+  assert.deepStrictEqual(
+    publicationMetadataIssues(
+      "draft: false\ndate: 2021-10-28\nreviewedBy: May\nreviewedAt: 2026-07-11",
+      sourceDate
+    ),
+    ["missing-published-at"]
+  );
+  assert.deepStrictEqual(
+    publicationMetadataIssues(
+      "draft: false\ndate: 2021-10-28\nreviewedBy: May\nreviewedAt: 2026-07-11\npublishedAt: 2026-07-13\nupdatedAt: 2026-07-14",
+      sourceDate
+    ),
+    []
+  );
+});
+
+test("publication metadata rejects invalid or contradictory dates", () => {
+  const sourceDate = "2021-10-28";
+  assert.deepStrictEqual(
+    publicationMetadataIssues("draft: true\ndate: 2021-10-29", sourceDate),
+    ["date-mismatch"]
+  );
+  assert.deepStrictEqual(
+    publicationMetadataIssues(
+      "draft: false\ndate: 2021-10-28\nreviewedBy: May\nreviewedAt: 2026-02-30\npublishedAt: 2021/10/28\nupdatedAt: 2026-07-13T10:00:00Z",
+      sourceDate
+    ),
+    ["invalid-published-at", "invalid-updated-at", "invalid-reviewed-at"]
+  );
+  assert.deepStrictEqual(
+    publicationMetadataIssues(
+      "draft: false\ndate: 2021-10-28\nreviewedBy: May\nreviewedAt: 2026-07-11\npublishedAt: 2021-10-27\nupdatedAt: 2021-10-26",
+      sourceDate
+    ),
+    ["published-before-source", "updated-before-published"]
+  );
+});
+
+test("version dates are validated independently of translation review", () => {
+  assert.deepStrictEqual(
+    publicationVersionDateIssues(
+      "publishedAt: 2026-02-30\nupdatedAt: 2026/07/13",
+      "2021-10-28"
+    ),
+    ["invalid-published-at", "invalid-updated-at"]
+  );
+  assert.deepStrictEqual(
+    publicationVersionDateIssues("updatedAt: 2021-10-27", "2021-10-28"),
+    ["updated-before-published"]
+  );
+});
+
+test("sourceHashIssue requires the title-aware source hash", () => {
+  const source =
+    "---\ntitle: Original\nlang: zh-TW\ntranslationKey: tian/example\n---\n\nBody\n";
+
+  assert.strictEqual(sourceHashIssue(hashSource(source), source), null);
+  assert.strictEqual(sourceHashIssue(hashBody(source), source), "stale");
+  assert.strictEqual(sourceHashIssue(null, source), "no-hash");
+});
+
+function git(repo, args) {
+  return execFileSync("git", args, {
+    cwd: repo,
+    env: ISOLATED_ENV,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function write(repo, relativePath, contents) {
+  const absolutePath = path.join(repo, relativePath);
+  fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+  fs.writeFileSync(absolutePath, contents, "utf8");
+}
+
+function sourcePost(
+  title,
+  body = "Source body.\n",
+  targets = TARGET_LANGS,
+  draft = false
+) {
+  return (
+    "---\n" +
+    `title: ${title}\n` +
+    "date: 2021-10-28\n" +
+    "lang: zh-TW\n" +
+    "translationKey: tester/example\n" +
+    `translationTargets: [${targets.join(", ")}]\n` +
+    (draft ? `draft: ${draft === true ? "true" : draft}\n` : "") +
+    "---\n\n" +
+    body
+  );
+}
+
+function translationPost(
+  lang,
+  sourceHash,
+  body = "Translated body.\n",
+  draft = true,
+  metadata = {}
+) {
+  return (
+    "---\n" +
+    `title: Translation ${lang}\n` +
+    "date: 2021-10-28\n" +
+    `lang: ${lang}\n` +
+    "sourceLang: zh-TW\n" +
+    "translationKey: tester/example\n" +
+    (draft
+      ? `draft: ${draft === true ? "true" : draft}\n`
+      : `reviewedBy: ${metadata.reviewedBy || "Translation Reviewer"}\n` +
+        `reviewedAt: ${metadata.reviewedAt || "2026-07-13"}\n` +
+        (metadata.publishedAt ? `publishedAt: ${metadata.publishedAt}\n` : "") +
+        (metadata.updatedAt ? `updatedAt: ${metadata.updatedAt}\n` : "")) +
+    `sourceHash: ${sourceHash}\n` +
+    "---\n\n" +
+    body
+  );
+}
+
+function runGuard(repo, args = []) {
+  return spawnSync(process.execPath, [GUARD_SCRIPT, ...args], {
+    cwd: repo,
+    env: ISOLATED_ENV,
+    encoding: "utf8",
+  });
+}
+
+function runHash(repo, sourcePath) {
+  return spawnSync(process.execPath, [GUARD_SCRIPT, "--hash", sourcePath], {
+    cwd: repo,
+    env: ISOLATED_ENV,
+    encoding: "utf8",
+  });
+}
+
+function withTranslationRepo(fn, targetLangs = TARGET_LANGS) {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), "translation-guard-"));
+  const sourcePath = "posts/tester/example.md";
+  const initialSource = sourcePost("Original title", "Source body.\n", targetLangs);
+  const sourceHash = hashSource(initialSource);
+  const translations = {};
+
+  try {
+    git(repo, ["init", "--quiet"]);
+    git(repo, ["config", "user.name", "Translation Guard Test"]);
+    git(repo, ["config", "user.email", "translation-guard@example.test"]);
+    write(repo, sourcePath, initialSource);
+    for (const lang of targetLangs) {
+      const translationPath = `posts/tester/example.${lang}.md`;
+      translations[lang] = translationPath;
+      write(repo, translationPath, translationPost(lang, sourceHash));
+    }
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "--quiet", "-m", "initial translations"]);
+
+    fn({ repo, sourcePath, initialSource, sourceHash, translations });
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+}
+
+test("integration: a staged title change makes translations stale", () => {
+  withTranslationRepo(({ repo, sourcePath, translations }) => {
+    const retitledSource = sourcePost("Retitled source");
+    write(repo, sourcePath, retitledSource);
+    git(repo, ["add", sourcePath]);
+
+    const stale = runGuard(repo);
+    assert.strictEqual(stale.status, 1);
+    for (const lang of TARGET_LANGS) {
+      assert.match(stale.stderr, new RegExp(`${lang} \\(stale\\)`));
+    }
+
+    const hashResult = runHash(repo, sourcePath);
+    assert.strictEqual(hashResult.status, 0, hashResult.stderr);
+    assert.strictEqual(hashResult.stdout.trim(), hashSource(retitledSource));
+    for (const lang of TARGET_LANGS) {
+      write(repo, translations[lang], translationPost(lang, hashResult.stdout.trim()));
+      git(repo, ["add", translations[lang]]);
+    }
+
+    const repaired = runGuard(repo);
+    assert.strictEqual(repaired.status, 0, repaired.stderr);
+  });
+});
+
+test("integration: a staged translation deletion is reported from the index", () => {
+  withTranslationRepo(({ repo, translations }) => {
+    const deletedContents = fs.readFileSync(path.join(repo, translations.ja), "utf8");
+    git(repo, ["rm", "--quiet", translations.ja]);
+    // Recreate an unstaged working-tree copy. The staged deletion must still win.
+    write(repo, translations.ja, deletedContents);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /ja \(missing\)/);
+  });
+});
+
+test("integration: deleting a source while translations remain is rejected", () => {
+  withTranslationRepo(({ repo, sourcePath }) => {
+    git(repo, ["rm", "--quiet", sourcePath]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /en \(orphaned-translation\)/);
+    assert.match(result.stderr, /Restore the source/);
+    assert.doesNotMatch(result.stderr, /Run: \/translate-post/);
+  }, ["en"]);
+});
+
+test("integration: deleting a source and all of its translations together is allowed", () => {
+  withTranslationRepo(({ repo, sourcePath, translations }) => {
+    git(repo, ["rm", "--quiet", sourcePath, ...Object.values(translations)]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 0, result.stderr);
+  });
+});
+
+test("integration: --all catches an orphaned translation in a clean checkout", () => {
+  withTranslationRepo(({ repo, sourcePath }) => {
+    git(repo, ["rm", "--quiet", sourcePath]);
+    git(repo, ["commit", "--quiet", "-m", "delete source only"]);
+
+    const result = runGuard(repo, ["--all"]);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /en \(orphaned-translation\)/);
+  }, ["en"]);
+});
+
+test("integration: removing i18n metadata cannot leave translations unmanaged", () => {
+  withTranslationRepo(({ repo, sourcePath }) => {
+    write(repo, sourcePath, "---\ntitle: Original title\n---\n\nSource body.\n");
+    git(repo, ["add", sourcePath]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /en \(unmanaged-source\)/);
+    assert.match(result.stderr, /Restore lang: zh-TW and translationKey/);
+  }, ["en"]);
+});
+
+test("integration: a draft source may keep draft translations", () => {
+  withTranslationRepo(({ repo, sourcePath }) => {
+    write(repo, sourcePath, sourcePost("Original title", "Source body.\n", ["en"], true));
+    git(repo, ["add", sourcePath]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 0, result.stderr);
+  }, ["en"]);
+});
+
+test("integration: a draft source cannot anchor a published translation", () => {
+  withTranslationRepo(({ repo, sourcePath, sourceHash, translations }) => {
+    write(repo, sourcePath, sourcePost("Original title", "Source body.\n", ["en"], true));
+    write(
+      repo,
+      translations.en,
+      translationPost("en", sourceHash, "Translated body.\n", false)
+    );
+    git(repo, ["add", sourcePath, translations.en]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /en \(source-unpublished\)/);
+    assert.match(result.stderr, /Set these translations back to draft: true/);
+    assert.doesNotMatch(result.stderr, /Run: \/translate-post/);
+  }, ["en"]);
+});
+
+test("integration: an unreviewed translation requests metadata, not retranslation", () => {
+  withTranslationRepo(({ repo, sourceHash, translations }) => {
+    write(
+      repo,
+      translations.en,
+      translationPost("en", sourceHash, "Translated body.\n", false, {
+        publishedAt: "2026-07-13",
+      }).replace(
+        "reviewedBy: Translation Reviewer\nreviewedAt: 2026-07-13\n",
+        ""
+      )
+    );
+    git(repo, ["add", translations.en]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /en \(not-reviewed\)/);
+    assert.match(result.stderr, /Add reviewedBy and reviewedAt/);
+    assert.doesNotMatch(result.stderr, /Run: \/translate-post/);
+  }, ["en"]);
+});
+
+test("integration: YAML boolean variants cannot bypass draft-source isolation", () => {
+  withTranslationRepo(({ repo, sourcePath, sourceHash, translations }) => {
+    write(
+      repo,
+      sourcePath,
+      sourcePost("Original title", "Source body.\n", ["en"], "TRUE # WIP")
+    );
+    write(
+      repo,
+      translations.en,
+      translationPost("en", sourceHash, "Translated body.\n", false)
+    );
+    git(repo, ["add", sourcePath, translations.en]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /en \(source-unpublished\)/);
+  }, ["en"]);
+});
+
+test("integration: YAML boolean variants keep source and translation drafts aligned", () => {
+  withTranslationRepo(({ repo, sourcePath, sourceHash, translations }) => {
+    write(
+      repo,
+      sourcePath,
+      sourcePost("Original title", "Source body.\n", ["en"], "TRUE # WIP")
+    );
+    write(
+      repo,
+      translations.en,
+      translationPost("en", sourceHash, "Translated body.\n", "True # WIP")
+    );
+    git(repo, ["add", sourcePath, translations.en]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 0, result.stderr);
+  }, ["en"]);
+});
+
+test("integration: quoted draft source cannot anchor a published translation", () => {
+  withTranslationRepo(({ repo, sourcePath, sourceHash, translations }) => {
+    write(
+      repo,
+      sourcePath,
+      sourcePost("Original title", "Source body.\n", ["en"], '"true"')
+    );
+    write(
+      repo,
+      translations.en,
+      translationPost("en", sourceHash, "Translated body.\n", false)
+    );
+    git(repo, ["add", sourcePath, translations.en]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /en \(source-unpublished\)/);
+  }, ["en"]);
+});
+
+test("integration: quoted source and translation drafts remain aligned", () => {
+  withTranslationRepo(({ repo, sourcePath, sourceHash, translations }) => {
+    write(
+      repo,
+      sourcePath,
+      sourcePost("Original title", "Source body.\n", ["en"], '"true"')
+    );
+    write(
+      repo,
+      translations.en,
+      translationPost("en", sourceHash, "Translated body.\n", "'true'")
+    );
+    git(repo, ["add", sourcePath, translations.en]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 0, result.stderr);
+  }, ["en"]);
+});
+
+test("integration: an explicit target subset does not require other site languages", () => {
+  withTranslationRepo(({ repo }) => {
+    const result = runGuard(repo, ["--all"]);
+    assert.strictEqual(result.status, 0, result.stderr);
+  }, ["en", "ja"]);
+});
+
+test("integration: a translation outside the explicit target set is rejected", () => {
+  withTranslationRepo(({ repo, sourceHash }) => {
+    const translationPath = "posts/tester/example.ja.md";
+    write(repo, translationPath, translationPost("ja", sourceHash));
+    git(repo, ["add", translationPath]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /ja \(not-declared\)/);
+    assert.match(result.stderr, /Add ja to translationTargets/);
+  }, ["en"]);
+});
+
+test("integration: removing a target and its translation together is intentional", () => {
+  withTranslationRepo(({ repo, sourcePath, translations }) => {
+    write(repo, sourcePath, sourcePost("Original title", "Source body.\n", ["en", "zh-CN"]));
+    git(repo, ["add", sourcePath]);
+    git(repo, ["rm", "--quiet", translations.ja]);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 0, result.stderr);
+  });
+});
+
+test("integration: source comparisons use staged content, not the working tree", () => {
+  withTranslationRepo(({ repo, sourcePath, initialSource }) => {
+    write(repo, sourcePath, sourcePost("Staged title"));
+    git(repo, ["add", sourcePath]);
+    // Make the working tree look current again without changing the index.
+    write(repo, sourcePath, initialSource);
+
+    const result = runGuard(repo);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /en \(stale\)/);
+  });
+});
+
+test("integration: --all validates the working checkout", () => {
+  withTranslationRepo(({ repo, sourcePath }) => {
+    write(repo, sourcePath, sourcePost("Unstaged title change"));
+
+    const stagedOnly = runGuard(repo);
+    assert.strictEqual(stagedOnly.status, 0, stagedOnly.stderr);
+
+    const fullRepository = runGuard(repo, ["--all"]);
+    assert.strictEqual(fullRepository.status, 1);
+    assert.match(fullRepository.stderr, /en \(stale\)/);
+  });
+});
+
+test("integration: --all rejects an impossible managed source date", () => {
+  withTranslationRepo(({ repo, sourcePath }) => {
+    write(
+      repo,
+      sourcePath,
+      sourcePost("Original title").replace(
+        "date: 2021-10-28",
+        "date: 2022-06-31"
+      )
+    );
+
+    const result = runGuard(repo, ["--all"]);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /invalid-source-date/);
+    assert.doesNotMatch(result.stderr, /Run: \/translate-post/);
+  });
+});
+
+test("integration: --all rejects impossible new dates on a legacy post", () => {
+  withTranslationRepo(({ repo }) => {
+    const legacyPath = "posts/legacy/example.md";
+    write(
+      repo,
+      legacyPath,
+      "---\ntitle: Legacy\ndate: 2021-10-28\npublishedAt: 2026-02-30\n---\n\nBody\n"
+    );
+    git(repo, ["add", legacyPath]);
+
+    const result = runGuard(repo, ["--all"]);
+    assert.strictEqual(result.status, 1);
+    assert.match(result.stderr, /source-invalid-published-at/);
+    assert.match(result.stderr, /publishedAt must be a valid YYYY-MM-DD/);
+    assert.doesNotMatch(result.stderr, /Run: \/translate-post/);
+  });
+});
+
+test("integration: --all requires publishedAt before a translation is public", () => {
+  withTranslationRepo(({ repo, sourceHash, translations }) => {
+    write(
+      repo,
+      translations.en,
+      translationPost("en", sourceHash, "Translated body.\n", false)
+    );
+
+    const missingDate = runGuard(repo, ["--all"]);
+    assert.strictEqual(missingDate.status, 1);
+    assert.match(missingDate.stderr, /en \(missing-published-at\)/);
+    assert.doesNotMatch(missingDate.stderr, /Run: \/translate-post/);
+
+    write(
+      repo,
+      translations.en,
+      translationPost("en", sourceHash, "Translated body.\n", false, {
+        publishedAt: "2026-07-13",
+      })
+    );
+    const valid = runGuard(repo, ["--all"]);
+    assert.strictEqual(valid.status, 0, valid.stderr);
+  });
+});
+
+test("integration: --all catches a missing translation in a clean checkout", () => {
+  withTranslationRepo(({ repo, translations }) => {
+    git(repo, ["rm", "--quiet", translations.ja]);
+    git(repo, ["commit", "--quiet", "-m", "delete Japanese translation"]);
+
+    const stagedOnly = runGuard(repo);
+    assert.strictEqual(stagedOnly.status, 0, stagedOnly.stderr);
+
+    const fullRepository = runGuard(repo, ["--all"]);
+    assert.strictEqual(fullRepository.status, 1);
+    assert.match(fullRepository.stderr, /ja \(missing\)/);
+  });
+});
+
+console.log(`\n${passed} tests passed.`);


### PR DESCRIPTION
## 摘要

啟用翻譯工作流與品質閘門：`check-translations` 的 40 條測試與全倉一致性檢查進入 `npm test` 與 pre-commit，`/translate-post` 指令與 AGENTS.md 工作流契約落地。

## Stack 位置與合併順序

本 PR 是 #202 拆分計畫的第 **4/9** 級（完整索引見 #202 的留言）。

- ⬆️ 依賴：`i18n-stack/03-i18n-core`（守門腳本本體已在該級進場）
- ⬇️ 被依賴：第 5–9 級

## 背景與動機

譯文必須經過機器可驗證的關卡才能公開：來源雜湊一致（title-aware sourceHash）、`publishedAt` 齊備、草稿狀態與源文對齊、不允許孤兒譯文。#202 review 第一輪意見 2（翻譯測試不在 `npm test` 內）與意見 3（pre-commit hook 需說明文件）在此解決。

## 變更內容

- **`package.json`**：`test` = site 測試 ＋ `test:translations`（守門自測 40 條 + `check-translations --all` 全倉檢查）；`pre-commit: [check-translations]` 檢查 staged 的文章變更
- **`scripts/check-translations.test.js`**：40 條單元＋整合測試，涵蓋：sourceHash 漂移、publishedAt 關卡、YAML 布林變體不能繞過草稿隔離、quoted draft 對齊、部分翻譯目標集、孤兒譯文拒絕、**讀 staged 內容而非 working tree**（並隔離真實 git index，hook 環境安全）
- **AGENTS.md**（工作流唯一事實來源）＋ `.claude/commands/translate-post.md`、`.agents/skills/translate-post/SKILL.md`（零邏輯 alias，任何 agent 工具行為一致；review 後修復 e8fd05a 將驗證邏輯單一來源化）
- **README.md**：語系與作者 onboarding 文件（第一輪意見 3 的說明義務）
- **`.eleventyignore`**：`AGENTS.md`、`.agents/` 不進站台輸出

## 測試計畫

- `npm run build` 全綠（27 mocha + 40 守門測試 + `--all` 檢查 exit 0）
- Reviewer 重現：改一篇源文不同步譯文 → `git add` → commit 應被 pre-commit 擋下

## 風險與回滾

- 影響面：開發工作流（commit/push 多一道檢查）；站台輸出不變
- pre-commit 全倉生效：文件已在 README/AGENTS.md 說明（回應第一輪意見 3）
- 回滾：revert 單一 merge commit 即解除接線；守門腳本本體在第 3 級，不受影響

## Review 重點

1. `--all` 與 staged 模式的行為差異
2. pre-commit 的擋下訊息是否足夠 actionable（review 修復 65d01bb 已改善）
3. AGENTS.md 契約與 alias 檔案的零邏輯原則

🤖 Generated with [Claude Code](https://claude.com/claude-code)
