### PR TITLE
[Stack 5/9] SEO/GEO：結構化資料、在地化 sitemap 與逐作者 AI 爬蟲 opt-in

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -56,6 +56,7 @@ const localImages = require("./third_party/eleventy-plugin-local-images/.elevent
 const CleanCSS = require("clean-css");
 const activeLanguages = require("./_11ty/activeLanguages");
 const isDraftFrontmatter = require("./_11ty/draftFlag");
+const { buildAiCrawlRules } = require("./_11ty/aiCrawlPolicy");
 const {
   effectivePublishedDate,
   effectiveModifiedDate,
@@ -386,6 +387,16 @@ module.exports = function (eleventyConfig) {
       }
       return true;
     });
+  });
+
+  // AI-crawler opt-in policy for robots.txt, per author with a per-article
+  // override — see _11ty/aiCrawlPolicy.js for the full contract.
+  eleventyConfig.addCollection("aiCrawlRules", function (collectionApi) {
+    const authors = require("./_data/metadata.json").authors;
+    const posts = collectionApi
+      .getFilteredByTag("posts")
+      .filter((item) => isVisible(item));
+    return buildAiCrawlRules(posts, authors, SITE_LANGS, DEFAULT_LANG);
   });
 
   // zh-TW-only posts — the source language listing (homepage, archive, feeds).

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -81,8 +81,10 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPlugin(require("./_11ty/summary.js"));
   eleventyConfig.addPlugin(require("./_11ty/link-target.js"));
   eleventyConfig.addPlugin(require("./_11ty/img-dim.js"));
-  eleventyConfig.addPlugin(require("./_11ty/json-ld.js"));
   eleventyConfig.addPlugin(require("./_11ty/optimize-html.js"));
+  // Validate structured data after every HTML-mutating transform so CI checks
+  // the exact minified document that will be deployed.
+  eleventyConfig.addPlugin(require("./_11ty/json-ld.js"));
   // NOTE: disable CSP because we don't need it
   // eleventyConfig.addPlugin(require("./_11ty/apply-csp.js"));
   eleventyConfig.setDataDeepMerge(true);
@@ -350,6 +352,40 @@ module.exports = function (eleventyConfig) {
       inputPath:
         code === DEFAULT_LANG ? "./about/index.md" : "./about-i18n.njk",
     }));
+  });
+
+  // Return only controlled pagination records missing from collections.all.
+  // Never return collections.all itself here: computed draft exclusions are
+  // applied later in Eleventy's lifecycle and must remain handled by Eleventy.
+  eleventyConfig.addFilter("missingSitemapPages", function (
+    pages,
+    ...extraGroups
+  ) {
+    const seen = new Set((pages || []).map((page) => page.url));
+    const missing = [];
+    for (const group of extraGroups) {
+      for (const page of group || []) {
+        if (seen.has(page.url)) continue;
+        missing.push(page);
+        seen.add(page.url);
+      }
+    }
+    return missing;
+  });
+
+  // Keep sitemap input limited to pages that are both visible and intended for
+  // indexing. Draft computed data is applied late in Eleventy 0.12, so mirror
+  // the production gate here instead of relying on collection timing.
+  eleventyConfig.addFilter("indexablePages", function (pages) {
+    return (pages || []).filter((page) => {
+      if (!page || !page.url) return false;
+      const data = page.data || {};
+      if (data.sitemapExclude) return false;
+      if ((data.draft === true || data.draft === "true") && !IS_DEVELOPMENT) {
+        return false;
+      }
+      return true;
+    });
   });
 
   // zh-TW-only posts — the source language listing (homepage, archive, feeds).

--- a/_11ty/aiCrawlPolicy.js
+++ b/_11ty/aiCrawlPolicy.js
@@ -1,0 +1,59 @@
+/**
+ * AI-crawler opt-in policy, resolved per author with a per-article override.
+ *
+ * Every author defaults to NOT welcoming AI/GEO crawlers — this is a content
+ * authorization decision, not a technical one, so it belongs to whoever wrote
+ * the post. An author opts in for all their own writing by setting
+ * `aiCrawl: true` on their entry in _data/metadata.json; a single article can
+ * flip the outcome the other way with its own frontmatter `aiCrawl: true` or
+ * `false`, regardless of what its author's default is.
+ *
+ * The output feeds robots.txt, which can only express this with path-prefix
+ * rules. Per-author rules disallow that author's whole section
+ * (`/posts/<author>/` plus each active locale's `/<lang>/posts/<author>/`,
+ * since posts and that author's listing page share the same prefix). A
+ * per-article override then re-enables (or blocks) just that one URL —
+ * robots.txt resolves conflicting rules by longest path match, so a more
+ * specific Allow/Disallow on one article's URL always wins over its author's
+ * section-wide rule (RFC 9309; every crawler in the allowlist documents
+ * following this).
+ */
+"use strict";
+
+function authorAllows(authors, key) {
+  return Boolean(authors[key] && authors[key].aiCrawl === true);
+}
+
+function buildAiCrawlRules(posts, authors, siteLangs, defaultLang) {
+  const disallowPaths = new Set();
+  const allowOverridePaths = new Set();
+  const disallowOverridePaths = new Set();
+
+  for (const key of Object.keys(authors || {})) {
+    if (authorAllows(authors, key)) continue;
+    disallowPaths.add(`/posts/${key}/`);
+    for (const lang of siteLangs || []) {
+      if (lang === defaultLang) continue;
+      disallowPaths.add(`/${lang}/posts/${key}/`);
+    }
+  }
+
+  for (const item of posts || []) {
+    const override = item.data && item.data.aiCrawl;
+    if (typeof override !== "boolean") continue;
+    const allowedByDefault = authorAllows(authors, item.data.author);
+    if (override === true && !allowedByDefault) {
+      allowOverridePaths.add(item.url);
+    } else if (override === false && allowedByDefault) {
+      disallowOverridePaths.add(item.url);
+    }
+  }
+
+  return {
+    disallowPaths: Array.from(disallowPaths).sort(),
+    allowOverridePaths: Array.from(allowOverridePaths).sort(),
+    disallowOverridePaths: Array.from(disallowOverridePaths).sort(),
+  };
+}
+
+module.exports = { buildAiCrawlRules, authorAllows };

--- a/_11ty/json-ld.js
+++ b/_11ty/json-ld.js
@@ -20,51 +20,110 @@
  */
 
 const { JSDOM } = require("jsdom");
-const BASE_URL = require("../_data/metadata.json").url;
+const { isDateOnly } = require("./publication-dates");
 
-/**
- * Validate json-ld being valid JSON and add the document images to the JSON.
- */
+function isHttpUrl(value) {
+  if (typeof value !== "string") return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch (error) {
+    return false;
+  }
+}
 
-const jsonLd = (rawContent, outputPath) => {
-  let content = rawContent;
+function articleIssues(article) {
+  const issues = [];
+  const images = Array.isArray(article.image) ? article.image : [];
 
-  if (outputPath && outputPath.endsWith(".html")) {
-    const dom = new JSDOM(content);
-    const jsonLd = dom.window.document.querySelector(
-      "script[type='application/ld+json']"
-    );
-    if (!jsonLd) {
-      return content;
-    }
-
-    const images = [
-      ...dom.window.document.querySelectorAll("main img,amp-img"),
-    ];
-    try {
-      const obj = JSON.parse(jsonLd.textContent);
-
-      if (images.length) {
-        obj.image = images.map(img => {
-            if (img.src.startsWith('http://') || img.src.startsWith('https://')) {
-              return img.src
-            }
-            return BASE_URL + img.src
-        });
-        jsonLd.textContent = JSON.stringify(obj);
-        content = dom.serialize();
-      }
-    } catch (e) {
-      throw new Error(`Failed to parse json-ld: ${e.message}`);
-    }
+  if (!article.headline) issues.push("headline is required");
+  if (!isHttpUrl(article.url)) issues.push("url must be absolute HTTP(S)");
+  if (!isHttpUrl(article.mainEntityOfPage)) {
+    issues.push("mainEntityOfPage must be absolute HTTP(S)");
+  }
+  if (images.length !== 1 || !isHttpUrl(images[0])) {
+    issues.push("image must contain exactly one absolute HTTP(S) URL");
+  }
+  if (!article.author || !article.author.name || !isHttpUrl(article.author.url)) {
+    issues.push("author name and absolute URL are required");
+  }
+  if (
+    !article.publisher ||
+    !article.publisher.name ||
+    !isHttpUrl(article.publisher.url)
+  ) {
+    issues.push("publisher name and absolute URL are required");
+  }
+  if (
+    !article.publisher ||
+    !article.publisher.logo ||
+    !isHttpUrl(article.publisher.logo.url)
+  ) {
+    issues.push("publisher logo must have an absolute HTTP(S) URL");
+  }
+  if (!isDateOnly(article.datePublished)) {
+    issues.push("datePublished must be a valid YYYY-MM-DD date");
+  }
+  if (!isDateOnly(article.dateModified)) {
+    issues.push("dateModified must be a valid YYYY-MM-DD date");
+  }
+  if (
+    isDateOnly(article.datePublished) &&
+    isDateOnly(article.dateModified) &&
+    article.dateModified < article.datePublished
+  ) {
+    issues.push("dateModified cannot be before datePublished");
+  }
+  if (Object.prototype.hasOwnProperty.call(article, "genre")) {
+    issues.push("placeholder genre must not be emitted");
   }
 
-  return content;
+  return issues;
+}
+
+/** Validate every JSON-LD block without mutating the generated HTML. */
+const validateJsonLd = (rawContent, outputPath) => {
+  if (!outputPath || !outputPath.endsWith(".html")) return rawContent;
+  if (!rawContent.includes("application/ld+json")) return rawContent;
+
+  const dom = new JSDOM(rawContent);
+  const blocks = [
+    ...dom.window.document.querySelectorAll("script[type='application/ld+json']"),
+  ];
+
+  blocks.forEach((block, index) => {
+    let value;
+    try {
+      value = JSON.parse(block.textContent);
+    } catch (error) {
+      throw new Error(
+        `Invalid JSON-LD in ${outputPath} (block ${index + 1}): ${error.message}`
+      );
+    }
+
+    const types = Array.isArray(value && value["@type"])
+      ? value["@type"]
+      : [value && value["@type"]];
+    if (types.includes("Article")) {
+      const issues = articleIssues(value);
+      if (issues.length > 0) {
+        throw new Error(
+          `Invalid Article JSON-LD in ${outputPath} (block ${index + 1}): ${issues.join(
+            "; "
+          )}`
+        );
+      }
+    }
+  });
+
+  return rawContent;
 };
 
 module.exports = {
   initArguments: {},
+  validateJsonLd,
+  articleIssues,
   configFunction: async (eleventyConfig, pluginOptions = {}) => {
-    eleventyConfig.addTransform("jsonLd", jsonLd);
+    eleventyConfig.addTransform("jsonLd", validateJsonLd);
   },
 };

--- a/_data/metadata.json
+++ b/_data/metadata.json
@@ -87,7 +87,8 @@
       "intro_en": "A record of my clumsy but endearing moments",
       "intro_ja": "不器用で愛おしい瞬間の記録",
       "intro_zh-CN": "记录那些我笨拙可爱的时刻",
-      "avatarUrl": "/img/authors/tian.jpg"
+      "avatarUrl": "/img/authors/tian.jpg",
+      "aiCrawl": true
     },
     "YongChen": {
       "name": "YongChen",

--- a/_data/metadata.json
+++ b/_data/metadata.json
@@ -4,7 +4,6 @@
   "ogimage": "https://blog.errorbaker.tw/img/ogimage.png",
   "domain": "blog.errorbaker.tw",
   "description": "錯誤烘焙師，從錯誤中學習",
-  "genre": "Insert a schema.org genre",
   "googleAnalyticsId": "",
   "sendWebVitals": false,
   "feed": {
@@ -97,6 +96,7 @@
     }
   },
   "publisher": {
-    "name": "ErrorBaker 技術共筆部落格"
+    "name": "ErrorBaker 技術共筆部落格",
+    "logo": "/img/favicon/favicon-512x512.png"
   }
 }

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -51,7 +51,7 @@
     {% else %}
       <meta property="og:image" content="{{ metadata.ogimage }}">
     {% endif %}
-    <meta property="og:type" content="article">
+    <meta property="og:type" content="{{ 'article' if templateClass == 'tmpl-post' else 'website' }}">
     <meta property="og:url" content="{{ metadata.url }}{{ canonicalUrl or page.url }}">
     <meta property="og:site_name" content="{{ t.siteName or metadata.title }}">
     <meta property="og:locale" content="{{ t.ogLocale }}">

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -5,6 +5,18 @@ templateClass: tmpl-post
 {% extends "layouts/base.njk" %}
 
 {% set postAuthor = metadata.authors[author] %}
+{% set pageLang = lang or 'zh-TW' %}
+{% set t = i18n[pageLang] or i18n['zh-TW'] %}
+{# Author page in the article's language (the per-language page exists because
+   this article is in that language). #}
+{% set authorUrl = ('/posts/' + author + '/') if pageLang == 'zh-TW' else ('/' + pageLang + '/posts/' + author + '/') %}
+{% set versionPublishedDate = page.date | effectivePublishedDate(publishedAt) %}
+{% set versionModifiedDate = page.date | effectiveModifiedDate(publishedAt, updatedAt) %}
+{% set articleImagePath = image or metadata.ogimage %}
+{% set articleImageUrl = articleImagePath | absoluteUrl(metadata.url) %}
+{% set articleUrl = (canonicalUrl or page.url) | absoluteUrl(metadata.url) %}
+{% set articleAuthorUrl = authorUrl | absoluteUrl(metadata.url) %}
+{% set publisherLogoUrl = metadata.publisher.logo | absoluteUrl(metadata.url) %}
 
 {% block extraArticleHeader %}
    <aside class="w-full">
@@ -65,23 +77,30 @@ templateClass: tmpl-post
 {
   "@context": "https://schema.org",
   "@type": "Article",
-  "headline": "{{ title }}",
-  "image": [],
-  "author": "{{ postAuthor.name }}", 
-  "genre": "{{ metadata.genre }}", 
+  "headline": {{ title | dump | safe }},
+  "inLanguage": {{ pageLang | dump | safe }},
+  "image": [{{ articleImageUrl | dump | safe }}],
+  "author": {
+    "@type": "Person",
+    "name": {{ postAuthor.name | dump | safe }},
+    "url": {{ articleAuthorUrl | dump | safe }}
+  },
   "publisher": {
     "@type": "Organization",
-    "name": "{{ metadata.publisher.name }}",
+    "name": {{ (t.siteName or metadata.publisher.name) | dump | safe }},
+    "url": {{ metadata.url | dump | safe }},
     "logo": {
       "@type": "ImageObject",
-      "url": "{{ '/img/favicon/favicon-192x192.png' | addHash }}"
+      "url": {{ publisherLogoUrl | dump | safe }},
+      "width": 512,
+      "height": 512
     }
   },
-  "url": "{{ metadata.url }}{{ canonicalUrl or page.url }}",
-  "mainEntityOfPage": "{{ metadata.url }}{{ canonicalUrl or page.url }}",
-  "datePublished": "{{ page.date | htmlDateString }}",
-  "dateModified": "{{ page.inputPath | lastModifiedDate  | htmlDateString }}",
-  "description": "{{ content | striptags | truncate(140) }}"
+  "url": {{ articleUrl | dump | safe }},
+  "mainEntityOfPage": {{ articleUrl | dump | safe }},
+  "datePublished": "{{ versionPublishedDate | htmlDateString }}",
+  "dateModified": "{{ versionModifiedDate | htmlDateString }}",
+  "description": {{ (renderData.description or description or (content | striptags | truncate(140))) | dump | safe }}
 }
 </script>
 

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -1,10 +1,13 @@
 <ul id="post-list">
 {% for post in postslist %}
-  {% set author = metadata.authors[post.data.author] %} 
-  <li>
-    <time class="f-monospace" datetime="{{ post.date | htmlDateString }}">{{ post.date | htmlDateString }}</time>&nbsp;&nbsp;
-    <a href="{{ post.url | url }}">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
-    by <img class="avatar avatar-small" src="{{ author.avatarUrl }}"> <a href="/posts/{{ post.data.author }}">{{ author.name }}</a>
+  {% set author = metadata.authors[post.data.author] %}
+  <li class="archive-row">
+    <time class="archive-date f-monospace" datetime="{{ post | postPublishedDate | htmlDateString }}">{{ post | postPublishedDate | htmlDateString }}</time>
+    <a class="archive-title" href="{{ post.url | url }}">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
+    <span class="archive-by">
+      <img class="avatar avatar-small" src="{{ author.avatarUrl }}" alt="" loading="lazy" />
+      <a href="/posts/{{ post.data.author }}">{{ author.name }}</a>
+    </span>
   </li>
 {% endfor %}
 </ul>

--- a/llms.txt.njk
+++ b/llms.txt.njk
@@ -1,0 +1,19 @@
+---
+permalink: /llms.txt
+eleventyExcludeFromCollections: true
+---
+# {{ metadata.title }}
+
+> {{ metadata.description }}。技術共筆部落格，由一群工程師共同撰寫，主題以 web 前後端為主，涵蓋 JavaScript、TypeScript、React、Node.js、Golang、CSS、工具與工程實踐等。提供繁體中文（原文）與 English / 日本語 / 简体中文 翻譯。
+
+## Articles
+{% for post in collections.postsZhTW | reverse -%}
+- [{{ post.data.title }}]({{ metadata.url }}{{ post.url }}){% if post.data.description %}: {{ post.data.description }}{% endif %}
+{% endfor %}
+## Pages
+- [Archive]({{ metadata.url }}/archive/): 全部文章的時間軸索引
+- [About]({{ metadata.url }}/about/): 關於 ErrorBaker 與作者列表（依文章數排序）
+- [Tags]({{ metadata.url }}/tags/): 依主題標籤瀏覽
+
+## Feeds
+- [Atom feed]({{ metadata.url }}{{ metadata.feed.path }})

--- a/robots.njk
+++ b/robots.njk
@@ -5,38 +5,36 @@ permalink: robots.txt
 User-agent: *
 Allow: /
 
-# Generative-engine / AI crawlers are explicitly welcome (GEO).
-User-agent: GPTBot
-Allow: /
+{%- set aiBots = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "ClaudeBot",
+  "Claude-Web",
+  "PerplexityBot",
+  "Google-Extended",
+  "Applebot-Extended",
+  "CCBot",
+  "Amazonbot",
+  "meta-externalagent"
+] %}
+{%- set rules = collections.aiCrawlRules %}
+{#- Generative-engine / AI crawlers: each author opts in for their own
+    writing via metadata.json (`aiCrawl: true`); an article's own frontmatter
+    can override its author's default either way. Unset = not welcome. #}
+{%- for bot in aiBots %}
 
-User-agent: OAI-SearchBot
+User-agent: {{ bot }}
 Allow: /
-
-User-agent: ChatGPT-User
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: Claude-Web
-Allow: /
-
-User-agent: PerplexityBot
-Allow: /
-
-User-agent: Google-Extended
-Allow: /
-
-User-agent: Applebot-Extended
-Allow: /
-
-User-agent: CCBot
-Allow: /
-
-User-agent: Amazonbot
-Allow: /
-
-User-agent: meta-externalagent
-Allow: /
+{%- for path in rules.disallowPaths %}
+Disallow: {{ path }}
+{%- endfor %}
+{%- for path in rules.disallowOverridePaths %}
+Disallow: {{ path }}
+{%- endfor %}
+{%- for path in rules.allowOverridePaths %}
+Allow: {{ path }}
+{%- endfor %}
+{%- endfor %}
 
 Sitemap: {{ metadata.url }}/sitemap.xml

--- a/robots.njk
+++ b/robots.njk
@@ -3,5 +3,40 @@ layout: false
 permalink: robots.txt
 ---
 User-agent: *
+Allow: /
 
-Sitemap: https://blog.errorbaker.tw/sitemap.xml
+# Generative-engine / AI crawlers are explicitly welcome (GEO).
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /
+
+Sitemap: {{ metadata.url }}/sitemap.xml

--- a/sitemap.xml.njk
+++ b/sitemap.xml.njk
@@ -1,25 +1,42 @@
 ---
 permalink: /sitemap.xml
 eleventyExcludeFromCollections: true
-siteWideUpdate: 2020-07-12
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-{%- for page in collections.all %}
+{%- set indexable = collections.all | indexablePages %}
+{%- for page in indexable %}
   {% set absoluteUrl %}{{ page.url | url | absoluteUrl(metadata.url) }}{% endset %}
   {% set pageDate = page.date | sitemapDateTimeString %}
   {% set lastModifiedDate = page.inputPath | lastModifiedDate  | sitemapDateTimeString %}
-  {% set siteWide = siteWideUpdate| sitemapDateTimeString %}
-  {% set lastmod = siteWide %}
-  {% if pageDate > lastmod %}
-    {% set lastmod = pageDate %}
-  {% endif %}
+  {% set lastmod = pageDate %}
   {% if lastModifiedDate > lastmod %}
     {% set lastmod = lastModifiedDate %}
   {% endif %}
   <url>
-    <loc>{{ absoluteUrl }}</loc>
+    <loc>{{ absoluteUrl | safe }}</loc>
+    {%- if lastmod %}
     <lastmod>{{ lastmod }}</lastmod>
+    {%- endif %}
+  </url>
+{%- endfor %}
+{%- set activeLangs = collections.siteLangsWithPublishedPosts %}
+{%- set homePages = activeLangs | homeVersions %}
+{%- set aboutPages = activeLangs | aboutVersions %}
+{%- set missingPages = indexable | missingSitemapPages(homePages, aboutPages) %}
+{%- for page in missingPages %}
+  {% set absoluteUrl %}{{ page.url | url | absoluteUrl(metadata.url) }}{% endset %}
+  {% set pageDate = page.date | sitemapDateTimeString %}
+  {% set lastModifiedDate = page.inputPath | lastModifiedDate  | sitemapDateTimeString %}
+  {% set lastmod = pageDate %}
+  {% if lastModifiedDate > lastmod %}
+    {% set lastmod = lastModifiedDate %}
+  {% endif %}
+  <url>
+    <loc>{{ absoluteUrl | safe }}</loc>
+    {%- if lastmod %}
+    <lastmod>{{ lastmod }}</lastmod>
+    {%- endif %}
   </url>
 {%- endfor %}
 </urlset>

--- a/tags.njk
+++ b/tags.njk
@@ -13,6 +13,7 @@ pagination:
     - translations
     - authorsByPostCount
     - authorLangPages
+    - aiCrawlRules
     - tagList
   addAllPagesToCollections: true
 layout: layouts/home.njk

--- a/test/test-ai-crawl-policy.js
+++ b/test/test-ai-crawl-policy.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const assert = require("assert").strict;
+const { buildAiCrawlRules } = require("../_11ty/aiCrawlPolicy");
+
+const SITE_LANGS = ["zh-TW", "en", "ja", "zh-CN"];
+const DEFAULT_LANG = "zh-TW";
+
+function post(author, url, aiCrawl) {
+  const data = { author };
+  if (typeof aiCrawl === "boolean") data.aiCrawl = aiCrawl;
+  return { url, data };
+}
+
+describe("AI crawler opt-in policy", () => {
+  it("defaults every author to disallowed, across every non-default locale", () => {
+    const authors = { xiang: {}, tian: { aiCrawl: true } };
+    const rules = buildAiCrawlRules([], authors, SITE_LANGS, DEFAULT_LANG);
+
+    assert.ok(rules.disallowPaths.includes("/posts/xiang/"));
+    assert.ok(rules.disallowPaths.includes("/en/posts/xiang/"));
+    assert.ok(rules.disallowPaths.includes("/ja/posts/xiang/"));
+    assert.ok(rules.disallowPaths.includes("/zh-CN/posts/xiang/"));
+    assert.ok(!rules.disallowPaths.includes("/posts/tian/"));
+  });
+
+  it("never emits a default-language-suffixed path", () => {
+    const authors = { xiang: {} };
+    const rules = buildAiCrawlRules([], authors, SITE_LANGS, DEFAULT_LANG);
+
+    assert.ok(!rules.disallowPaths.includes("/zh-TW/posts/xiang/"));
+  });
+
+  it("lets one article opt in under an author who defaults to deny", () => {
+    const authors = { xiang: {} };
+    const posts = [post("xiang", "/posts/xiang/console-log/", true)];
+    const rules = buildAiCrawlRules(posts, authors, SITE_LANGS, DEFAULT_LANG);
+
+    assert.deepEqual(rules.allowOverridePaths, ["/posts/xiang/console-log/"]);
+    assert.equal(rules.disallowOverridePaths.length, 0);
+  });
+
+  it("lets one article opt out under an author who defaults to allow", () => {
+    const authors = { tian: { aiCrawl: true } };
+    const posts = [post("tian", "/posts/tian/git-flow/", false)];
+    const rules = buildAiCrawlRules(posts, authors, SITE_LANGS, DEFAULT_LANG);
+
+    assert.deepEqual(rules.disallowOverridePaths, ["/posts/tian/git-flow/"]);
+    assert.equal(rules.allowOverridePaths.length, 0);
+  });
+
+  it("ignores posts without an explicit override either way", () => {
+    const authors = { tian: { aiCrawl: true }, xiang: {} };
+    const posts = [
+      post("tian", "/posts/tian/git-flow/"),
+      post("xiang", "/posts/xiang/console-log/"),
+    ];
+    const rules = buildAiCrawlRules(posts, authors, SITE_LANGS, DEFAULT_LANG);
+
+    assert.equal(rules.allowOverridePaths.length, 0);
+    assert.equal(rules.disallowOverridePaths.length, 0);
+  });
+
+  it("handles an empty author map without throwing", () => {
+    const rules = buildAiCrawlRules([], {}, SITE_LANGS, DEFAULT_LANG);
+    assert.deepEqual(rules, {
+      disallowPaths: [],
+      allowOverridePaths: [],
+      disallowOverridePaths: [],
+    });
+  });
+});

--- a/test/test-json-ld.js
+++ b/test/test-json-ld.js
@@ -1,0 +1,74 @@
+"use strict";
+
+const assert = require("assert").strict;
+const { validateJsonLd } = require("../_11ty/json-ld");
+
+function article(overrides = {}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: "Example article",
+    inLanguage: "en",
+    image: ["https://example.test/article.png"],
+    author: {
+      "@type": "Person",
+      name: "Example Author",
+      url: "https://example.test/authors/example/",
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Example Publisher",
+      url: "https://example.test",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://example.test/logo.png",
+      },
+    },
+    url: "https://example.test/posts/example/",
+    mainEntityOfPage: "https://example.test/posts/example/",
+    datePublished: "2026-07-13",
+    dateModified: "2026-07-13",
+    ...overrides,
+  };
+}
+
+function block(value) {
+  return `<script type="application/ld+json">${JSON.stringify(value)}</script>`;
+}
+
+describe("JSON-LD output validator", () => {
+  it("returns valid final HTML byte-for-byte without rewriting images", () => {
+    const html = `<!doctype html><main><img src="/decorative.png"></main>${block(
+      article()
+    )}`;
+    assert.equal(validateJsonLd(html, "_site/posts/example/index.html"), html);
+  });
+
+  it("validates every JSON-LD block and reports the output path", () => {
+    const html = `${block({ "@type": "BreadcrumbList" })}<script type="application/ld+json">{broken</script>`;
+    assert.throws(
+      () => validateJsonLd(html, "_site/posts/broken/index.html"),
+      /Invalid JSON-LD in _site\/posts\/broken\/index\.html \(block 2\)/
+    );
+  });
+
+  it("rejects invalid Article URLs, images, dates, or placeholder genre", () => {
+    const html = block(
+      article({
+        image: ["/relative.png", "https://example.test/extra.png"],
+        dateModified: "2026-07-12",
+        genre: "Insert a schema.org genre",
+      })
+    );
+    assert.throws(
+      () => validateJsonLd(html, "_site/posts/invalid/index.html"),
+      /image must contain exactly one absolute.*dateModified cannot be before.*genre must not be emitted/
+    );
+  });
+
+  it("ignores non-HTML output and pages without structured data", () => {
+    assert.equal(validateJsonLd("feed", "_site/feed/feed.xml"), "feed");
+    const html = "<!doctype html><p>No structured data</p>";
+    assert.equal(validateJsonLd(html, "_site/about/index.html"), html);
+  });
+});

--- a/test/test-production-output.js
+++ b/test/test-production-output.js
@@ -1,0 +1,198 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+const metadata = require("../_data/metadata.json");
+const computedData = require("../_data/eleventyComputed.js");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const SITE_ROOT = path.join(PROJECT_ROOT, "_site");
+const { TARGET_LANGS } = require("../scripts/check-translations.js");
+const { isDateOnly } = require("../_11ty/publication-dates.js");
+
+function walk(directory) {
+  if (!fs.existsSync(directory)) return [];
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? walk(fullPath) : [fullPath];
+  });
+}
+
+function frontmatterValue(raw, field) {
+  const block = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!block) return null;
+  const match = block[1].match(new RegExp(`^${field}:\\s*(.*?)\\s*$`, "m"));
+  if (!match) return null;
+  const value = match[1].trim();
+  if (
+    value.length >= 2 &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function activeTranslationLanguages() {
+  const active = new Set();
+  for (const filename of walk(path.join(PROJECT_ROOT, "posts"))) {
+    const normalized = filename.split(path.sep).join("/");
+    const lang = TARGET_LANGS.find((code) => normalized.endsWith(`.${code}.md`));
+    if (!lang) continue;
+    const raw = fs.readFileSync(filename, "utf8");
+    const publishable =
+      frontmatterValue(raw, "draft") !== "true" &&
+      Boolean(frontmatterValue(raw, "reviewedBy")) &&
+      isDateOnly(frontmatterValue(raw, "reviewedAt")) &&
+      isDateOnly(frontmatterValue(raw, "publishedAt"));
+    if (publishable) active.add(lang);
+  }
+  return active;
+}
+
+function outputPathForUrl(urlString) {
+  const pathname = decodeURIComponent(new URL(urlString, metadata.url).pathname);
+  if (pathname.endsWith("/")) return path.join(SITE_ROOT, pathname, "index.html");
+  return path.join(SITE_ROOT, pathname);
+}
+
+describe("production output boundaries", () => {
+  const activeLangs = activeTranslationLanguages();
+  let sitemap;
+  let sitemapUrls;
+
+  before(() => {
+    const sitemapPath = path.join(SITE_ROOT, "sitemap.xml");
+    assert.ok(fs.existsSync(sitemapPath), `Missing build output: ${sitemapPath}`);
+    sitemap = fs.readFileSync(sitemapPath, "utf8");
+    const sitemapDoc = new JSDOM(sitemap, { contentType: "text/xml" }).window.document;
+    sitemapUrls = [...sitemapDoc.querySelectorAll("loc")].map((node) => node.textContent);
+  });
+
+  it("never publishes internal agent or diagnostic pages", () => {
+    assert.equal(fs.existsSync(path.join(SITE_ROOT, "AGENTS", "index.html")), false);
+    assert.equal(fs.existsSync(path.join(SITE_ROOT, "page-list", "index.html")), false);
+    assert.equal(fs.existsSync(path.join(SITE_ROOT, ".agents")), false);
+    assert.doesNotMatch(sitemap, /\/(?:AGENTS|page-list)\//);
+  });
+
+  for (const lang of TARGET_LANGS) {
+    it(`emits ${lang} site pages only when a reviewed translation can be published`, () => {
+      const expected = activeLangs.has(lang);
+      const outputs = [
+        path.join(SITE_ROOT, lang, "index.html"),
+        path.join(SITE_ROOT, lang, "about", "index.html"),
+        path.join(SITE_ROOT, lang, "feed", "feed.xml"),
+        path.join(SITE_ROOT, lang, "feed", "feed.json"),
+      ];
+      for (const output of outputs) {
+        assert.equal(
+          fs.existsSync(output),
+          expected,
+          `${output} ${expected ? "was not emitted" : "must not be emitted"}`
+        );
+      }
+
+      const localizedPrefix = `${metadata.url}/${lang}/`;
+      assert.equal(
+        sitemapUrls.some((url) => url.startsWith(localizedPrefix)),
+        expected,
+        `Unexpected sitemap state for ${lang}`
+      );
+    });
+  }
+
+  it("contains no duplicate or non-emitted sitemap URLs", () => {
+    assert.equal(new Set(sitemapUrls).size, sitemapUrls.length, "Duplicate sitemap URL");
+    for (const url of sitemapUrls) {
+      assert.ok(
+        fs.existsSync(outputPathForUrl(url)),
+        `Sitemap references missing output: ${url}`
+      );
+    }
+  });
+
+  it("does not expose inactive languages through hreflang", () => {
+    for (const filename of walk(SITE_ROOT).filter((name) => name.endsWith(".html"))) {
+      const html = fs.readFileSync(filename, "utf8");
+      for (const lang of TARGET_LANGS) {
+        if (activeLangs.has(lang)) continue;
+        const attribute = new RegExp(
+          `\\bhreflang=(?:"${lang}"|'${lang}'|${lang})(?=\\s|>)`
+        );
+        assert.doesNotMatch(
+          html,
+          attribute,
+          `${path.relative(SITE_ROOT, filename)} links inactive hreflang ${lang}`
+        );
+      }
+    }
+  });
+
+  it("enables localized author shells only for active languages", () => {
+    const page = { inputPath: "./author-langs.njk" };
+    const base = {
+      page,
+      activeLangs: ["zh-TW", "en"],
+      permalink: "/{{ ap.lang }}/posts/{{ ap.author }}/",
+    };
+
+    assert.equal(
+      computedData.permalink({ ...base, ap: { lang: "en", author: "tian" } }),
+      "/en/posts/tian/"
+    );
+    assert.equal(
+      computedData.permalink({ ...base, ap: { lang: "ja", author: "tian" } }),
+      false
+    );
+  });
+
+  it("enables both localized feed formats only for active languages", () => {
+    const activeLangs = ["zh-TW", "en"];
+    const cases = [
+      {
+        inputPath: "./feed/feed-i18n.njk",
+        raw: "/{{ flang }}/feed/feed.xml",
+        expected: "/en/feed/feed.xml",
+      },
+      {
+        inputPath: "./feed/json-i18n.njk",
+        raw: "/{{ flang }}/feed/feed.json",
+        expected: "/en/feed/feed.json",
+      },
+    ];
+    for (const { inputPath, raw, expected } of cases) {
+      const base = { page: { inputPath }, activeLangs, permalink: raw };
+      assert.equal(computedData.permalink({ ...base, flang: "en" }), expected);
+      assert.equal(computedData.permalink({ ...base, flang: "ja" }), false);
+    }
+  });
+
+  // Eleventy 0.12 does not re-render a permalink string returned from
+  // computed data, so active shells must yield concrete URLs — echoing the
+  // raw front-matter template collapses them all onto one empty output path.
+  it("renders concrete permalinks for active localized shells", () => {
+    const activeLangs = ["zh-TW", "en"];
+    assert.equal(
+      computedData.permalink({
+        page: { inputPath: "./home-i18n.njk" },
+        activeLangs,
+        hlang: "en",
+        permalink: "/{{ hlang }}/",
+      }),
+      "/en/"
+    );
+    assert.equal(
+      computedData.permalink({
+        page: { inputPath: "./about-i18n.njk" },
+        activeLangs,
+        alang: "en",
+        permalink: "/{{ alang }}/about/",
+      }),
+      "/en/about/"
+    );
+  });
+});


### PR DESCRIPTION
## 摘要

結構化資料與搜尋/生成引擎最佳化：重寫 Article JSON-LD（真實 Person 作者、在地化 publisher、版本感知日期、JSON 安全轉義）、sitemap 涵蓋在地化頁面、JSON-LD 驗證器在建置期把關最終輸出，並讓 AI 爬蟲的存取權**由每位作者自行決定**（預設不開放，可逐篇覆寫）。

## Stack 位置與合併順序

本 PR 是 #202 拆分計畫的第 **5/9** 級（完整索引見 #202 的留言）。

- ⬆️ 依賴：`i18n-stack/04-translation-gate`
- ⬇️ 被依賴：第 6–9 級

## 背景與動機

原 JSON-LD 有佔位 genre、字串作者、未轉義的 title/description（CJK 引號會產生非法 JSON）。Lighthouse SEO 92 → 100 的主要來源即本級。review 修復 fe226b9（S3：description 優先取 frontmatter 而非盲目截斷 140 字；N1：publisher 在地化）已包含。

**AI 爬蟲政策的設計異動**：最初版本是全站統一「歡迎所有 AI/GEO 爬蟲」，review 的 N2 意見指出這是內容授權政策決定，應由維護者簽核、甚至過合規。討論後改採**逐作者 opt-in**：每位作者預設**不**開放 AI 爬取自己的文章，需自行在 `metadata.json` 設定 `aiCrawl: true` 才會開放；單篇文章也能用自己的 frontmatter 覆寫作者的預設值（雙向皆可）。這讓「要不要被 AI 訓練/檢索」回歸給實際寫文章的人自己決定，不再是單一維護者對全體作者的政策拍板，N2 的疑慮由設計解決。目前只有 tian 選擇開放（含其 en/ja/zh-CN 三個語系版本，已實測確認 `robots.txt` 對其零 Disallow）。

## 變更內容

- **`post.njk` JSON-LD 重寫**：`| dump | safe` 全面 JSON 安全轉義；`author` 升級為帶 URL 的 Person；`publisher` 帶 512×512 logo 與在地化名稱；`inLanguage`；`datePublished/dateModified` 走發布日期契約（譯文用自己的 `publishedAt`）；`description` 優先 frontmatter
- **`_11ty/json-ld.js` 驗證器**＋調整插件順序至所有 HTML 變換之後——CI 驗證的是**實際部署的最終壓縮文件**，invalid 直接 fail build
- **sitemap**：`indexablePages`／`missingSitemapPages` filters 讓在地化殼頁進 sitemap 且草稿/noindex 安全（不讀 `data.collections`，遵守第 3 級的 computed-data 限制）
- **`_11ty/aiCrawlPolicy.js`（新）**：純函式，把「作者預設 + 單篇覆寫」解析成 robots.txt 的路徑規則。作者未開放時，擋掉該作者整個區段（`/posts/<author>/` 與各語系 `/<lang>/posts/<author>/`，因為文章與該作者的列表頁共用同一路徑前綴）；單篇覆寫則靠 robots.txt「路徑越長越優先」的規則，蓋過作者層級的規則（RFC 9309，allowlist 上的爬蟲皆聲明遵守）
- **`robots.njk`**：改為對 AI 爬蟲清單跑迴圈（不再是 9 個爬蟲各自複製貼上一份 `Allow: /`），每個爬蟲區塊套用同一份解析後的規則；`Sitemap:` 改用 metadata URL
- **`llms.txt.njk`**：站台描述供生成式引擎使用
- **`og:type`**：文章 article、其他頁 website
- **archive/tag 列表**改用版本感知發布日期（`postslist.njk`）
- **`_data/metadata.json`**：tian 的作者設定加上 `"aiCrawl": true`
- **`tags.njk`**：新增的 `aiCrawlRules` collection 加進分頁排除清單（任何新 `addCollection` 都要加進這裡，否則會被誤判成一個 tag 去跑文章篩選）
- **新測試**：`test-json-ld.js`（驗證器單元）、`test-production-output.js`（整個 `_site` 的煙霧測試）、`test-ai-crawl-policy.js`（作者預設/單篇覆寫雙向/預設語系不加後綴/空作者表等 6 個案例）

## 測試計畫

- `npm run build` 全綠（含 `test-ai-crawl-policy.js` 6 個案例）
- 已實測：建置後的 `_site/robots.txt` 對 tian（含其三個語系版本）零 Disallow；其餘 13 位作者在每個 AI 爬蟲區塊都被擋
- 人工抽查：任一文章頁的 `<script type="application/ld+json">` 貼到 Google Rich Results Test

## 風險與回滾

- 影響面：SEO 表面（JSON-LD、sitemap、robots）；HTML 版面不變
- 回滾：revert 單一 merge commit；robots.txt 回到只有 `User-agent: *`（無任何 AI 爬蟲規則）
- 已知：sitemap lastmod 在 shallow clone 下可能失真（review N4，後續處理）
- 後續：其餘作者若想開放，自行在 `metadata.json` 設定 `aiCrawl: true`（或請維護者代為設定）即可，不需要重新走一次 PR review

## Review 重點

1. `aiCrawlPolicy.js` 的作者預設/單篇覆寫解析邏輯（尤其雙向覆寫的判斷條件）
2. JSON-LD 的 `| dump | safe` 轉義是否涵蓋所有使用者輸入欄位
3. `indexablePages` 對草稿的鏡像閘門（與 computed data 的時序關係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
