### PR TITLE
[Stack 6/9] Feeds：多語系、版本感知的 Atom 與 JSON feed

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -63,6 +63,12 @@ const {
   postPublishedDate,
   sortByPublishedDate,
 } = require("./_11ty/publication-dates");
+const {
+  feedPublishedDate,
+  feedModifiedDate,
+  sortFeedPosts,
+  feedUpdatedDate,
+} = require("./_11ty/feed-data");
 const GA_ID = require("./_data/metadata.json").googleAnalyticsId;
 
 module.exports = function (eleventyConfig) {
@@ -169,6 +175,10 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("effectiveModifiedDate", effectiveModifiedDate);
   eleventyConfig.addFilter("postPublishedDate", postPublishedDate);
   eleventyConfig.addFilter("sortByPublishedDate", sortByPublishedDate);
+  eleventyConfig.addFilter("feedPublishedDate", feedPublishedDate);
+  eleventyConfig.addFilter("feedModifiedDate", feedModifiedDate);
+  eleventyConfig.addFilter("sortFeedPosts", sortFeedPosts);
+  eleventyConfig.addFilter("feedUpdatedDate", feedUpdatedDate);
 
   eleventyConfig.addFilter("sitemapDateTimeString", (dateObj) => {
     const dt = DateTime.fromJSDate(dateObj, { zone: "utc" });

--- a/_11ty/feed-data.js
+++ b/_11ty/feed-data.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const {
+  effectiveModifiedDate,
+  postPublishedDate,
+} = require("./publication-dates");
+
+function dataFor(post) {
+  return (post && post.data) || {};
+}
+
+/** Return the first public date of this language version. */
+function feedPublishedDate(post) {
+  return postPublishedDate(post);
+}
+
+/** Return the last explicit content-update date of this language version. */
+function feedModifiedDate(post) {
+  if (!post) throw new Error("feed post is required");
+  const data = dataFor(post);
+  return effectiveModifiedDate(post.date, data.publishedAt, data.updatedAt);
+}
+
+/** Newest version activity first, without mutating Eleventy's collection. */
+function sortFeedPosts(posts, limit) {
+  const sorted = [...(posts || [])].sort((left, right) => {
+    const modifiedDifference =
+      feedModifiedDate(right).getTime() - feedModifiedDate(left).getTime();
+    if (modifiedDifference !== 0) return modifiedDifference;
+
+    const publishedDifference =
+      feedPublishedDate(right).getTime() - feedPublishedDate(left).getTime();
+    if (publishedDifference !== 0) return publishedDifference;
+
+    const leftKey = String(left.url || left.inputPath || "");
+    const rightKey = String(right.url || right.inputPath || "");
+    return leftKey.localeCompare(rightKey);
+  });
+
+  if (limit === undefined || limit === null) return sorted;
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error("feed limit must be a positive integer");
+  }
+  return sorted.slice(0, limit);
+}
+
+/** Atom requires one feed-level updated value; use the newest item update. */
+function feedUpdatedDate(posts) {
+  const items = posts || [];
+  if (items.length === 0) {
+    throw new Error("cannot render a feed without published posts");
+  }
+
+  return items.slice(1).reduce((newest, post) => {
+    const modified = feedModifiedDate(post);
+    return modified > newest ? modified : newest;
+  }, feedModifiedDate(items[0]));
+}
+
+module.exports = {
+  feedPublishedDate,
+  feedModifiedDate,
+  sortFeedPosts,
+  feedUpdatedDate,
+};

--- a/_data/metadata.json
+++ b/_data/metadata.json
@@ -7,14 +7,13 @@
   "googleAnalyticsId": "",
   "sendWebVitals": false,
   "feed": {
-    "subtitle": "ErrorBaker 技術共筆部落格",
     "filename": "feed.xml",
     "path": "/feed/feed.xml",
-    "id": "https://blog.errorbaker.tw"
+    "id": "https://blog.errorbaker.tw",
+    "limit": 20
   },
   "jsonfeed": {
-    "path": "/feed/feed.json",
-    "url": "https://blog.errorbaker.tw/feed/feed.json"
+    "path": "/feed/feed.json"
   },
   "author": {
     "name": "ErrorBaker 技術共筆部落格",

--- a/_headers
+++ b/_headers
@@ -13,3 +13,12 @@
   cache-control: public,max-age=31536000,immutable
 /favicon.svg
   cache-control: public,max-age=3600
+
+/feed/feed.xml
+  Content-Type: application/atom+xml; charset=utf-8
+/:lang/feed/feed.xml
+  Content-Type: application/atom+xml; charset=utf-8
+/feed/feed.json
+  Content-Type: application/feed+json; charset=utf-8
+/:lang/feed/feed.json
+  Content-Type: application/feed+json; charset=utf-8

--- a/_includes/feeds/atom.njk
+++ b/_includes/feeds/atom.njk
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ feedLang | escape }}">
+	<title type="text">{{ feedTitle | escape }}</title>
+	<subtitle type="text">{{ feedDescription | escape }}</subtitle>
+	<link href="{{ feedSelfUrl }}" rel="self" type="application/atom+xml"/>
+	<link href="{{ feedHomeUrl }}" rel="alternate" type="text/html" hreflang="{{ feedLang | escape }}"/>
+	<updated>{{ feedPosts | feedUpdatedDate | dateToRfc3339 }}</updated>
+	<id>{{ feedId }}</id>
+	<author>
+		<name>{{ metadata.publisher.name | escape }}</name>
+		<uri>{{ metadata.url }}</uri>
+	</author>
+	{%- for post in feedPosts %}
+	{% set absolutePostUrl = post.url | url | absoluteUrl(metadata.url) %}
+	{% set postAuthor = metadata.authors[post.data.author] %}
+	{% set postAuthorUrl = collections.authorLangPages | authorUrlForLang(feedLang, post.data.author) | url | absoluteUrl(metadata.url) %}
+	<entry>
+		<title type="text">{{ post.data.title | escape }}</title>
+		<link href="{{ absolutePostUrl }}" rel="alternate" type="text/html"/>
+		<id>{{ absolutePostUrl }}</id>
+		<published>{{ post | feedPublishedDate | dateToRfc3339 }}</published>
+		<updated>{{ post | feedModifiedDate | dateToRfc3339 }}</updated>
+		<author>
+			<name>{{ postAuthor.name | escape }}</name>
+			<uri>{{ postAuthorUrl }}</uri>
+		</author>
+		<content type="html">
+		  {{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}
+			{% if feedAnalytics and googleanalytics %}
+				{% set titleUrlEncoded = post.data.title | encodeURIComponent %}
+				{% set urlUrlEncoded = post.url | encodeURIComponent %}
+				{{ '<img src="' + metadata.url + '/.netlify/functions/ga?v=1&_v=j83&t=pageview&dr=https%3A%2F%2Frss-feed-reader.com&_s=1&dh=' + metadata.domain + '&dp=' + urlUrlEncoded + '&ul=en-us&de=UTF-8&dt=' + titleUrlEncoded + '&tid=' + googleanalytics + '" width="1" height="1" style="display:none" alt="">' }}
+			{% endif %}
+		</content>
+	</entry>
+	{%- endfor %}
+</feed>

--- a/_includes/feeds/json.njk
+++ b/_includes/feeds/json.njk
@@ -1,0 +1,39 @@
+{
+  "version": "https://jsonfeed.org/version/1.1",
+  "title": {{ feedTitle | dump | safe }},
+  "home_page_url": {{ feedHomeUrl | dump | safe }},
+  "feed_url": {{ feedSelfUrl | dump | safe }},
+  "description": {{ feedDescription | dump | safe }},
+  "icon": {{ metadata.publisher.logo | absoluteUrl(metadata.url) | dump | safe }},
+  "language": {{ feedLang | dump | safe }},
+  "authors": [
+    {
+      "name": {{ metadata.publisher.name | dump | safe }},
+      "url": {{ metadata.url | dump | safe }},
+      "avatar": {{ metadata.publisher.logo | absoluteUrl(metadata.url) | dump | safe }}
+    }
+  ],
+  "items": [
+    {%- for post in feedPosts %}
+    {% set absolutePostUrl = post.url | url | absoluteUrl(metadata.url) %}
+    {% set postAuthor = metadata.authors[post.data.author] %}
+    {% set postAuthorUrl = collections.authorLangPages | authorUrlForLang(feedLang, post.data.author) | url | absoluteUrl(metadata.url) %}
+    {
+      "id": {{ absolutePostUrl | dump | safe }},
+      "url": {{ absolutePostUrl | dump | safe }},
+      "title": {{ post.data.title | dump | safe }},
+      "content_html": {% if post.templateContent %}{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) | dump | safe }}{% else %}""{% endif %},
+      "date_published": "{{ post | feedPublishedDate | dateToRfc3339 }}",
+      "date_modified": "{{ post | feedModifiedDate | dateToRfc3339 }}",
+      "language": {{ feedLang | dump | safe }},
+      "authors": [
+        {
+          "name": {{ postAuthor.name | dump | safe }},
+          "url": {{ postAuthorUrl | dump | safe }}
+        }
+      ]{% if post.data.image %},
+      "image": {{ post.data.image | absoluteUrl(metadata.url) | dump | safe }}{% endif %}
+    }{% if not loop.last %},{% endif %}
+    {%- endfor %}
+  ]
+}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -79,7 +79,10 @@
          https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy
           -->
     <meta name="referrer" content="always">
-    <link rel="alternate" href="{{ metadata.feed.path | url }}" type="application/atom+xml" title="{{ metadata.title }}">
+    {%- set feedPath = metadata.feed.path if pageLang == 'zh-TW' else '/' + pageLang + metadata.feed.path %}
+    {%- set jsonFeedPath = metadata.jsonfeed.path if pageLang == 'zh-TW' else '/' + pageLang + metadata.jsonfeed.path %}
+    <link rel="alternate" href="{{ feedPath | url }}" type="application/atom+xml" title="{{ t.siteName or metadata.title }} (Atom)">
+    <link rel="alternate" href="{{ jsonFeedPath | url }}" type="application/feed+json" title="{{ t.siteName or metadata.title }} (JSON Feed)">
 
     <link rel="preconnect" href="/" crossorigin>
     <script async defer src="{{ "/js/min.js" | addHash }}"
@@ -212,7 +215,9 @@
 
     <footer>
       <div class="copyright">&copy; 2021&ndash;{{ year }} {{ t.copyright }}</div>
-      <a href="{{ metadata.feed.id + metadata.feed.path | url }}" id="rss"><img  src="/img/rss-feed.svg" alt="rss feed" /></a>
+      {#- Reuse the localized feedPath computed in <head> so the footer icon
+          points at the current language's feed, not always the zh-TW one. #}
+      <a href="{{ feedPath | url }}" id="rss"><img  src="/img/rss-feed.svg" alt="rss feed" /></a>
     </footer>
 
     <!-- Current page: {{ page.url | url }} -->

--- a/feed/feed-i18n.njk
+++ b/feed/feed-i18n.njk
@@ -1,0 +1,21 @@
+---
+# Per-language Atom feeds: /en/feed/feed.xml, /ja/feed/feed.xml, /zh-CN/feed/feed.xml
+# (the zh-TW feed is feed/feed.njk at /feed/feed.xml).
+pagination:
+  data: collections.siteLangsWithPublishedPosts
+  size: 1
+  alias: flang
+  filter:
+    - zh-TW
+permalink: "/{{ flang }}/feed/feed.xml"
+eleventyExcludeFromCollections: true
+---
+{%- set feedPosts = collections.posts | filterByLang(flang) %}
+{%- set feedPosts = feedPosts | sortFeedPosts(metadata.feed.limit) %}
+{%- set feedLang = flang %}
+{%- set feedTitle = i18n[feedLang].siteName %}
+{%- set feedDescription = i18n[feedLang].intro %}
+{%- set feedSelfUrl = ('/' + feedLang + metadata.feed.path) | url | absoluteUrl(metadata.url) %}
+{%- set feedHomeUrl = ('/' + feedLang + '/') | url | absoluteUrl(metadata.url) %}
+{%- set feedId = feedHomeUrl %}
+{%- include "feeds/atom.njk" %}

--- a/feed/feed.njk
+++ b/feed/feed.njk
@@ -1,35 +1,13 @@
 ---
-permalink: feed/feed.xml
+permalink: /feed/feed.xml
 eleventyExcludeFromCollections: true
 ---
-<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-	<title>{{ metadata.title }}</title>
-	<subtitle>{{ metadata.feed.subtitle }}</subtitle>
-	{% set absoluteUrl %}{{ metadata.feed.path | url | absoluteUrl(metadata.url) }}{% endset %}
-	<link href="{{ absoluteUrl }}" rel="self"/>
-	<link href="{{ metadata.url }}"/>
-	<updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
-	<id>{{ metadata.feed.id }}</id>
-	<author>
-		<name>{{ metadata.author.name }}</name>
-		<email>{{ metadata.author.email }}</email>
-	</author>
-	{%- for post in collections.posts %}
-	{% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
-	<entry>
-		<title>{{ post.data.title }}</title>
-		<link href="{{ absolutePostUrl }}"/>
-		<updated>{{ post.date | rssDate }}</updated>
-		<id>{{ absolutePostUrl }}</id>
-		<content type="html">
-		  {{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}
-			{% if googleanalytics %}
-				{% set titleUrlEncoded = post.data.title|encodeURIComponent %}
-				{% set urlUrlEncoded = post.url | encodeURIComponent %}
-				{{'<img src="' + metadata.url +  '/.netlify/functions/ga?v=1&_v=j83&t=pageview&dr=https%3A%2F%2Frss-feed-reader.com&_s=1&dh=' + metadata.domain + '&dp=' + urlUrlEncoded + '&ul=en-us&de=UTF-8&dt=' + titleUrlEncoded + '&tid=' + googleanalytics + '" width="1" height="1" style="display:none" alt="">'}}
-			{% endif %}
-		</content>
-	</entry>
-	{%- endfor %}
-</feed>
+{%- set feedLang = 'zh-TW' %}
+{%- set feedPosts = collections.postsZhTW | sortFeedPosts(metadata.feed.limit) %}
+{%- set feedTitle = i18n[feedLang].siteName %}
+{%- set feedDescription = i18n[feedLang].intro %}
+{%- set feedSelfUrl = metadata.feed.path | url | absoluteUrl(metadata.url) %}
+{%- set feedHomeUrl = '/' | url | absoluteUrl(metadata.url) %}
+{%- set feedId = metadata.feed.id %}
+{%- set feedAnalytics = true %}
+{%- include "feeds/atom.njk" %}

--- a/feed/json-i18n.njk
+++ b/feed/json-i18n.njk
@@ -1,0 +1,19 @@
+---
+# Per-language JSON Feeds; zh-TW remains at /feed/feed.json.
+pagination:
+  data: collections.siteLangsWithPublishedPosts
+  size: 1
+  alias: flang
+  filter:
+    - zh-TW
+permalink: "/{{ flang }}/feed/feed.json"
+eleventyExcludeFromCollections: true
+---
+{%- set feedPosts = collections.posts | filterByLang(flang) %}
+{%- set feedPosts = feedPosts | sortFeedPosts(metadata.feed.limit) %}
+{%- set feedLang = flang %}
+{%- set feedTitle = i18n[feedLang].siteName %}
+{%- set feedDescription = i18n[feedLang].intro %}
+{%- set feedSelfUrl = ('/' + feedLang + metadata.jsonfeed.path) | url | absoluteUrl(metadata.url) %}
+{%- set feedHomeUrl = ('/' + feedLang + '/') | url | absoluteUrl(metadata.url) %}
+{%- include "feeds/json.njk" %}

--- a/feed/json.njk
+++ b/feed/json.njk
@@ -1,31 +1,11 @@
 ---
-# Metadata comes from _data/metadata.json
 permalink: "{{ metadata.jsonfeed.path | url }}"
 eleventyExcludeFromCollections: true
 ---
-{
-  "version": "https://jsonfeed.org/version/1",
-  "title": "{{ metadata.title }}",
-  "home_page_url": "{{ metadata.url }}",
-  "feed_url": "{{ metadata.jsonfeed.url }}",
-  "description": "{{ metadata.description }}",
-  "author": {
-    "name": "{{ metadata.author.name }}",
-    "url": "{{ metadata.author.url }}"
-  },
-  "items": [
-    {%- for post in collections.posts | reverse %}
-    {%- set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset -%}
-    {
-      "id": "{{ absolutePostUrl }}",
-      "url": "{{ absolutePostUrl }}",
-      "title": "{{ post.data.title }}",
-      "content_html": {% if post.templateContent %}{{ post.templateContent | dump | safe }}{% else %}""{% endif %},
-      "date_published": "{{ post.date | rssDate }}"
-    }
-    {%- if not loop.last -%}
-    ,
-    {%- endif -%}
-    {%- endfor %}
-  ]
-}
+{%- set feedLang = 'zh-TW' %}
+{%- set feedPosts = collections.postsZhTW | sortFeedPosts(metadata.feed.limit) %}
+{%- set feedTitle = i18n[feedLang].siteName %}
+{%- set feedDescription = i18n[feedLang].intro %}
+{%- set feedSelfUrl = metadata.jsonfeed.path | url | absoluteUrl(metadata.url) %}
+{%- set feedHomeUrl = '/' | url | absoluteUrl(metadata.url) %}
+{%- include "feeds/json.njk" %}

--- a/test/test-feed-data.js
+++ b/test/test-feed-data.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const assert = require("assert").strict;
+const {
+  feedPublishedDate,
+  feedModifiedDate,
+  sortFeedPosts,
+  feedUpdatedDate,
+} = require("../_11ty/feed-data");
+
+function post(url, date, data = {}) {
+  return { url, date: new Date(`${date}T00:00:00.000Z`), data };
+}
+
+describe("feed publication data", () => {
+  it("uses version publication and update dates with source-compatible fallbacks", () => {
+    const source = post("/source/", "2021-10-28");
+    const translation = post("/en/translation/", "2021-10-28", {
+      publishedAt: "2026-07-13",
+      updatedAt: "2026-07-15",
+    });
+
+    assert.equal(feedPublishedDate(source).toISOString(), "2021-10-28T00:00:00.000Z");
+    assert.equal(feedModifiedDate(source).toISOString(), "2021-10-28T00:00:00.000Z");
+    assert.equal(
+      feedPublishedDate(translation).toISOString(),
+      "2026-07-13T00:00:00.000Z"
+    );
+    assert.equal(
+      feedModifiedDate(translation).toISOString(),
+      "2026-07-15T00:00:00.000Z"
+    );
+  });
+
+  it("sorts newest version activity first and limits without mutating the collection", () => {
+    const items = [
+      post("/older/", "2024-01-01"),
+      post("/same-b/", "2021-01-01", { publishedAt: "2026-07-13" }),
+      post("/same-a/", "2020-01-01", { publishedAt: "2026-07-13" }),
+      post("/recently-updated/", "2020-01-01", { updatedAt: "2026-07-14" }),
+    ];
+
+    assert.deepEqual(
+      sortFeedPosts(items, 3).map((item) => item.url),
+      ["/recently-updated/", "/same-a/", "/same-b/"]
+    );
+    assert.deepEqual(
+      items.map((item) => item.url),
+      ["/older/", "/same-b/", "/same-a/", "/recently-updated/"]
+    );
+    assert.throws(() => sortFeedPosts(items, 0), /positive integer/);
+  });
+
+  it("uses the newest explicit modification for the feed timestamp", () => {
+    const items = [
+      post("/new/", "2026-07-13"),
+      post("/updated/", "2024-01-01", { updatedAt: "2026-07-15" }),
+    ];
+    assert.equal(feedUpdatedDate(items).toISOString(), "2026-07-15T00:00:00.000Z");
+    assert.equal(
+      feedUpdatedDate([post("/historical/", "1960-01-01")]).toISOString(),
+      "1960-01-01T00:00:00.000Z"
+    );
+  });
+
+  it("rejects empty feeds and invalid version dates", () => {
+    assert.throws(() => feedUpdatedDate([]), /without published posts/);
+    assert.throws(
+      () => feedPublishedDate(post("/bad/", "2021-01-01", { publishedAt: "bad" })),
+      /publishedAt must be a valid YYYY-MM-DD date/
+    );
+  });
+});

--- a/test/test-feeds.js
+++ b/test/test-feeds.js
@@ -1,0 +1,302 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const nunjucks = require("nunjucks");
+const { JSDOM } = require("jsdom");
+const rssPlugin = require("@11ty/eleventy-plugin-rss");
+const metadata = require("../_data/metadata.json");
+const i18n = require("../_data/i18n.json");
+const langs = require("../_data/langs.json");
+const {
+  feedPublishedDate,
+  feedModifiedDate,
+  feedUpdatedDate,
+} = require("../_11ty/feed-data");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const SITE_ROOT = path.join(PROJECT_ROOT, "_site");
+const RFC3339 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+function absoluteHttpUrl(value, label) {
+  let parsed;
+  assert.doesNotThrow(() => {
+    parsed = new URL(value);
+  }, `${label} must be an absolute URL: ${value}`);
+  assert.ok(
+    parsed.protocol === "http:" || parsed.protocol === "https:",
+    `${label} must use HTTP(S): ${value}`
+  );
+}
+
+function assertRfc3339(value, label) {
+  assert.match(value, RFC3339, `${label} must be an RFC 3339 UTC timestamp`);
+  assert.ok(Number.isFinite(Date.parse(value)), `${label} must be parseable`);
+}
+
+function assertAbsoluteContentUrls(html, label) {
+  const doc = new JSDOM(`<body>${html}</body>`).window.document;
+  for (const element of doc.querySelectorAll("[href],[src],[poster],[srcset]")) {
+    for (const attribute of ["href", "src", "poster"]) {
+      if (!element.hasAttribute(attribute)) continue;
+      const value = element.getAttribute(attribute);
+      let parsed;
+      assert.doesNotThrow(() => {
+        parsed = new URL(value);
+      }, `${label} has a relative ${attribute}: ${value}`);
+      assert.ok(
+        ["http:", "https:", "mailto:", "tel:", "data:"].includes(parsed.protocol),
+        `${label} has an unsupported ${attribute}: ${value}`
+      );
+    }
+
+    if (element.hasAttribute("srcset")) {
+      for (const candidate of element.getAttribute("srcset").split(",")) {
+        const value = candidate.trim().split(/\s+/, 1)[0];
+        absoluteHttpUrl(value, `${label} srcset`);
+      }
+    }
+  }
+}
+
+function outputForUrl(urlString) {
+  const pathname = decodeURIComponent(new URL(urlString).pathname);
+  return path.join(SITE_ROOT, pathname, "index.html");
+}
+
+function pathsForLang(lang) {
+  const prefix = lang === "zh-TW" ? "" : lang;
+  return {
+    atom: path.join(SITE_ROOT, prefix, "feed", "feed.xml"),
+    json: path.join(SITE_ROOT, prefix, "feed", "feed.json"),
+    home: path.join(SITE_ROOT, prefix, "index.html"),
+    atomUrl:
+      lang === "zh-TW"
+        ? `${metadata.url}/feed/feed.xml`
+        : `${metadata.url}/${lang}/feed/feed.xml`,
+    jsonUrl:
+      lang === "zh-TW"
+        ? `${metadata.url}/feed/feed.json`
+        : `${metadata.url}/${lang}/feed/feed.json`,
+    homeUrl: lang === "zh-TW" ? `${metadata.url}/` : `${metadata.url}/${lang}/`,
+  };
+}
+
+function validateFeedPair(lang, files) {
+  const atomRaw = fs.readFileSync(files.atom, "utf8");
+  assert.equal(atomRaw[0], "<", `${files.atom} must start with its XML declaration`);
+  const atom = new JSDOM(atomRaw, { contentType: "text/xml" }).window.document;
+  const json = JSON.parse(fs.readFileSync(files.json, "utf8"));
+  const entries = [...atom.querySelectorAll("entry")];
+
+  assert.equal(atom.documentElement.localName, "feed");
+  assert.equal(atom.documentElement.namespaceURI, "http://www.w3.org/2005/Atom");
+  assert.equal(atom.documentElement.getAttribute("xml:lang"), lang);
+  assert.equal(atom.querySelector("feed > title").textContent, i18n[lang].siteName);
+  assert.equal(atom.querySelector("link[rel='self']").getAttribute("href"), files.atomUrl);
+  assert.equal(
+    atom.querySelector("link[rel='alternate']").getAttribute("href"),
+    files.homeUrl
+  );
+  assert.equal(atom.querySelectorAll("email").length, 0, "Do not emit an empty email");
+
+  assert.equal(json.version, "https://jsonfeed.org/version/1.1");
+  assert.equal(json.title, i18n[lang].siteName);
+  assert.equal(json.language, lang);
+  assert.equal(json.feed_url, files.jsonUrl);
+  assert.equal(json.home_page_url, files.homeUrl);
+  absoluteHttpUrl(json.icon, "feed icon URL");
+  assert.ok(Array.isArray(json.authors) && json.authors.length > 0);
+  for (const author of json.authors) absoluteHttpUrl(author.url, "feed author URL");
+
+  assert.ok(entries.length > 0, `${lang} Atom feed must contain entries`);
+  assert.equal(entries.length, json.items.length);
+  assert.ok(entries.length <= metadata.feed.limit);
+
+  const atomIds = entries.map((entry) => entry.querySelector("id").textContent);
+  const jsonIds = json.items.map((item) => item.id);
+  assert.deepEqual(atomIds, jsonIds, "Atom and JSON Feed order must match");
+  assert.equal(new Set(atomIds).size, atomIds.length, "Feed IDs must be unique");
+
+  const expectedPrefix =
+    lang === "zh-TW" ? `${metadata.url}/posts/` : `${metadata.url}/${lang}/posts/`;
+  const modifiedTimes = [];
+  entries.forEach((entry, index) => {
+    const item = json.items[index];
+    const id = atomIds[index];
+    assert.ok(id.startsWith(expectedPrefix), `${id} leaked into the ${lang} feed`);
+    absoluteHttpUrl(id, "entry ID");
+    assert.ok(fs.existsSync(outputForUrl(id)), `Feed links missing output: ${id}`);
+
+    const atomPublished = entry.querySelector("published").textContent;
+    const atomModified = entry.querySelector("updated").textContent;
+    assert.equal(item.url, id);
+    assert.equal(item.language, lang);
+    assert.equal(item.date_published, atomPublished);
+    assert.equal(item.date_modified, atomModified);
+    assertRfc3339(atomPublished, `${id} published`);
+    assertRfc3339(atomModified, `${id} updated`);
+    assert.ok(Date.parse(atomModified) >= Date.parse(atomPublished));
+    modifiedTimes.push(Date.parse(atomModified));
+
+    for (const author of item.authors || []) {
+      absoluteHttpUrl(author.url, `${id} author URL`);
+    }
+    if (item.image) absoluteHttpUrl(item.image, `${id} image URL`);
+    assertAbsoluteContentUrls(
+      entry.querySelector("content").textContent,
+      `${id} Atom content`
+    );
+    assertAbsoluteContentUrls(item.content_html, `${id} JSON content`);
+  });
+
+  for (let index = 1; index < modifiedTimes.length; index += 1) {
+    assert.ok(modifiedTimes[index - 1] >= modifiedTimes[index]);
+  }
+  const newestModified = Math.max(...modifiedTimes);
+  const atomUpdated = atom.querySelector("feed > updated").textContent;
+  assertRfc3339(atomUpdated, `${lang} feed updated`);
+  assert.equal(Date.parse(atomUpdated), newestModified);
+}
+
+function createFeedEnvironment() {
+  const env = new nunjucks.Environment(
+    new nunjucks.FileSystemLoader(path.join(PROJECT_ROOT, "_includes")),
+    { autoescape: true }
+  );
+  env.addFilter("url", (value) => value);
+  env.addFilter("absoluteUrl", rssPlugin.absoluteUrl);
+  env.addFilter("dateToRfc3339", rssPlugin.dateToRfc3339);
+  env.addFilter("dump", JSON.stringify);
+  env.addFilter("feedPublishedDate", feedPublishedDate);
+  env.addFilter("feedModifiedDate", feedModifiedDate);
+  env.addFilter("feedUpdatedDate", feedUpdatedDate);
+  env.addFilter(
+    "authorUrlForLang",
+    (_pages, lang, author) => `/${lang}/posts/${author}/`
+  );
+  env.addFilter(
+    "htmlToAbsoluteUrls",
+    (html, base, callback) => {
+      rssPlugin.convertHtmlToAbsoluteUrls(html, base).then(
+        (value) => callback(null, value),
+        (error) => callback(error)
+      );
+    },
+    true
+  );
+  return env;
+}
+
+function render(env, template, context) {
+  return new Promise((resolve, reject) => {
+    env.render(template, context, (error, output) => {
+      if (error) reject(error);
+      else resolve(output);
+    });
+  });
+}
+
+describe("syndication feed output", () => {
+  it("emits matching, valid, language-isolated Atom and JSON feeds", () => {
+    let validated = 0;
+    for (const lang of langs) {
+      const files = pathsForLang(lang);
+      if (!fs.existsSync(files.atom)) continue;
+      assert.ok(fs.existsSync(files.json), `${lang} is missing its JSON Feed`);
+      validateFeedPair(lang, files);
+      validated += 1;
+    }
+    assert.ok(validated >= 1, "The source-language feeds must always exist");
+  });
+
+  it("advertises both feed formats for each generated language home", () => {
+    for (const lang of langs) {
+      const files = pathsForLang(lang);
+      if (!fs.existsSync(files.home)) continue;
+      const doc = new JSDOM(fs.readFileSync(files.home, "utf8")).window.document;
+      const atom = doc.querySelectorAll(
+        "link[rel='alternate'][type='application/atom+xml']"
+      );
+      const json = doc.querySelectorAll(
+        "link[rel='alternate'][type='application/feed+json']"
+      );
+      assert.equal(atom.length, 1);
+      assert.equal(json.length, 1);
+      assert.equal(
+        new URL(atom[0].getAttribute("href"), metadata.url).href,
+        files.atomUrl
+      );
+      assert.equal(
+        new URL(json[0].getAttribute("href"), metadata.url).href,
+        files.jsonUrl
+      );
+    }
+  });
+
+  it("declares deploy-time MIME types for both root and localized feeds", () => {
+    const headers = fs.readFileSync(path.join(SITE_ROOT, "_headers"), "utf8");
+    assert.match(headers, /\/feed\/feed\.xml[\s\S]*application\/atom\+xml/);
+    assert.match(headers, /\/:lang\/feed\/feed\.xml[\s\S]*application\/atom\+xml/);
+    assert.match(headers, /\/feed\/feed\.json[\s\S]*application\/feed\+json/);
+    assert.match(headers, /\/:lang\/feed\/feed\.json[\s\S]*application\/feed\+json/);
+  });
+
+  it("renders a localized old-work/new-version fixture without escaped URLs", async () => {
+    const env = createFeedEnvironment();
+    const fixture = {
+      url: "/en/posts/sixwings/beginner's-guide/",
+      date: new Date("2021-08-07T00:00:00.000Z"),
+      data: {
+        title: 'Rock & "Roll"',
+        author: "sixwings",
+        publishedAt: "2026-07-13",
+        updatedAt: "2026-07-14",
+      },
+      templateContent: '<p><a href="/docs/">Docs</a><img src="./hero.png"></p>',
+    };
+    const base = {
+      feedLang: "en",
+      feedPosts: [fixture],
+      feedTitle: "Site & Feed",
+      feedDescription: "English description",
+      feedHomeUrl: "https://example.test/en/",
+      feedId: "https://example.test/en/",
+      metadata: {
+        url: "https://example.test",
+        publisher: { name: "Publisher", logo: "/logo.png" },
+        authors: { sixwings: { name: "Six & Wings" } },
+      },
+      collections: { authorLangPages: [] },
+      googleanalytics: "",
+    };
+
+    const atomRaw = await render(env, "feeds/atom.njk", {
+      ...base,
+      feedSelfUrl: "https://example.test/en/feed/feed.xml",
+    });
+    const jsonRaw = await render(env, "feeds/json.njk", {
+      ...base,
+      feedSelfUrl: "https://example.test/en/feed/feed.json",
+    });
+    const atom = new JSDOM(atomRaw, { contentType: "text/xml" }).window.document;
+    const json = JSON.parse(jsonRaw);
+    const expectedUrl = "https://example.test/en/posts/sixwings/beginner's-guide/";
+
+    assert.equal(atom.documentElement.getAttribute("xml:lang"), "en");
+    assert.equal(atom.querySelector("entry > id").textContent, expectedUrl);
+    assert.equal(atom.querySelector("entry > title").textContent, 'Rock & "Roll"');
+    assert.equal(atom.querySelector("published").textContent, "2026-07-13T00:00:00Z");
+    assert.equal(atom.querySelector("entry > updated").textContent, "2026-07-14T00:00:00Z");
+    assert.doesNotMatch(atomRaw, /&amp;#39;/);
+    assertAbsoluteContentUrls(atom.querySelector("content").textContent, "fixture Atom");
+
+    assert.equal(json.language, "en");
+    assert.equal(json.items[0].id, expectedUrl);
+    assert.equal(json.items[0].title, 'Rock & "Roll"');
+    assert.equal(json.items[0].date_published, "2026-07-13T00:00:00Z");
+    assert.equal(json.items[0].date_modified, "2026-07-14T00:00:00Z");
+    assertAbsoluteContentUrls(json.items[0].content_html, "fixture JSON");
+  });
+});


### PR DESCRIPTION
## 摘要

多語系、版本感知的 Atom 與 JSON feed：feed 渲染抽成共享 partial，各語系有自己的 `/<lang>/feed/feed.xml|json`（僅在該語系有已發布譯文時生成），日期與排序遵循發布日期契約。

## Stack 位置與合併順序

本 PR 是 #202 拆分計畫的第 **6/9** 級（完整索引見 #202 的留言）。

- ⬆️ 依賴：`i18n-stack/05-seo-geo`
- ⬇️ 被依賴：第 7–9 級

## 背景與動機

譯文不能混進 zh-TW 的 RSS；各語系讀者需要自己的 feed；feed 條目的時間戳必須反映「該版本」的發布/更新時間而非源文的。

## 變更內容

- **共享 partial**：`_includes/feeds/atom.njk`、`json.njk` —— zh-TW feed 與各語系殼 feed（`feed/feed-i18n.njk`、`feed/json-i18n.njk`）共用同一渲染，格式永不分歧
- **`_11ty/feed-data.js`**：條目按版本發布日排序與標記時間、feed 的 `updated` 取最新條目、條目數上限 `metadata.feed.limit`（20）
- **殼 feed 閘門**：沿用第 3 級的 `eleventyComputed` 機制，未啟用語系不產出 feed URL
- **`base.njk`**：`<link rel=alternate>`（Atom + JSON Feed）與頁尾 RSS icon 指向**當前語系**的 feed
- **`_headers`**：所有 feed 路徑（含 `/:lang/feed/*`）的正確 Content-Type
- **`metadata.json`**：`feed.limit` 新增；移除未使用的 `feed.subtitle`、`jsonfeed.url`
- **新測試**：`test-feed-data.js`（單元）＋ `test-feeds.js`（渲染後 Atom/JSON 斷言）

## 測試計畫

- `npm run build` 全綠（35 mocha）
- 人工抽查：`_site/feed/feed.xml` 過 W3C Feed Validator；JSON Feed 過 validator.jsonfeed.org

## 風險與回滾

- 影響面：feed 訂閱者。zh-TW feed URL 不變；條目時間戳語義從「檔案 mtime」改為「版本發布日」是刻意修正
- 回滾：revert 單一 merge commit

## Review 重點

1. feed 條目日期契約（`feedPublishedDate` vs `feedUpdatedDate` 的取值規則）
2. 共享 partial 的參數面（zh-TW 與 `<lang>` 殼的差異點）
3. `metadata.feed.limit` 的取捨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
