### PR TITLE
[Stack 7/9] UI 改版：編輯排版重設計、無障礙修正與 CSP-hash theme script

### DIFF
--- a/_11ty/optimize-html.js
+++ b/_11ty/optimize-html.js
@@ -70,6 +70,21 @@ const purifyCss = async (rawContent, outputPath) => {
       ],*/
       fontFace: true,
       variables: true,
+      // Classes/states toggled by JS (TOC scroll-spy, back-to-top) never appear
+      // in the server-rendered HTML PurgeCSS scans, so keep them explicitly.
+      // NOTE: purgecss@2 only honors `whitelist`/`whitelistPatterns` and
+      // silently ignores v3's `safelist` — don't add one; on a purgecss
+      // upgrade, rename these keys instead.
+      whitelist: [
+        "active",
+        "toc-ready",
+        "toc-h2",
+        "toc-h3",
+      ],
+      // Language-aware typography selectors (`:lang(ja) article` etc.) start
+      // with a functional pseudo-class purgecss@2 can't match against content,
+      // so the whole rule group is dropped without this.
+      whitelistPatterns: [/^:lang/],
     });
 
     const after = csso.minify(purged[0].css).css;

--- a/_includes/home-postslist.njk
+++ b/_includes/home-postslist.njk
@@ -1,21 +1,21 @@
 {% for post in postslist %}
   {% set author = metadata.authors[post.data.author] %}
-<article class="post">
+<article class="post{% if loop.first %} post--lead{% endif %}">
+  {% if post.data.image %}
+  <a class="post-cover" href="{{ post.url | url }}" tabindex="-1" aria-hidden="true">
+    <img src="{{ post.data.image }}" class="post-cover-img" alt="" loading="lazy" />
+  </a>
+  {% endif %}
   <div class="post-body">
-    <a href="{{ post.url | url }}"><h3 class="post-title">{{ post.data.title | safe }}</h3></a>
+    <h2 class="post-title"><a href="{{ post.url | url }}">{{ post.data.title | safe }}</a></h2>
     {% summary post=post.templateContent %}
     <div class="post-info">
-        <a href="/posts/{{ author.name }}" class="author-link">
-          <img src="{{ author.avatarUrl}}" class="avatar-small" />
-          <span class="post-author">{{ author.name }}</span>
-        </a>on<time class="f-monospace post-date" datetime="{{ post.date | htmlDateString }}">{{ post.date | htmlDateString }}</time>
+      <a href="{{ collections.authorLangPages | authorUrlForLang(lang, post.data.author) | url }}" class="author-link">
+        <img src="{{ author.avatarUrl }}" class="avatar-small" alt="" />
+        <span class="post-author">{{ author.name }}</span>
+      </a>
+      <time class="post-date" datetime="{{ post | postPublishedDate | htmlDateString }}">{{ post | postPublishedDate | htmlDateString }}</time>
     </div>
   </div>
-  {% if post.data.image %}
-  <div class="post-cover">
-    <a href="{{ post.url | url }}"><img src="{{ post.data.image }}" class="post-cover-img" /></a>
-  </div>
-  {% endif %}
 </article>
-<hr class="divider">
 {% endfor %}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -20,6 +20,17 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Apply the colour theme to <html> BEFORE the inlined CSS paints, so
+         navigating between pages never flashes light-then-dark. -->
+    <script csp-hash>
+      (function () {
+        try {
+          var t = localStorage.getItem("theme") ||
+            (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+          if (t === "dark") document.documentElement.classList.add("dark");
+        } catch (e) {}
+      })();
+    </script>
     <meta name="robots" content="index, follow">
     <meta name="google-site-verification" content="zbyBgfDuOtaLUTLY7nVzYLdVhNdDIxUCv2xA0R3J1W8" />
     {% if isdevelopment %}
@@ -96,7 +107,8 @@
     </script>
     <!-- css is inserted by optimize-html custom plugin -->
   </head>
-  <body>
+  <body class="{{ templateClass }}">
+    <a class="skip-link" href="#main">{{ t.skipToContent or '跳到主要內容' }}</a>
     <script>
       // light/dark theme switch
       const bodyEl = document.querySelector("body");
@@ -124,12 +136,13 @@
         }
 
         function setTheme(theme) {
+          const toggleImg = toggleEl.querySelector("img");
           if (theme === DARK) {
             setUtterancesTheme(DARK);
-            toggleEl.src = toggleEl.src.replace(DARK, LIGHT);
+            toggleImg.src = toggleImg.src.replace(DARK, LIGHT);
           } else {
             setUtterancesTheme(LIGHT);
-            toggleEl.src = toggleEl.src.replace(LIGHT, DARK);
+            toggleImg.src = toggleImg.src.replace(LIGHT, DARK);
           }
         }
       });
@@ -137,13 +150,15 @@
     <header>
       <nav>
         <div id="nav">
-          <h1>
+          <p class="site-title">
             <a href="{{ homeUrl | url }}" title="Homepage">{{ t.siteName or metadata.title }}</a>
             <label for="menu__control" class="menu__btn">
               <span>{{ t.menu }}</span>
             </label>
-          </h1>
-          <img id="color-scheme-toggle" src="{{ '/img/dark.svg' | url }}" alt="switch dark mode" />
+          </p>
+          <button id="color-scheme-toggle" type="button" aria-label="{{ t.toggleTheme or 'switch dark mode' }}">
+            <img src="{{ '/img/dark.svg' | url }}" alt="" />
+          </button>
           {#- Read more about `eleventy-navigation` at https://www.11ty.dev/docs/plugins/navigation/ #}
           <input id="menu__control" type="checkbox" />
           <div class="nav__links">
@@ -192,12 +207,13 @@
       {% endif %}
     </header>
 
-    <main>
+    <main id="main">
       <article>
         {% block article %}
           {{ content | safe }}
         {% endblock %}
       </article>
+      {% block aside %}{% endblock %}
     </main>
 
     {#- Locale-suggestion banner: only render when this page has another visible

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -19,21 +19,16 @@ templateClass: tmpl-post
 {% set publisherLogoUrl = metadata.publisher.logo | absoluteUrl(metadata.url) %}
 
 {% block extraArticleHeader %}
-   <aside class="w-full">
-      <div class="flex items-center">
-        <img class="avatar" src="{{ postAuthor.avatarUrl }}">
-        <span style="margin-left: 12px;"><a href="/posts/{{ author }}">{{ postAuthor.name }}</a> 於 {{ date | htmlDateString }} 發布</span>
-      </div>
-      <div style="text-align: left;">
-      {% for tag in tags %}
-        {% if tag !== "posts" %}
-          {% set tagUrl %}/tags/{{ tag | slug }}/{% endset %}
-          <a href="{{ tagUrl | url }}" class="post-tag">#{{ tag }}</a>
-        {% endif %}
-        
-      {% endfor %}
-      </div>
-   </aside>
+  <div class="byline">
+    <a class="byline-author" href="{{ authorUrl }}">
+      <img class="avatar" src="{{ postAuthor.avatarUrl }}" alt="" />
+      <span>{{ postAuthor.name }}</span>
+    </a>
+    <time class="byline-date" datetime="{{ versionPublishedDate | htmlDateString }}">{{ t.publishedOn }} {{ versionPublishedDate | htmlDateString }}</time>
+    <span class="byline-tags">
+    {%- for tag in tags %}{% if tag !== "posts" %}{% set tagUrl %}/tags/{{ tag | slug }}/{% endset %}<a href="{{ tagUrl | url }}" class="post-tag">#{{ tag }}</a>{% endif %}{% endfor %}
+    </span>
+  </div>
 {% endblock %}
 
 
@@ -44,17 +39,18 @@ templateClass: tmpl-post
 {{ content | safe }}
 
 <hr>
-<p>
-  <h3>關於作者</h3>
+<section class="author-bio">
+  <h2>{{ t.aboutAuthor }}</h2>
   <div class="flex items-center">
-    <img class="avatar avatar-large" src="{{ postAuthor.avatarUrl }}">
-    <h3 style="margin-left: 12px;"><a href="/posts/{{ author }}">{{ postAuthor.name }}</a></h3>
+    <img class="avatar avatar-large" src="{{ postAuthor.avatarUrl }}" alt="">
+    <h3 style="margin-left: 12px;"><a href="{{ authorUrl }}">{{ postAuthor.name }}</a></h3>
   </div>
-  <p>{{ postAuthor.intro | safe }}</p>
-</p>
+  {% set authorIntro = postAuthor['intro_' + pageLang] or postAuthor.intro %}
+  <div class="author-intro">{{ authorIntro | safe }}</div>
+</section>
 
 <p>
-  <a href="{{ shareUrl | safe }}" on-click="share">分享文章</a>
+  <a href="{{ shareUrl | safe }}" on-click="share">{{ t.shareArticle }}</a>
 </p>
 
 <script
@@ -104,4 +100,13 @@ templateClass: tmpl-post
 }
 </script>
 
+{% endblock %}
+
+{% block aside %}
+  <nav class="toc" id="toc" aria-label="{{ t.toc or '目錄' }}">
+    <details class="toc-details" open>
+      <summary class="toc-title">{{ t.toc or '目錄' }}</summary>
+      <ul class="toc-list"></ul>
+    </details>
+  </nav>
 {% endblock %}

--- a/css/main.css
+++ b/css/main.css
@@ -15,14 +15,14 @@
   --fluid-typography-ratio: 0.7;
   --rem: calc(var(--base-font-size) + var(--fluid-typography-ratio) * 1vw);
 
-  --small: 0.5rem;
-  --p: 0.9rem;
-  --h6: 0.9rem;
-  --h5: 0.9rem;
-  --h4: 1rem;
-  --h3: 1.1rem;
-  --h2: 1.2rem;
-  --h1: 1.6rem;
+  --small: 0.7rem;
+  --p: 1rem;
+  --h6: 0.95rem;
+  --h5: 1rem;
+  --h4: 1.15rem;
+  --h3: 1.3rem;
+  --h2: 1.55rem;
+  --h1: 2rem;
 
   --black: 900;
   --bold: 700;
@@ -30,14 +30,12 @@
 
   /* prevent compiler from removing --p */
   font-size: var(--p);
-  font-size: var(--rem);
+  /* Bounded fluid root size: never smaller than 16px (mobile-readable,
+     avoids iOS form zoom), capped at 21px on very wide screens. Replaces the
+     old unbounded calc(12px + 0.7vw) which made text too small on phones and
+     unstable on ultra-wide displays. */
+  font-size: clamp(16px, calc(13px + 0.45vw), 21px);
   font-weight: var(--normal);
-}
-
-@media (min-width: 1168px) {
-  :root {
-    --p: 0.8rem;
-  }
 }
 
 .test-dead-code-elimination-sentinel {
@@ -602,8 +600,6 @@ html {
     "Noto Sans TC", "PingFang TC", "Hiragino Sans GB", "Heiti TC",
     "Microsoft YaHei", "Microsoft Jhenghei", sans-serif;
 }
-@supports (font-variation-settings: normal) {
-}
 form {
   padding: 1.5em 1.5em 0;
   border: 0.2rem solid #202020;
@@ -752,7 +748,6 @@ body {
   font-family: var(--font-family);
   background: var(--bg);
   color: var(--fg);
-  transition: all 0.3s;
 }
 body {
   --fg: var(--dark);
@@ -1336,85 +1331,1295 @@ ul#post-list li {
   }
 }
 
-/* home article end */
-
-.nav-pagination {
-  text-align: center;
-  margin-top: 72px;
-  padding: 0 28px;
-}
-
-.nav-pagination ol {
-  display: inline-flex;
-  flex-direction: row;
-  list-style: none;
-  padding: 0;
-}
-
-.nav-pagination li {
-  width: 32px;
-  height: 32px;
-  border: 1px solid #cccccc;
-  background: #fff;
-  border-radius: 6px;
-}
-
-.nav-pagination li.current {
-  border-color: var(--primary);
-}
-
-.nav-pagination li a,
-.nav-pagination li span {
-  font-size: 14px;
-  color: #000;
-  height: 32px;
-  line-height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-}
-
-.nav-pagination li a:hover {
-  text-decoration: none;
-  color: var(--primary);
-}
-
-.nav-pagination li:not(:first-child) {
-  margin-left: 8px;
-}
-
-.nav-pagination li.nav-pagination__prev,
-.nav-pagination li.nav-pagination__next {
-  background: var(--primary);
-  border-color: var(--primary);
-}
-
-.nav-pagination li.nav-pagination__prev *,
-.nav-pagination li.nav-pagination__next * {
-  color: #fff;
-  margin-top: -1px;
-}
-
-.nav-pagination li.nav-pagination__prev *:hover,
-.nav-pagination li.nav-pagination__next *:hover {
-  color: #fff;
-}
-
-.nav-pagination li.nav-pagination__prev:hover,
-.nav-pagination li.nav-pagination__next:hover {
-  background: var(--primary-light);
-}
-
-.nav-pagination li.nav-pagination__prev--disable,
-.nav-pagination li.nav-pagination__next--disable {
-  background: #ccc;
-  border-color: #ccc;
-  pointer-events: none;
-}
-
 /* Global style */
 .post-image-width {
   width: 800px;
   max-width: 90%;
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+   READING EXPERIENCE / SEO / A11y ENHANCEMENTS  (layered overrides)
+   Appended so the cascade lets these win over the base Bahunya rules above
+   without destabilising the original stylesheet.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* ── Design tokens: links, hairlines, inline-code, surfaces ──────────────
+   New vars are referenced below so PurgeCSS (variables:true) keeps them. */
+/* ── Editorial palette: warm "paper" light, warm "ink" dark ─────────────*/
+body {
+  --paper: #fbfaf8;
+  --paper-raised: #ffffff;
+  --ink: #1f1d1b;
+  --ink-soft: #4a4642;
+  --ink-faint: #6b6660;
+  --accent: #b5322e;
+  --accent-hover: #8f2723;
+  --rule: rgba(31, 29, 27, 0.12);
+  --rule-strong: rgba(31, 29, 27, 0.22);
+  /* Map the legacy tokens used across the stylesheet onto the palette. */
+  --bg: var(--paper);
+  --fg: var(--ink);
+  --primary: var(--accent);
+  --linkColor: var(--accent);
+  --navColor: var(--paper);
+  --progressColor: var(--accent);
+  --hairline: var(--rule);
+  --surface: var(--paper-raised);
+  --muted: var(--ink-soft);
+  --inlineCodeBg: rgba(31, 29, 27, 0.05);
+  --inlineCodeColor: var(--accent);
+  /* Serif display family (Latin first, CJK appended below per language). */
+  --font-serif: "Iowan Old Style", "Apple Garamond", Georgia, "Source Serif 4",
+    "Times New Roman", Times, serif;
+}
+body.dark {
+  --paper: #1a1816;
+  --paper-raised: #232020;
+  --ink: #ece7e0;
+  --ink-soft: #b8b2aa;
+  --ink-faint: #8f8980;
+  --accent: #ff7d72;
+  --accent-hover: #ff9a91;
+  --rule: rgba(236, 231, 224, 0.14);
+  --rule-strong: rgba(236, 231, 224, 0.24);
+  --bg: var(--paper);
+  --fg: var(--ink);
+  --primary: var(--accent);
+  --linkColor: var(--accent);
+  --navColor: var(--paper);
+  --progressColor: var(--accent);
+  --hairline: var(--rule);
+  --surface: var(--paper-raised);
+  --muted: var(--ink-soft);
+  --inlineCodeBg: rgba(236, 231, 224, 0.08);
+  --inlineCodeColor: #ffb0a3;
+  --codeColor: #ffb0a3; /* AA-contrast on the dark code surfaces (was #d65c5c, 3.3:1) */
+  color-scheme: dark;
+}
+/* CJK display headings use a Ming/Song serif; Latin serif stays first in the
+   stack so Latin words render in the Latin face and CJK glyphs fall through. */
+body:lang(zh-TW),
+body:lang(zh-Hant) {
+  --font-serif: "Iowan Old Style", Georgia, "Source Serif 4", "Noto Serif TC",
+    "Songti TC", "Source Han Serif TC", serif;
+}
+body:lang(zh-CN),
+body:lang(zh-Hans) {
+  --font-serif: "Iowan Old Style", Georgia, "Source Serif 4", "Noto Serif SC",
+    "Songti SC", "Source Han Serif SC", serif;
+}
+body:lang(ja) {
+  --font-serif: "Iowan Old Style", Georgia, "Source Serif 4", "Noto Serif JP",
+    "YuMincho", "Hiragino Mincho ProN", serif;
+}
+
+/* ── Article measure & comfortable padding ──────────────────────────────
+   Replaces the rigid width:50.5em / padding:1.5em / word-break:break-word. */
+article {
+  width: min(100%, 46rem);
+  padding: clamp(1rem, 4vw, 2rem);
+  word-break: normal;
+  overflow-wrap: break-word;
+  line-height: 1.8;
+}
+
+/* ── Language-aware typography (i18n-ready; lang set on <html>) ──────────
+   CJK wants more leading + a touch of tracking and may break anywhere;
+   Latin keeps default tracking and must not hard-break words. */
+:lang(zh-Hant) article,
+:lang(zh-TW) article,
+:lang(zh-Hans) article,
+:lang(zh-CN) article,
+:lang(ja) article {
+  line-height: 1.85;
+  letter-spacing: 0.02em;
+  word-break: normal;
+  overflow-wrap: anywhere;
+}
+:lang(en) article,
+:lang(es) article {
+  line-height: 1.7;
+  letter-spacing: 0;
+  overflow-wrap: break-word;
+}
+
+/* ── Paragraph rhythm & heading hierarchy ───────────────────────────────*/
+article p,
+article ul,
+article ol,
+article pre,
+article blockquote {
+  margin-bottom: 1.4em;
+}
+article h1,
+article h2,
+article h3,
+article h4,
+article h5,
+article h6 {
+  line-height: 1.3;
+  margin-top: 1.8em;
+  margin-bottom: 0.6em;
+  letter-spacing: normal;
+}
+article > :first-child {
+  margin-top: 0;
+}
+/* Section-heading underline applies to ARTICLE BODY headings only — not the
+   home feed's post-title h2 nor the archive. */
+body.tmpl-post article h2 {
+  padding-bottom: 0.25em;
+  border-bottom: 1px solid var(--hairline);
+}
+
+/* Heading anchor "#": hidden until the heading is hovered/focused, so it no
+   longer clutters every title but stays available for sharing. */
+.direct-link {
+  opacity: 0;
+  text-decoration: none;
+  margin-left: 0.35em;
+  font-weight: var(--normal);
+  transition: opacity 0.2s;
+}
+h1:hover .direct-link,
+h2:hover .direct-link,
+h3:hover .direct-link,
+h4:hover .direct-link,
+h5:hover .direct-link,
+h6:hover .direct-link,
+.direct-link:focus {
+  opacity: 0.55;
+}
+
+/* ── Links: underline content links for non-colour-reliant affordance ───*/
+a {
+  color: var(--linkColor);
+}
+article a {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  text-decoration-thickness: 1px;
+}
+article a:hover {
+  text-decoration-thickness: 2px;
+}
+/* keep chrome (nav, cards, tags) underline-free */
+header nav a,
+.post a,
+.post-tag,
+footer a {
+  text-decoration: none;
+}
+
+/* ── Code: bigger, theme-aware inline chips; readable blocks ─────────────*/
+code,
+kbd {
+  font-size: 0.9em;
+}
+:not(pre) > code:not([class*="language-"]),
+kbd {
+  background: var(--inlineCodeBg);
+  color: var(--inlineCodeColor);
+  padding: 0.15em 0.4em;
+  border-radius: 0.35em;
+  font-size: 0.875em;
+}
+code[class*="language-"],
+pre[class*="language-"] {
+  line-height: 1.6;
+}
+pre[class*="language-"],
+pre code:not([class]) {
+  border-radius: 8px;
+  padding: 1.25em 1.5em;
+}
+/* code/tables/wide media never break the page on small screens */
+pre,
+table {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+/* ── Accessibility: skip link, focus ring, reduced motion ───────────────*/
+.skip-link {
+  position: absolute;
+  left: 0.5rem;
+  top: -3rem;
+  z-index: 1001;
+  padding: 0.5rem 1rem;
+  background: var(--surface);
+  color: var(--linkColor);
+  border-radius: 0.35em;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  transition: top 0.2s;
+}
+.skip-link:focus {
+  top: 0.5rem;
+}
+:focus-visible {
+  outline: 2px solid var(--linkColor);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+html {
+  scroll-behavior: smooth;
+}
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+
+/* ── Dark-mode-aware misc surfaces (replace hard-coded greys) ────────────*/
+small,
+figcaption,
+blockquote footer,
+.post-date {
+  color: var(--muted);
+}
+hr,
+main {
+  border-color: var(--hairline);
+}
+.divider,
+.dark .divider {
+  border-top: 1px solid var(--hairline);
+}
+
+/* ── Header / nav: keyboard-operable theme toggle, accessible site title ─*/
+.site-title {
+  float: left;
+  font-size: inherit;
+  line-height: inherit;
+  margin: 0;
+  text-align: left;
+  font-weight: var(--bold);
+}
+#color-scheme-toggle {
+  background: transparent;
+  border: 0;
+  padding: 0.25rem;
+  cursor: pointer;
+  line-height: 0;
+}
+#color-scheme-toggle img {
+  width: 24px;
+  display: block;
+  pointer-events: none;
+}
+/* Mobile nav bar layout for the (renamed) site title — mirrors the old
+   `#nav h1` rules now that the element is a <p class="site-title">. */
+@media screen and (max-width: 840px) {
+  #nav .site-title {
+    padding: 0.375rem 1.5rem;
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    float: none;
+  }
+  #nav .site-title * {
+    margin: 0;
+  }
+}
+
+/* ── Post cards: robust clamp + gentle hover ────────────────────────────*/
+.summary {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  max-height: none;
+  overflow: hidden;
+}
+.post {
+  border-radius: 10px;
+  padding: 1em;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+.post:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
+}
+.post-cover,
+.post-cover-img {
+  border-radius: 8px;
+}
+
+/* ── Table of Contents (post sidebar; populated by JS) ───────────────────*/
+.toc {
+  display: none;            /* shown by JS only when >= 2 headings exist */
+}
+.toc-details {
+  border: 1px solid var(--hairline);
+  border-radius: 0.5rem;
+  background: var(--surface);
+  padding: 0.5rem 0.9rem;
+}
+.toc-title {
+  font-weight: var(--bold);
+  cursor: pointer;
+  list-style: none;
+}
+.toc-title::-webkit-details-marker {
+  display: none;
+}
+.toc-title::before {
+  content: "›";
+  display: inline-block;
+  margin-right: 0.4em;
+  transition: transform 0.2s;
+}
+.toc-details[open] .toc-title::before {
+  transform: rotate(90deg);
+}
+.toc-list {
+  list-style: none;
+  margin: 0.6rem 0 0;
+  padding: 0;
+  font-size: 0.92em;
+}
+.toc-list li {
+  margin: 0.15em 0;
+}
+.toc-list .toc-h3 {
+  padding-left: 1em;
+  font-size: 0.95em;
+}
+.toc-list a {
+  color: var(--muted);
+  text-decoration: none;
+  display: block;
+  padding: 0.2em 0;
+  border-left: 2px solid transparent;
+  padding-left: 0.6em;
+}
+.toc-list a:hover {
+  color: var(--linkColor);
+}
+.toc-list a.active {
+  color: var(--linkColor);
+  border-left-color: var(--linkColor);
+  font-weight: var(--bold);
+}
+
+/* ── Back-to-top button (fixed;
+
+/* ════════════════════════════════════════════════════════════════════════
+   RESPONSIVE: phone / tablet / desktop — unified strategy
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* Desktop (>=1024px): article + sticky TOC sidebar. The grid reserves the
+   sidebar column up-front so populating the TOC causes no layout shift. */
+@media (min-width: 1024px) {
+  body.tmpl-post main {
+    display: grid;
+    grid-template-columns: minmax(0, 46rem) 15rem;
+    justify-content: center;
+    align-items: start;
+    gap: clamp(1.5rem, 3vw, 3rem);
+  }
+  body.tmpl-post main > article {
+    width: 100%;
+    margin: 0;
+  }
+  /* Sidebar TOC is desktop-only; .toc-ready is added by JS once populated.
+     On phone/tablet the .toc stays display:none (set above) so no bottom-of-
+     page TOC box appears and there is zero layout shift. */
+  .toc.toc-ready {
+    display: block;
+    align-self: start;
+    position: sticky;
+    top: 4.5rem;
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+  }
+}
+
+/* Tablet (768–1023px): single column, generous side padding, TOC hidden
+   (sidebar would crowd the measure; future: collapsible top card). */
+@media (min-width: 768px) and (max-width: 1023px) {
+  article {
+    width: min(100%, 42rem);
+    padding: clamp(1.25rem, 5vw, 2.5rem);
+  }
+}
+
+/* Touch devices: enlarge tap targets to >= 44px. */
+@media (pointer: coarse) {
+  header nav a,
+  .nav__links a,
+  .toc-list a {
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+  }
+  #color-scheme-toggle {
+    min-width: 44px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+/* Never allow horizontal scrolling of the whole page.
+   `clip` (not `hidden`) so we don't create a scroll container that would
+   break the TOC's position:sticky. */
+html,
+body {
+  overflow-x: clip;
+}
+article h1,
+article h2,
+article h3,
+header > h1.w-full {
+  font-weight: 700;
+}
+
+/* ── Top nav: "paper" bar with a hairline, accent only on hover ─────────*/
+header nav {
+  background: var(--navColor);
+  border-bottom: 1px solid var(--rule);
+}
+header nav a,
+.site-title a {
+  color: var(--ink);
+  font-size: 0.82rem;
+  letter-spacing: 0.02em;
+}
+header nav a:hover {
+  color: var(--accent);
+  opacity: 1;
+}
+.site-title a {
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+/* Thin reading-progress line along the bottom of the nav (was a full sweep). */
+#reading-progress {
+  top: auto;
+  bottom: 0;
+  height: 3px;
+  background-color: var(--accent);
+}
+/* mobile menu panel + hamburger on paper — MOBILE ONLY (on desktop the
+   nav links are an inline group and must have no background/border). */
+@media (max-width: 840px) {
+  .nav__links {
+    background: var(--paper);
+    border-bottom: 1px solid var(--rule);
+  }
+  .nav__links a:hover {
+    background: var(--rule);
+    color: var(--accent);
+  }
+}
+.menu__btn {
+  border-color: var(--ink-faint);
+}
+.menu__btn::before {
+  background-color: var(--ink);
+  box-shadow: 0 0.3rem 0 var(--ink), 0 -0.3rem 0 var(--ink);
+}
+
+/* ── Page header / masthead ──────────────────────────────────────────────*/
+main {
+  border-top: 0;
+}
+header > h1.w-full {
+  font-size: clamp(2.1rem, 1.5rem + 2vw, 3rem);
+  line-height: 1.18;
+  margin: 0.2em 0 0.3em;
+  color: var(--ink);
+}
+/* Home masthead: site name + tagline, centred, with a strong rule below. */
+body.tmpl-home header {
+  padding-bottom: 1.5em;
+}
+body.tmpl-home .intro {
+  max-width: 40rem;
+  margin: 0 auto 2.5rem;
+  text-align: center;
+  font-family: var(--font-serif);
+  font-size: 1.15rem;
+  line-height: 1.7;
+  color: var(--ink-soft);
+  border-bottom: 1px solid var(--rule-strong);
+  padding-bottom: 2rem;
+}
+body.tmpl-home .intro p {
+  margin: 0 0 0.5em;
+}
+
+/* ── Home / list page width ──────────────────────────────────────────────*/
+body.tmpl-home article {
+  width: min(100%, 52rem);
+}
+
+/* ════════ Homepage magazine list ════════ */
+.posts .post {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  margin: 0;
+  padding: 1.8rem 0;
+  border-bottom: 1px solid var(--rule);
+  border-radius: 0;
+  transition: none;
+}
+.posts .post:hover {
+  transform: none;
+  box-shadow: none;
+}
+.posts .post:last-child {
+  border-bottom: 0;
+}
+.post-cover {
+  flex: 0 0 190px;
+  height: 124px;
+  order: 2;
+  margin: 0;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.post-cover-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 2px;
+}
+.post-body {
+  flex: 1 1 auto;
+}
+.post-title {
+  font-size: 1.5rem;
+  line-height: 1.25;
+  margin: 0 0 0.5rem;
+}
+.post-title a {
+  color: var(--ink);
+  text-decoration: none;
+  background-image: linear-gradient(var(--accent), var(--accent));
+  background-size: 0 1px;
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  transition: background-size 0.25s, color 0.2s;
+}
+.post-title a:hover {
+  color: var(--accent);
+  background-size: 100% 1px;
+}
+.posts .summary {
+  color: var(--ink-soft);
+  font-size: 0.98rem;
+  line-height: 1.65;
+  margin: 0 0 0.2rem;
+}
+.post-info {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-top: 0.8rem;
+  font-size: 0.82rem;
+  color: var(--ink-faint);
+}
+.author-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--ink-soft);
+  text-decoration: none;
+}
+.author-link:hover {
+  color: var(--accent);
+}
+.avatar-small {
+  width: 22px;
+  height: 22px;
+  margin: 0;
+}
+.post-date {
+  font-family: Consolas, Monaco, "Andale Mono", monospace;
+  letter-spacing: 0.02em;
+}
+.post-date::before {
+  content: "·";
+  margin-right: 0.55rem;
+  color: var(--rule-strong);
+}
+
+/* Lead (featured) article: cover on top, oversized serif title.
+   Selector matches `.posts .post` specificity (2 classes) so display:block
+   and the strong rule win over the row layout. */
+.posts .post--lead {
+  display: block;
+  padding: 0 0 2.6rem;
+  margin-bottom: 0.6rem;
+  border-bottom: 1px solid var(--rule-strong);
+}
+.post--lead .post-cover {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 16 / 9;
+  max-height: 360px;
+  margin-bottom: 1.4rem;
+  border-radius: 3px;
+}
+.post--lead .post-title {
+  font-size: clamp(1.9rem, 1.3rem + 1.8vw, 2.7rem);
+  line-height: 1.18;
+  margin-bottom: 0.7rem;
+}
+.post--lead .summary {
+  font-size: 1.1rem;
+  line-height: 1.7;
+}
+
+@media (max-width: 768px) {
+  .posts .post:not(.post--lead) .post-cover {
+    display: none;
+  }
+}
+
+/* ════════ Article: editorial reading ════════ */
+body.tmpl-post article {
+  width: min(100%, 40rem);
+}
+/* Refined byline under the article title (markup from post.njk). */
+.byline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem 0.8rem;
+  margin: 0.4rem 0 0.6rem;
+  font-size: 0.88rem;
+  color: var(--ink-faint);
+}
+.byline-author {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--ink-soft);
+  text-decoration: none;
+  font-weight: 700;
+}
+.byline-author:hover {
+  color: var(--accent);
+}
+.byline-author .avatar {
+  width: 30px;
+  height: 30px;
+  margin: 0;
+}
+.byline-tags {
+  width: 100%;
+  text-align: center;
+  margin-top: 0.4rem;
+}
+
+/* Drop cap on the first paragraph — an editorial signature. */
+body.tmpl-post article > p:first-of-type::first-letter {
+  float: left;
+  font-family: var(--font-serif);
+  font-size: 3.3em;
+  line-height: 0.78;
+  font-weight: 700;
+  color: var(--accent);
+  margin: 0.04em 0.12em 0 0;
+}
+
+/* Pull-quote */
+article blockquote {
+  font-family: var(--font-serif);
+  font-size: 1.25em;
+  font-style: italic;
+  color: var(--ink-soft);
+  border-left: 3px solid var(--accent);
+  padding: 0.1em 0 0.1em 1.2em;
+  margin: 1.8em 0;
+}
+article blockquote footer {
+  font-style: normal;
+  font-family: var(--font-family);
+}
+
+/* Figures & captions */
+article figure {
+  margin: 2em auto;
+  text-align: center;
+}
+article figcaption {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--ink-faint);
+  text-align: center;
+  font-size: 0.9em;
+  margin-top: 0.6em;
+}
+
+/* Centred ornament instead of a full-width rule */
+article hr {
+  border: 0;
+  text-align: center;
+  margin: 2.6em 0;
+  line-height: 1;
+}
+article hr::before {
+  content: "✳";
+  color: var(--ink-faint);
+  font-size: 1.05em;
+  letter-spacing: 0.5em;
+}
+
+/* Tags */
+.post-tag {
+  display: inline-block;
+  font-size: 0.78rem;
+  color: var(--ink-soft);
+  border: 1px solid var(--rule-strong);
+  border-radius: 2px;
+  padding: 0.12em 0.55em;
+  margin: 0.15em 0.35em 0.15em 0;
+  text-decoration: none;
+  transition: color 0.2s, border-color 0.2s;
+}
+.post-tag:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* About-the-author card */
+.author-bio {
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--paper-raised);
+  padding: 1.5rem 1.6rem;
+  margin-top: 2.6rem;
+}
+.author-bio h2 {
+  font-size: 1.2rem;
+  margin: 0 0 0.8rem;
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+.author-bio .author-intro {
+  color: var(--ink-soft);
+  margin-top: 0.6rem;
+}
+
+/* ── TOC: editorial styling ──────────────────────────────────────────────*/
+.toc-details {
+  border: 0;
+  border-left: 1px solid var(--rule);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.1rem 0 0.1rem 1rem;
+}
+.toc-title {
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.toc-list a {
+  border-left: 2px solid transparent;
+  margin-left: -1rem;
+  padding-left: 0.9rem;
+}
+.toc-list a.active {
+  border-left-color: var(--accent);
+}
+button:not([disabled]),
+button[type="submit"],
+input[type="submit"] {
+  background: var(--accent);
+  color: #fff;
+  border-radius: 2px;
+}
+button:not([disabled]):hover,
+button[type="submit"]:hover,
+input[type="submit"]:hover {
+  background: var(--accent-hover);
+  color: #fff;
+}
+footer {
+  border-top: 1px solid var(--rule);
+  color: var(--ink-faint);
+  margin-top: 4rem;
+  font-size: 0.82rem;
+}
+
+/* Editorial article body link affordance (underline offset a touch more). */
+body.tmpl-post article a {
+  text-underline-offset: 0.18em;
+}
+
+/* Tablet: keep article comfortable, lead cover a bit shorter. */
+@media (min-width: 768px) and (max-width: 1023px) {
+  body.tmpl-post article {
+    width: min(100%, 40rem);
+  }
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+   REFINEMENTS / FIXES (review round 1)
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* (1) CRITICAL: legacy Bahunya `section { width:900px }` forced .intro and
+   .author-bio to 900px, overflowing small screens (clipped by overflow-x).
+   Neutralise it so sections fit their container. */
+section {
+  width: auto;
+  max-width: 100%;
+}
+
+/* (9) Underlined content links belong to article BODY only — not the home
+   feed or the archive list (which manage their own link styling). */
+body:not(.tmpl-post) article a {
+  text-decoration: none;
+}
+
+/* (1b) Home intro: left-aligned readable lead, not centred long paragraphs. */
+body.tmpl-home .intro {
+  text-align: start;
+  max-width: 38rem;
+  font-size: 1.08rem;
+}
+
+/* (5) Heading "#" permalink: hang it in the gutter so it never indents the
+   heading text, and only reveal it on hover. Keeps every heading flush-left
+   with the body text. */
+article h1,
+article h2,
+article h3,
+article h4,
+article h5,
+article h6 {
+  position: relative;
+}
+.direct-link {
+  position: absolute;
+  left: -0.85em;
+  top: 0;
+  margin: 0;
+  opacity: 0;
+  color: var(--accent);
+  text-decoration: none;
+}
+h1:hover > .direct-link,
+h2:hover > .direct-link,
+h3:hover > .direct-link,
+h4:hover > .direct-link,
+h5:hover > .direct-link,
+h6:hover > .direct-link {
+  opacity: 0.5;
+}
+
+/* (4) Tags: subtle text links ("#JavaScript"), not boxy outlined pills. */
+.post-tag {
+  display: inline-block;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0 0.85rem 0.2rem 0;
+  font-size: 0.86rem;
+  color: var(--ink-faint);
+  text-decoration: none;
+}
+.post-tag:hover {
+  color: var(--accent);
+  border-color: transparent;
+}
+
+/* (7) Pagination: wrap instead of overflowing on phones;
+
+/* (6) Archive list: clean three-part rows (date · serif title · by author),
+   not a wall of red underlined links. */
+#post-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.archive-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.3rem 0.9rem;
+  padding: 0.85rem 0;
+  margin: 0;
+  border-bottom: 1px solid var(--rule);
+  font-size: 1rem;
+}
+.archive-date {
+  flex: 0 0 7em;
+  color: var(--ink-faint);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+   REFINEMENTS round 2 — nav, language dropdown, back-to-top, author card,
+   home masthead rhythm, modern pagination (design-craft review)
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* ── Nav: single clean bar, everything vertically centred ────────────────*/
+header nav {
+  padding: 0.5rem 1.5rem;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--rule);
+}
+#nav {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+.site-title {
+  float: none;
+  margin: 0 auto 0 0; /* wordmark left, push the rest right */
+  display: inline-flex;
+  align-items: center;
+}
+.site-title a {
+  line-height: 1.1;
+}
+@media (min-width: 841px) {
+  .nav__links {
+    order: 5;
+    display: flex;
+    align-items: center;
+    gap: 1.4rem;
+  }
+  #color-scheme-toggle {
+    order: 6;
+    margin: 0;
+  }
+  .nav__link {
+    font-size: 0.9rem;
+  }
+}
+/* Reading-progress hairline sits exactly on the nav border (no double line) */
+#reading-progress {
+  height: 2px;
+  bottom: -1px;
+}
+
+/* Theme-toggle icon: the SVGs are white (#fafafa); invert them on the light
+   "paper" nav so the icon is visible, keep them white on the dark nav. */
+#color-scheme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+#color-scheme-toggle img {
+  filter: invert(1) brightness(0.2);
+}
+body.dark #color-scheme-toggle img {
+  filter: none;
+}
+
+/* ── Language switcher: compact globe dropdown (native <details>) ─────────*/
+.lang-switch {
+  position: relative;
+}
+.lang-switch__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.32rem 0.6rem;
+  border: 1px solid var(--rule);
+  border-radius: 7px;
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  white-space: nowrap;
+}
+.lang-switch__btn::-webkit-details-marker,
+.lang-switch__btn::marker {
+  display: none;
+}
+.lang-switch__btn:hover {
+  border-color: var(--rule-strong);
+  color: var(--ink);
+}
+.lang-switch__globe {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+}
+.lang-switch__chev {
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  transition: transform 0.2s;
+}
+.lang-switch[open] .lang-switch__chev {
+  transform: rotate(180deg);
+}
+.lang-switch[open] .lang-switch__btn {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+.lang-switch__menu {
+  position: absolute;
+  top: calc(100% + 7px);
+  right: 0;
+  z-index: 1001;
+  min-width: 9.5rem;
+  margin: 0;
+  padding: 0.35rem;
+  list-style: none;
+  text-align: left;
+  background: var(--paper-raised);
+  border: 1px solid var(--rule);
+  border-radius: 9px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+}
+.lang-switch__menu li {
+  margin: 0;
+}
+.lang-switch__item {
+  display: block;
+  padding: 0.45rem 0.7rem;
+  border-radius: 5px;
+  font-size: 0.85rem;
+  color: var(--ink-soft);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.lang-switch__item:hover {
+  background: var(--rule);
+  color: var(--ink);
+}
+.lang-switch__item.is-current {
+  color: var(--accent);
+  font-weight: 700;
+}
+.lang-switch__item.is-disabled {
+  color: var(--ink-faint);
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* (7) About-the-author card: aligned avatar + serif name (no raw red link),
+   tighter rhythm. */
+.author-bio {
+  padding: 1.6rem 1.8rem;
+}
+.author-bio h2 {
+  font-size: 1.15rem;
+  margin: 0 0 1rem;
+  color: var(--ink);
+}
+.author-bio .flex.items-center {
+  gap: 0;
+}
+.author-bio .avatar-large {
+  width: 54px;
+  height: 54px;
+}
+.author-bio h3 {
+  margin: 0 0 0 0.9rem;
+  font-size: 1.15rem;
+}
+.author-bio h3 a {
+  font-family: var(--font-serif);
+  color: var(--ink);
+  text-decoration: none;
+}
+.author-bio h3 a:hover {
+  color: var(--accent);
+}
+.author-bio .author-intro {
+  color: var(--ink-soft);
+  margin-top: 1rem;
+}
+
+/* (10) Home masthead → feed rhythm: distinguish the masthead from the lead
+   article (no hairline crammed between two big serif titles). */
+body.tmpl-home header > h1.w-full {
+  font-size: clamp(1.9rem, 1.4rem + 1.7vw, 2.5rem);
+}
+body.tmpl-home .intro {
+  border-bottom: 0;
+  padding-bottom: 0;
+  margin-bottom: 3.2rem;
+}
+.posts .post--lead .post-title {
+  font-size: clamp(1.7rem, 1.25rem + 1.5vw, 2.3rem);
+}
+
+/* Mobile: language menu expands inline inside the collapsed nav menu. */
+@media (max-width: 840px) {
+  .lang-switch {
+    margin-top: 0.4rem;
+  }
+  .lang-switch__menu {
+    position: static;
+    box-shadow: none;
+    border: 0;
+    padding: 0.2rem 0;
+    min-width: 0;
+    text-align: center;
+  }
+}
+
+/* Set the document background per theme so the very first paint after a
+   navigation is already the right colour (the <head> script adds html.dark).
+   Hard-coded to match --paper / dark --paper because <html> has no tokens. */
+html {
+  background: #fbfaf8;
+}
+html.dark {
+  background: #1a1816;
+}
+
+/* ── round 3: line-breaking & "view all" link ───────────────────────────*/
+/* Avoid lonely orphan characters on the last line (esp. CJK). */
+article p,
+body.tmpl-home .intro p,
+.summary {
+  text-wrap: pretty;
+}
+header > h1.w-full,
+.post-title,
+.archive-title,
+article h1,
+article h2,
+article h3 {
+  text-wrap: balance;
+}
+
+/* Home → archive call-to-action (replaces page-by-page pagination). */
+.view-all {
+  text-align: center;
+  margin: 2.6rem 0 1rem;
+}
+.view-all a {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  color: var(--ink);
+  text-decoration: none;
+  border-bottom: 1px solid var(--rule-strong);
+  padding-bottom: 2px;
+  transition: color 0.2s, border-color 0.2s;
+}
+.view-all a:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.archive-title {
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+.archive-title:hover {
+  color: var(--accent);
+}
+.archive-by {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--ink-faint);
+  font-size: 0.85rem;
+}
+.archive-by a {
+  color: var(--ink-soft);
+  text-decoration: none;
+}
+.archive-by a:hover {
+  color: var(--accent);
+}
+.archive-by .avatar-small {
+  width: 20px;
+  height: 20px;
+}
+@media (max-width: 480px) {
+  .archive-date {
+    flex-basis: 100%;
+  }
+}
+
+/* ── round 4: cohesive LEFT-aligned home masthead ───────────────────────
+   The title and the intro now share ONE left edge (aligned with the article),
+   instead of a centred title floating over a centred-but-left-text intro.
+   `balance` evens out the two-line intro so no lone CJK character is orphaned. */
+body.tmpl-home header {
+  align-items: stretch; /* full-width children so the title wraps, not shrink-wraps */
+  text-align: left;
+  width: min(100%, 52rem);
+  max-width: 100%;
+  padding: 4.5em clamp(1rem, 4vw, 2rem) 0;
+}
+body.tmpl-home header > h1.w-full {
+  text-align: left;
+  margin: 0.2em 0 0.4em;
+}
+body.tmpl-home .intro {
+  margin: 1.4rem 0 3.2rem;
+  max-width: 44rem;
+  text-align: start;
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+body.tmpl-home .intro p {
+  text-wrap: balance;
+}
+
+/* ── Locale-suggestion banner (revealed by src/main.js) ────────────────── */
+/* Fixed to the viewport bottom so revealing it causes no layout shift. */
+.lang-suggest {
+  position: fixed;
+  left: 50%;
+  bottom: 1rem;
+  transform: translateX(-50%);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  gap: 0.75em;
+  max-width: calc(100vw - 2rem);
+  padding: 0.6em 1em;
+  border-radius: 8px;
+  background: #fff;
+  color: #333;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+  font-size: 0.9rem;
+}
+.lang-suggest[hidden] {
+  display: none;
+}
+.lang-suggest__link {
+  white-space: nowrap;
+  font-weight: 600;
+}
+.lang-suggest__dismiss {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+  font-size: 1em;
+  line-height: 1;
+  padding: 0.2em;
+}
+body.dark .lang-suggest {
+  background: #333;
+  color: #eee;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -344,3 +344,55 @@ document.body.addEventListener(
   });
   banner.hidden = false;
 })();
+
+// ── Table of contents (post pages) + scroll-spy ─────────────────────────
+// The TOC <nav id="toc"> is rendered (empty) by post.njk so its styles survive
+// PurgeCSS. We populate it from the article's heading anchors (which already
+// have ids from markdown-it-anchor). Manually-authored headings such as the
+// "About the author" section have no id and are intentionally skipped.
+(function () {
+  var toc = document.getElementById("toc");
+  if (!toc) return;
+  var article = document.querySelector("main > article");
+  var list = toc.querySelector(".toc-list");
+  if (!article || !list) return;
+  var headings = [].slice.call(article.querySelectorAll("h2[id], h3[id]"));
+  if (headings.length < 2) {
+    // Nothing worth a TOC. It is display:none, so removing it shifts nothing.
+    toc.parentNode && toc.parentNode.removeChild(toc);
+    return;
+  }
+  var byId = {};
+  headings.forEach(function (h) {
+    var li = document.createElement("li");
+    li.className = h.tagName === "H3" ? "toc-h3" : "toc-h2";
+    var a = document.createElement("a");
+    a.href = "#" + h.id;
+    a.textContent = (h.textContent || "").replace(/^#+\s*/, "").trim();
+    li.appendChild(a);
+    list.appendChild(li);
+    byId[h.id] = a;
+  });
+  // CSS reveals .toc.toc-ready only on >=1024px (desktop sidebar); on smaller
+  // screens it stays hidden, avoiding a bottom-of-page TOC and any layout shift.
+  toc.classList.add("toc-ready");
+
+  if ("IntersectionObserver" in window) {
+    var current = null;
+    var io = new IntersectionObserver(
+      function (entries) {
+        entries.forEach(function (e) {
+          if (!e.isIntersecting) return;
+          if (current) current.classList.remove("active");
+          current = byId[e.target.id];
+          if (current) current.classList.add("active");
+        });
+      },
+      { rootMargin: "0px 0px -75% 0px", threshold: 0 }
+    );
+    headings.forEach(function (h) {
+      io.observe(h);
+    });
+  }
+})();
+

--- a/test/test-css-output.js
+++ b/test/test-css-output.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const activeLanguages = require("../_11ty/activeLanguages.js");
+
+function inlinedCss(relativeOutputPath) {
+  const filename = path.join(PROJECT_ROOT, "_site", relativeOutputPath);
+  assert.ok(fs.existsSync(filename), `Missing build output: ${filename}`);
+  const doc = new JSDOM(fs.readFileSync(filename, "utf8")).window.document;
+  const style = doc.querySelector("style");
+  assert.ok(style, `Missing inlined CSS: ${filename}`);
+  return style.textContent;
+}
+
+describe("purged CSS output", () => {
+  it("keeps language UI styles only when other languages are live", () => {
+    const css = inlinedCss("index.html");
+    assert.doesNotMatch(css, /\.lang-nav/);
+    assert.match(css, /\.lang-switch/);
+    // The reading-language banner only renders (and its styles only survive
+    // PurgeCSS) once at least one non-default language has published posts.
+    if (activeLanguages(false).length > 1) {
+      assert.match(css, /\.lang-suggest/);
+    } else {
+      assert.doesNotMatch(css, /\.lang-suggest/);
+    }
+  });
+
+  it("keeps classes added dynamically by the table-of-contents script", () => {
+    const css = inlinedCss("posts/tian/git-flow/index.html");
+    assert.match(css, /\.toc\.toc-ready/);
+    assert.match(css, /\.toc-list \.toc-h3/);
+    assert.match(css, /\.toc-list a\.active/);
+  });
+
+  it("contains no retired language-nav selectors in the source stylesheet", () => {
+    const css = fs.readFileSync(path.join(PROJECT_ROOT, "css", "main.css"), "utf8");
+    assert.doesNotMatch(css, /\.lang-nav/);
+    assert.match(css, /\.lang-suggest/);
+  });
+});

--- a/test/test-generic-post.js
+++ b/test/test-generic-post.js
@@ -1,203 +1,149 @@
+"use strict";
+
 const assert = require("assert").strict;
-const expect = require("expect.js");
+const fs = require("fs");
+const path = require("path");
 const { JSDOM } = require("jsdom");
-const readFileSync = require("fs").readFileSync;
-const existsSync = require("fs").existsSync;
 const metadata = require("../_data/metadata.json");
-const GA_ID = require("../_data/googleanalytics.js")();
 
-/**
- * These tests kind of suck and they are kind of useful.
- *
- * They suck, because they need to be changed when the hardcoded post changes.
- * They are useful because I tend to break the things they test all the time.
- */
+const POST_PATH = "/posts/tian/git-flow/";
+const POST_URL = metadata.url + POST_PATH;
+const POST_FILENAME = path.resolve(
+  __dirname,
+  "..",
+  "_site",
+  "posts",
+  "tian",
+  "git-flow",
+  "index.html"
+);
+const IMAGE_POST_FILENAME = path.resolve(
+  __dirname,
+  "..",
+  "_site",
+  "posts",
+  "ruofan",
+  "go-RESTful-api",
+  "index.html"
+);
 
-describe("check build output for a generic post", () => {
-  describe("sample post", () => {
-    const POST_FILENAME = "_site/posts/firstpost/index.html";
-    const URL = metadata.url;
-    const POST_URL = URL + "/posts/firstpost/";
+describe("representative post build output", () => {
+  let doc;
 
-    if (!existsSync(POST_FILENAME)) {
-      it("WARNING skipping tests because POST_FILENAME does not exist", () => {});
+  before(() => {
+    assert.ok(fs.existsSync(POST_FILENAME), `Missing build output: ${POST_FILENAME}`);
+    doc = new JSDOM(fs.readFileSync(POST_FILENAME, "utf8")).window.document;
+  });
+
+  it("has correct title, language, canonical, and social metadata", () => {
+    assert.equal(doc.documentElement.lang, "zh-TW");
+    assert.match(doc.title, /^我所理解的 GitFlow/);
+    assert.equal(doc.querySelector("link[rel='canonical']").href, POST_URL);
+    assert.equal(doc.querySelector("meta[property='og:url']").content, POST_URL);
+    assert.ok(doc.querySelector("meta[name='description']").content.length > 0);
+  });
+
+  it("has inlined CSS and the fingerprinted client bundle", () => {
+    assert.match(doc.querySelector("style").textContent, /header nav/);
+    const bundle = doc.querySelector("script[src^='/js/min.js?hash=']");
+    assert.ok(bundle, "Expected fingerprinted /js/min.js client bundle");
+  });
+
+  it("has an accessible share control and correct publication date", () => {
+    const share = doc.querySelector("share-widget button");
+    assert.ok(share);
+    assert.ok(share.getAttribute("aria-label"));
+    assert.equal(share.getAttribute("href"), POST_URL);
+
+    const published = doc.querySelector("time.byline-date");
+    assert.equal(published.getAttribute("datetime"), "2021-10-28");
+    assert.match(published.textContent, /2021-10-28/);
+  });
+
+  it("emits valid Article JSON-LD for the post", () => {
+    const value = doc.querySelector("script[type='application/ld+json']").textContent;
+    const article = JSON.parse(value);
+    assert.equal(article["@type"], "Article");
+    assert.equal(article.headline, "我所理解的 GitFlow");
+    assert.equal(article.inLanguage, "zh-TW");
+    assert.equal(article.url, POST_URL);
+    assert.equal(article.mainEntityOfPage, POST_URL);
+    assert.equal(article.datePublished, "2021-10-28");
+    assert.equal(article.dateModified, article.datePublished);
+    assert.deepEqual(article.image, [metadata.ogimage]);
+    assert.equal(article.author.name, "Tian");
+    assert.equal(article.author.url, `${metadata.url}/posts/tian/`);
+    assert.equal(article.publisher.name, metadata.publisher.name);
+    assert.equal(article.publisher.url, metadata.url);
+    assert.equal(article.publisher.logo.url, metadata.url + metadata.publisher.logo);
+    assert.equal(article.publisher.logo.width, 512);
+    assert.equal(article.publisher.logo.height, 512);
+    assert.equal(Object.hasOwn(article, "genre"), false);
+  });
+
+  it("uses exactly the declared hero image when a post has one", () => {
+    assert.ok(
+      fs.existsSync(IMAGE_POST_FILENAME),
+      `Missing build output: ${IMAGE_POST_FILENAME}`
+    );
+    const imagePost = new JSDOM(fs.readFileSync(IMAGE_POST_FILENAME, "utf8"))
+      .window.document;
+    const article = JSON.parse(
+      imagePost.querySelector("script[type='application/ld+json']").textContent
+    );
+    assert.deepEqual(article.image, [
+      `${metadata.url}/img/posts/ruofan/go-1.png`,
+    ]);
+  });
+
+  it("adds dimensions and responsive sources to local raster images", () => {
+    assert.ok(
+      fs.existsSync(IMAGE_POST_FILENAME),
+      `Missing build output: ${IMAGE_POST_FILENAME}`
+    );
+    const imageDoc = new JSDOM(
+      fs.readFileSync(IMAGE_POST_FILENAME, "utf8")
+    ).window.document;
+    const image = imageDoc.querySelector("picture img[src^='/img/']:not(.avatar)");
+    assert.ok(image, "Expected at least one optimized local image");
+    assert.match(image.getAttribute("width"), /^\d+$/);
+    assert.match(image.getAttribute("height"), /^\d+$/);
+    assert.equal(image.getAttribute("loading"), "lazy");
+    assert.equal(image.getAttribute("decoding"), "async");
+
+    const sources = [...image.closest("picture").querySelectorAll("source")];
+    assert.ok(sources.some((source) => source.type === "image/webp"));
+    assert.ok(sources.some((source) => source.type === "image/jpeg"));
+  });
+
+  it("advertises published translations and never drafts", () => {
+    // Derive this post's published translation languages from the source of
+    // truth (sibling .<lang>.md frontmatter), so the assertion follows the
+    // actual publication state instead of hardcoding it.
+    const langs = require("../_data/langs.json");
+    const published = langs.slice(1).filter((lang) => {
+      const file = path.resolve(__dirname, "..", `posts/tian/git-flow.${lang}.md`);
+      if (!fs.existsSync(file)) return false;
+      const fm = fs
+        .readFileSync(file, "utf8")
+        .match(/^---\r?\n([\s\S]*?)\r?\n---/);
+      return fm && !/^draft:\s*(?:true|["']true["'])\s*$/m.test(fm[1]);
+    });
+
+    const hreflangs = [
+      ...doc.querySelectorAll("link[rel='alternate'][hreflang]"),
+    ].map((link) => link.getAttribute("hreflang"));
+
+    if (published.length === 0) {
+      assert.equal(hreflangs.length, 0);
+      assert.equal(doc.querySelector("#lang-suggest"), null);
       return;
     }
-
-    let dom;
-    let html;
-    let doc;
-
-    function select(selector, opt_attribute) {
-      const element = doc.querySelector(selector);
-      assert(element, "Expected to find: " + selector);
-      if (opt_attribute) {
-        return element.getAttribute(opt_attribute);
-      }
-      return element.textContent;
-    }
-
-    before(() => {
-      html = readFileSync(POST_FILENAME);
-      dom = new JSDOM(html);
-      doc = dom.window.document;
-    });
-
-    // it("should have metadata", () => {
-    //   assert.equal(select("title"), "This is my first post.");
-    //   expect(select("meta[property='og:image']", "content")).to.match(
-    //     /\/img\/remote\/\w+.jpg/
-    //   );
-    //   assert.equal(select("link[rel='canonical']", "href"), POST_URL);
-    //   assert.equal(
-    //     select("meta[name='description']", "content"),
-    //     "This is a post on My Blog about agile frameworks."
-    //   );
-    // });
-
-    it("should have inlined css", () => {
-      const css = select("style");
-      expect(css).to.match(/header nav/);
-      expect(css).to.not.match(/test-dead-code-elimination-sentinel/);
-    });
-
-    it("should have script elements", () => {
-      const scripts = doc.querySelectorAll("script[src]");
-      let has_ga_id = GA_ID ? 1 : 0;
-      expect(scripts).to.have.length(has_ga_id + 1); // NOTE: update this when adding more <script>
-      expect(scripts[0].getAttribute("src")).to.match(
-        /^\/js\/min\.js\?hash=\w+/
-      );
-    });
-
-    it("should have GA a setup", () => {
-      if (!GA_ID) {
-        return;
-      }
-      const scripts = doc.querySelectorAll("script[src]");
-      expect(scripts[1].getAttribute("src")).to.match(
-        /^\/js\/cached\.js\?hash=\w+/
-      );
-      const noscript = doc.querySelectorAll("noscript");
-      expect(noscript.length).to.be.greaterThan(0);
-      let count = 0;
-      for (let n of noscript) {
-        if (n.textContent.includes("/.netlify/functions/ga")) {
-          count++;
-          expect(n.textContent).to.contain(GA_ID);
-        }
-      }
-      expect(count).to.equal(1);
-    });
-
-    it("should have a good CSP", () => {
-      const csp = select(
-        "meta[http-equiv='Content-Security-Policy']",
-        "content"
-      );
-      expect(csp).to.contain(";object-src 'none';");
-      expect(csp).to.match(/^default-src 'self';/);
-    });
-
-    it("should have accessible buttons", () => {
-      const buttons = doc.querySelectorAll("button");
-      for (let b of buttons) {
-        expect(
-          (b.firstElementChild === null && b.textContent.trim()) ||
-            b.getAttribute("aria-label") != null
-        ).to.be.true;
-      }
-    });
-
-    it("should have a share widget", () => {
-      expect(select("share-widget button", "href")).to.equal(POST_URL);
-    });
-
-    // it("should have a header", () => {
-    //   expect(select("header > h1")).to.equal("This is my first post.");
-    //   expect(select("header aside")).to.match(/\d+ min read./);
-    //   expect(select("header dialog", "id")).to.equal("message");
-    // });
-
-    it("should have a published date", () => {
-      expect(select("article time")).to.equal("01 May 2018");
-      expect(select("article time", "datetime")).to.equal("2018-05-01");
-    });
-
-    it("should link to twitter with noopener", () => {
-      const twitterLinks = Array.from(doc.querySelectorAll("a")).filter((a) =>
-        a.href.startsWith("https://twitter.com")
-      );
-      for (let a of twitterLinks) {
-        expect(a.rel).to.contain("noopener");
-        expect(a.target).to.equal("_blank");
-      }
-    });
-
-    describe("body", () => {
-      it("should have images", () => {
-        const images = Array.from(
-          doc.querySelectorAll("article :not(aside) picture img")
-        );
-        const pictures = Array.from(
-          doc.querySelectorAll("article :not(aside) picture")
-        );
-        const metaImage = select("meta[property='og:image']", "content");
-        expect(images.length).to.greaterThan(0);
-        expect(pictures.length).to.greaterThan(0);
-        const img = images[0];
-        const picture = pictures[0];
-        const sources = Array.from(picture.querySelectorAll("source"));
-        expect(sources).to.have.length(3);
-        expect(img.src).to.match(/^\/img\/remote\/\w+-1920w\.jpg$/);
-        expect(metaImage).to.match(new RegExp(URL));
-        expect(metaImage).to.match(/\/img\/remote\/\w+\.jpg$/);
-        const avif = sources.shift();
-        const webp = sources.shift();
-        const jpg = sources.shift();
-        expect(jpg.srcset).to.match(
-          /\/img\/remote\/\w+-1920w.jpg 1920w, \/img\/remote\/\w+-1280w.jpg 1280w, \/img\/remote\/\w+-640w.jpg 640w, \/img\/remote\/\w+-320w.jpg 320w/
-        );
-        expect(webp.srcset).to.match(
-          /\/img\/remote\/\w+-1920w.webp 1920w, \/img\/remote\/\w+-1280w.webp 1280w, \/img\/remote\/\w+-640w.webp 640w, \/img\/remote\/\w+-320w.webp 320w/
-        );
-        expect(avif.srcset).to.match(
-          /\/img\/remote\/\w+-1920w.avif 1920w, \/img\/remote\/\w+-1280w.avif 1280w, \/img\/remote\/\w+-640w.avif 640w, \/img\/remote\/\w+-320w.avif 320w/
-        );
-        expect(jpg.type).to.equal("image/jpeg");
-        expect(webp.type).to.equal("image/webp");
-        //expect(avif.type).to.equal("image/avif");
-        expect(jpg.sizes).to.equal("(max-width: 608px) 100vw, 608px");
-        expect(webp.sizes).to.equal("(max-width: 608px) 100vw, 608px");
-        expect(img.height).to.match(/^\d+$/);
-        expect(img.width).to.match(/^\d+$/);
-        expect(img.getAttribute("loading")).to.equal("lazy");
-        expect(img.getAttribute("decoding")).to.equal("async");
-        // JSDom fails to parse the style attribute properly
-        expect(img.outerHTML).to.match(/svg/);
-        expect(img.outerHTML).to.match(/filter/);
-      });
-
-      it("should have json-ld", () => {
-        const json = select("script[type='application/ld+json']");
-        const images = Array.from(
-          doc.querySelectorAll("article :not(aside) img")
-        );
-        const obj = JSON.parse(json);
-        expect(obj.url).to.equal(POST_URL);
-        expect(obj.description).to.equal(
-          "Leverage agile frameworks to provide a robust synopsis for high level overviews. Iterative approaches to corporate strategy foster..."
-        );
-        expect(obj.image.length).to.be.greaterThan(0);
-        obj.image.forEach((url, index) => {
-          expect(url).to.equal(URL + images[index].src);
-        });
-      });
-
-      it("should have paragraphs", () => {
-        const images = Array.from(doc.querySelectorAll("article > p"));
-        expect(images.length).to.greaterThan(0);
-      });
-    });
+    // Source + each published translation + x-default; nothing else — a draft
+    // or missing language must never leak into the alternates.
+    const allowed = ["zh-TW", "x-default", ...published];
+    assert.equal(hreflangs.length, published.length + 2);
+    allowed.forEach((lang) => assert.ok(hreflangs.includes(lang), `missing hreflang ${lang}`));
+    hreflangs.forEach((lang) => assert.ok(allowed.includes(lang), `unexpected hreflang ${lang}`));
   });
 });

--- a/test/test-homepage.js
+++ b/test/test-homepage.js
@@ -1,47 +1,48 @@
-const expect = require("expect.js");
+"use strict";
+
 const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
 const { JSDOM } = require("jsdom");
-const readFileSync = require("fs").readFileSync;
-const existsSync = require("fs").existsSync;
+const metadata = require("../_data/metadata.json");
 
-describe("check build output for homepage", () => {
-  describe("homepage", () => {
-    const FILENAME = "_site/index.html";
+const SITE_ROOT = path.resolve(__dirname, "..", "_site");
+const FILENAME = path.join(SITE_ROOT, "index.html");
 
-    if (!existsSync(FILENAME)) {
-      it("WARNING skipping tests because FILENAME does not exist", () => {});
-      return;
+describe("homepage build output", () => {
+  let doc;
+
+  before(() => {
+    assert.ok(fs.existsSync(FILENAME), `Missing build output: ${FILENAME}`);
+    doc = new JSDOM(fs.readFileSync(FILENAME, "utf8")).window.document;
+  });
+
+  it("has localized document metadata and a self canonical", () => {
+    assert.equal(doc.documentElement.lang, "zh-TW");
+    assert.equal(
+      doc.querySelector("link[rel='canonical']").href,
+      `${metadata.url}/`
+    );
+    assert.ok(doc.querySelector("meta[name='description']").content.length > 0);
+  });
+
+  it("has working primary navigation", () => {
+    const hrefs = [...doc.querySelectorAll("header nav a")].map((link) =>
+      link.getAttribute("href")
+    );
+    assert.ok(hrefs.includes("/archive/"));
+    assert.ok(hrefs.includes("/tags/"));
+    assert.ok(hrefs.includes("/about/"));
+  });
+
+  it("lists real posts whose generated pages exist", () => {
+    const links = [...doc.querySelectorAll(".posts .post-title a")];
+    assert.ok(links.length > 0, "Expected at least one post on the homepage");
+
+    for (const link of links) {
+      const pathname = new URL(link.href, metadata.url).pathname;
+      const output = path.join(SITE_ROOT, pathname, "index.html");
+      assert.ok(fs.existsSync(output), `Homepage links to missing output: ${pathname}`);
     }
-
-    let dom;
-    let html;
-    let doc;
-
-    function select(selector, opt_attribute) {
-      const element = doc.querySelector(selector);
-      assert(element, "Expected to find: " + selector);
-      if (opt_attribute) {
-        return element.getAttribute(opt_attribute);
-      }
-      return element.textContent;
-    }
-
-    before(() => {
-      html = readFileSync("_site/index.html");
-      dom = new JSDOM(html);
-      doc = dom.window.document;
-    });
-
-    it("should have a top navigation", () => {
-      const navs = Array.from(doc.querySelectorAll("header nav a"));
-
-      expect(navs.length).to.be.greaterThan(1);
-    });
-
-    it("should have a list of posts", () => {
-      const posts = Array.from(doc.querySelectorAll(".posts .post-title"));
-
-      expect(posts.length).to.be.greaterThan(0);
-    });
   });
 });

--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const POST_FILENAME = path.resolve(
+  __dirname,
+  "..",
+  "_site",
+  "posts",
+  "tian",
+  "git-flow",
+  "index.html"
+);
+describe("article readability build output", () => {
+  let doc;
+  let inlineCss;
+
+  before(() => {
+    assert.ok(fs.existsSync(POST_FILENAME), `Missing build output: ${POST_FILENAME}`);
+    doc = new JSDOM(fs.readFileSync(POST_FILENAME, "utf8")).window.document;
+    inlineCss = doc.querySelector("style").textContent;
+  });
+
+  it("ships an empty TOC shell for the client script to fill", () => {
+    const toc = doc.querySelector("nav#toc");
+    assert.ok(toc, "Expected <nav id='toc'> shell");
+    const list = toc.querySelector(".toc-list");
+    assert.ok(list);
+    assert.equal(list.children.length, 0, "TOC entries are added client-side");
+  });
+
+  it("anchors every section heading for the TOC and deep links", () => {
+    const headings = [...doc.querySelectorAll("article h2[id], article h3[id]")];
+    assert.ok(headings.length >= 2, "Expected at least two addressable headings");
+    for (const heading of headings) {
+      assert.ok(
+        heading.querySelector("a.direct-link"),
+        `Heading #${heading.id} is missing its direct link`
+      );
+    }
+  });
+
+  it("renders the reading progress bar element", () => {
+    assert.ok(doc.getElementById("reading-progress"));
+  });
+
+  it("keeps JS-toggled reading UI selectors through the CSS purge", () => {
+    assert.match(inlineCss, /#reading-progress/);
+    assert.match(inlineCss, /\.toc-ready/);
+    assert.match(inlineCss, /\.direct-link/);
+  });
+
+  it("keeps language-aware article typography through the CSS purge", () => {
+    // `:lang(...) article` starts with a functional pseudo-class purgecss@2
+    // cannot match against page content; a whitelistPatterns entry keeps it.
+    assert.match(inlineCss, /:lang\([^)]+\)[^{]*article[^{]*\{[^}]*line-height:1\.85/);
+    assert.match(inlineCss, /:lang\(en\)[^{]*article[^{]*\{[^}]*line-height:1\.7/);
+  });
+});


### PR DESCRIPTION
## 摘要

閱讀體驗改版與無障礙修正：editorial「紙墨」設計系統（含深色模式）、桌機目錄側欄（scroll-spy）、閱讀進度條、skip-link 與 focus ring 等 a11y 修正，以及消除主題閃爍的 CSP-hash pre-paint script。Lighthouse a11y 88 → 98。

## Stack 位置與合併順序

本 PR 是 #202 拆分計畫的第 **7/9** 級（完整索引見 #202 的留言）。

- ⬆️ 依賴：`i18n-stack/06-feeds`
- ⬇️ 被依賴：第 8–9 級

## 背景與動機

改版目標是長文閱讀體驗：字級節奏、行長、語言感知字體（CJK 與拉丁文各自的 serif stack 與行高），同時修正既有 a11y 問題（deep-link 對比、裝飾圖 alt、theme toggle 不是按鈕、無 skip-link）。

## 變更內容

- **`css/main.css`（本 PR 主體，約 +1300 行）**：design tokens、`:lang()` 語言感知排版、段落節奏、標題層級、首頁卡片（`post--lead`）、byline、author-bio、archive 列、深色模式表面、`prefers-reduced-motion`
- **TOC 側欄**：`post.njk` 渲染空殼（樣式才能過 PurgeCSS），`src/main.js` 從 heading anchors 建目錄＋IntersectionObserver scroll-spy；<1024px 隱藏、不足 2 個標題自動移除，零 layout shift
- **主題 pre-paint script（CSP-hash）**：在 inlined CSS 繪製前套用主題 class，跨頁導航不再閃白
- **a11y**：skip-link、focus ring、深色模式 code 對比、裝飾性頭像 `alt=""`、theme toggle 改為真 `<button>`
- **PurgeCSS whitelist**（purgecss@2 陷阱）：JS 切換的類（`active`/`toc-*`）與 `:lang()` 選擇器必須用 `whitelist`/`whitelistPatterns`——v3 的 `safelist` 會被**靜默忽略**，檔內已留註解防回歸
- **測試**：`test-css-output.js`（purge 後 CSS 斷言）、`test-readability.js`（TOC 殼、heading anchors、進度條、`:lang` 保留）、重寫 `test-homepage.js`／`test-generic-post.js` 對齊新 markup

## 測試計畫

- `npm run build` 全綠（50 mocha）
- 人工抽查：文章頁桌機寬度看 TOC/scroll-spy；深色模式切換無閃爍；Tab 鍵走訪 skip-link 與 focus ring

## 風險與回滾

- 影響面：全站視覺；純前端，無資料/URL 變更
- 回滾：revert 單一 merge commit 即回舊版視覺
- 已知：原文內容檔（posts/tian/*.md 排版）不在本級（第 9 級，回應 review N7 的內容/基礎設施分離）

## Review 重點

1. PurgeCSS whitelist 註解與防回歸（purgecss@2 vs v3 API）
2. TOC 的漸進增強路徑（無 JS、無 IntersectionObserver 時的行為）
3. pre-paint script 的 CSP hash 流程
4. 深色模式對比度抽查

🤖 Generated with [Claude Code](https://claude.com/claude-code)
