### PR TITLE
fix(ui): 語言建議 Banner 重新設計

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -339,6 +339,7 @@ module.exports = function (eleventyConfig) {
       out[code] = {
         available: strings.suggestAvailable,
         read: strings.suggestRead,
+        dismiss: strings.suggestDismiss,
       };
     }
     return JSON.stringify(out);

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -224,11 +224,22 @@
         match among the hreflang alternates in <head>. Fixed-position so
         revealing it causes no layout shift. No auto-redirect (SEO-safe). #}
     {%- if langVersions and langVersions.length > 1 %}
-    <aside id="lang-suggest" class="lang-suggest" hidden
+    <aside id="lang-suggest" class="lang-suggest" hidden aria-live="polite"
+      aria-labelledby="lang-suggest-text"
       data-strings="{{ i18n | langSuggestStrings(langs) }}">
-      <span class="lang-suggest__text"></span>
-      <a class="lang-suggest__link" href="#"></a>
-      <button class="lang-suggest__dismiss" type="button" aria-label="{{ t.suggestDismiss }}">&#10005;</button>
+      <svg class="lang-suggest__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <circle cx="12" cy="12" r="9"/>
+        <path d="M3 12h18M12 3c2.5 2.5 2.5 16 0 18M12 3c-2.5 2.5-2.5 16 0 18"/>
+      </svg>
+      <div class="lang-suggest__content">
+        <span id="lang-suggest-text" class="lang-suggest__text"></span>
+        <a class="lang-suggest__link" href="#"></a>
+      </div>
+      <button class="lang-suggest__dismiss" type="button" aria-label="{{ t.suggestDismiss }}">
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M6 6l12 12M18 6L6 18"/>
+        </svg>
+      </button>
     </aside>
     {%- endif %}
 

--- a/css/main.css
+++ b/css/main.css
@@ -2641,42 +2641,127 @@ body.tmpl-home .intro p {
 }
 
 /* ── Locale-suggestion banner (revealed by src/main.js) ────────────────── */
-/* Fixed to the viewport bottom so revealing it causes no layout shift. */
+/* A compact editorial callout that reuses the site's paper/ink palette. It
+   stays fixed to the viewport so revealing it causes no layout shift. */
 .lang-suggest {
   position: fixed;
   left: 50%;
-  bottom: 1rem;
+  bottom: calc(1rem + env(safe-area-inset-bottom));
   transform: translateX(-50%);
   z-index: 100;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 0.75em;
-  max-width: calc(100vw - 2rem);
-  padding: 0.6em 1em;
-  border-radius: 8px;
-  background: #fff;
-  color: #333;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
+  gap: 0.85rem;
+  box-sizing: border-box;
+  width: min(32rem, calc(100vw - 2rem));
+  padding: 0.8rem 0.8rem 0.8rem 1rem;
+  border: 1px solid var(--rule-strong);
+  border-left: 3px solid var(--accent);
+  border-radius: 7px;
+  background: var(--paper-raised);
+  color: var(--ink);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
   font-size: 0.9rem;
+  line-height: 1.45;
 }
 .lang-suggest[hidden] {
   display: none;
 }
-.lang-suggest__link {
-  white-space: nowrap;
-  font-weight: 600;
+.lang-suggest__icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 1.6;
 }
-.lang-suggest__dismiss {
-  border: none;
-  background: none;
+.lang-suggest__content {
+  min-width: 0;
+}
+.lang-suggest__text {
+  display: block;
+  color: var(--ink);
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  line-height: 1.4;
+  text-wrap: pretty;
+}
+.lang-suggest__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3em;
+  margin-top: 0.2rem;
+  color: var(--accent);
+  font-family: var(--font-family);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+.lang-suggest__link::after {
+  content: "\2192";
+  transition: transform 0.15s ease;
+}
+.lang-suggest__link:hover {
+  color: var(--accent-hover);
+}
+.lang-suggest__link:hover::after {
+  transform: translateX(0.15em);
+}
+.lang-suggest__link:focus-visible,
+.lang-suggest > .lang-suggest__dismiss:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+/* Two classes intentionally outrank the legacy button:not([disabled]) rule,
+   which otherwise paints this control as a large accent submit button. */
+.lang-suggest > .lang-suggest__dismiss {
+  appearance: none;
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  background: transparent;
   cursor: pointer;
-  color: inherit;
-  font-size: 1em;
+  color: var(--ink-faint);
+  box-shadow: none;
   line-height: 1;
-  padding: 0.2em;
+}
+.lang-suggest > .lang-suggest__dismiss svg {
+  width: 1rem;
+  height: 1rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.8;
+}
+.lang-suggest > .lang-suggest__dismiss:hover {
+  border-color: var(--rule);
+  background: var(--rule);
+  color: var(--ink);
 }
 body.dark .lang-suggest {
-  background: #333;
-  color: #eee;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+}
+@media (max-width: 480px) {
+  .lang-suggest {
+    right: 0.75rem;
+    bottom: calc(0.75rem + env(safe-area-inset-bottom));
+    left: 0.75rem;
+    width: auto;
+    padding: 0.75rem 0.65rem 0.75rem 0.8rem;
+    transform: none;
+  }
+}
+/* The article share control occupies the lower-right corner between 377px and
+   600px. Lift the notice above it; at 376px the share control is already hidden. */
+@media (min-width: 377px) and (max-width: 660px) {
+  body.tmpl-post .lang-suggest {
+    bottom: calc(5rem + env(safe-area-inset-bottom));
+  }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -330,13 +330,16 @@ document.body.addEventListener(
   if (!match) return;
   var s = strings[match.code];
   if (!s || !s.available || !s.read) return;
+  banner.setAttribute("lang", match.code);
   banner.querySelector(".lang-suggest__text").textContent = s.available;
   var link = banner.querySelector(".lang-suggest__link");
   link.textContent = s.read;
   link.href = match.href;
   link.setAttribute("hreflang", match.code);
   link.setAttribute("lang", match.code);
-  banner.querySelector(".lang-suggest__dismiss").addEventListener("click", function () {
+  var dismiss = banner.querySelector(".lang-suggest__dismiss");
+  if (s.dismiss) dismiss.setAttribute("aria-label", s.dismiss);
+  dismiss.addEventListener("click", function () {
     banner.hidden = true;
     try {
       localStorage.setItem("langSuggestDismissed", "1");
@@ -395,4 +398,3 @@ document.body.addEventListener(
     });
   }
 })();
-

--- a/test/test-css-output.js
+++ b/test/test-css-output.js
@@ -38,6 +38,17 @@ describe("purged CSS output", () => {
     assert.match(css, /\.toc-list a\.active/);
   });
 
+  it("keeps the banner dismiss control isolated from global button styles", () => {
+    const css = inlinedCss("posts/tian/git-flow/index.html");
+    const dismissRule = css.match(
+      /\.lang-suggest>\.lang-suggest__dismiss\{([^}]*)\}/
+    );
+    assert.ok(dismissRule, "Expected the specific banner dismiss-button reset");
+    assert.match(dismissRule[1], /margin:0/);
+    // clean-css serializes `transparent` shorthand as the equivalent `0 0`.
+    assert.match(dismissRule[1], /background:(?:transparent|0 0)/);
+  });
+
   it("contains no retired language-nav selectors in the source stylesheet", () => {
     const css = fs.readFileSync(path.join(PROJECT_ROOT, "css", "main.css"), "utf8");
     assert.doesNotMatch(css, /\.lang-nav/);

--- a/test/test-generic-post.js
+++ b/test/test-generic-post.js
@@ -145,5 +145,19 @@ describe("representative post build output", () => {
     assert.equal(hreflangs.length, published.length + 2);
     allowed.forEach((lang) => assert.ok(hreflangs.includes(lang), `missing hreflang ${lang}`));
     hreflangs.forEach((lang) => assert.ok(allowed.includes(lang), `unexpected hreflang ${lang}`));
+
+    const banner = doc.querySelector("#lang-suggest");
+    assert.ok(banner, "Expected a language suggestion for a translated post");
+    assert.equal(banner.hidden, true, "Client-side language matching reveals the banner");
+    assert.equal(banner.getAttribute("aria-live"), "polite");
+    assert.ok(banner.querySelector(".lang-suggest__icon[aria-hidden='true']"));
+    assert.ok(banner.querySelector(".lang-suggest__content"));
+    assert.ok(banner.querySelector("button.lang-suggest__dismiss[aria-label]"));
+    const bannerStrings = JSON.parse(banner.getAttribute("data-strings"));
+    assert.deepEqual(bannerStrings.en, {
+      available: "This page is available in English",
+      read: "Read in English",
+      dismiss: "Dismiss",
+    });
   });
 });

--- a/test/test-locale-suggestion.js
+++ b/test/test-locale-suggestion.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+const clientSource = fs.readFileSync(
+  path.resolve(__dirname, "..", "src", "main.js"),
+  "utf8"
+);
+const bannerMarker = clientSource.indexOf("// ── Locale-suggestion banner");
+const tocMarker = clientSource.indexOf("// ── Table of contents", bannerMarker);
+const bannerScript = clientSource.slice(
+  clientSource.indexOf("(function ()", bannerMarker),
+  tocMarker
+);
+
+function renderBanner(languages, dismissed = false) {
+  const dom = new JSDOM(
+    `<!doctype html>
+    <html lang="zh-TW">
+      <head>
+        <link rel="alternate" hreflang="zh-TW" href="https://blog.errorbaker.tw/posts/tian/git-flow/">
+        <link rel="alternate" hreflang="x-default" href="https://blog.errorbaker.tw/posts/tian/git-flow/">
+        <link rel="alternate" hreflang="en" href="https://blog.errorbaker.tw/en/posts/tian/git-flow/">
+      </head>
+      <body>
+        <aside id="lang-suggest" hidden>
+          <div class="lang-suggest__content">
+            <span class="lang-suggest__text"></span>
+            <a class="lang-suggest__link" href="#"></a>
+          </div>
+          <button class="lang-suggest__dismiss" type="button" aria-label="關閉"></button>
+        </aside>
+      </body>
+    </html>`,
+    {
+      runScripts: "outside-only",
+      url: "https://blog.errorbaker.tw/posts/tian/git-flow/",
+    }
+  );
+  const { window } = dom;
+  Object.defineProperty(window.navigator, "languages", {
+    configurable: true,
+    value: languages,
+  });
+  window.document.getElementById("lang-suggest").setAttribute(
+    "data-strings",
+    JSON.stringify({
+      en: {
+        available: "This page is available in English",
+        read: "Read in English",
+        dismiss: "Dismiss",
+      },
+    })
+  );
+  if (dismissed) window.localStorage.setItem("langSuggestDismissed", "1");
+  window.eval(bannerScript);
+  return dom;
+}
+
+describe("locale suggestion client behavior", () => {
+  it("offers the best published language and localizes its controls", () => {
+    const dom = renderBanner(["en-US", "zh-TW"]);
+    const { document, localStorage } = dom.window;
+    const banner = document.getElementById("lang-suggest");
+    const link = banner.querySelector(".lang-suggest__link");
+    const dismiss = banner.querySelector(".lang-suggest__dismiss");
+
+    assert.equal(banner.hidden, false);
+    assert.equal(banner.lang, "en");
+    assert.equal(
+      banner.querySelector(".lang-suggest__text").textContent,
+      "This page is available in English"
+    );
+    assert.equal(link.textContent, "Read in English");
+    assert.equal(link.hreflang, "en");
+    assert.equal(link.lang, "en");
+    assert.equal(link.href, "https://blog.errorbaker.tw/en/posts/tian/git-flow/");
+    assert.equal(dismiss.getAttribute("aria-label"), "Dismiss");
+
+    dismiss.click();
+    assert.equal(banner.hidden, true);
+    assert.equal(localStorage.getItem("langSuggestDismissed"), "1");
+  });
+
+  it("stays hidden when the reader previously dismissed it", () => {
+    const dom = renderBanner(["en-US", "zh-TW"], true);
+    assert.equal(dom.window.document.getElementById("lang-suggest").hidden, true);
+  });
+
+  it("stays hidden when the current language is the reader's first choice", () => {
+    const dom = renderBanner(["zh-TW", "en-US"]);
+    assert.equal(dom.window.document.getElementById("lang-suggest").hidden, true);
+  });
+});


### PR DESCRIPTION
## 背景與動機

目前的語言建議 Banner 使用獨立的白底、灰字與固定色碼，沒有沿用網站既有的 paper / ink / accent 設計 token；在深色模式下也顯得與整體介面脫節。

此外，關閉按鈕會被全域 `button:not([disabled])` 規則覆蓋，變成醒目的紅色實心按鈕並產生位置偏移。窄螢幕上的 Banner 也可能和文章右下角的分享按鈕重疊。

本 PR 延續 #212 的「安靜編輯風」方向，重新整理 Banner 的視覺、響應式行為與無障礙資訊。

## 問題根因

- `.lang-suggest` 使用 `#fff`、`#333`、`#eee` 等硬編碼色彩，無法自然跟隨全站設計系統。
- 全域 `button:not([disabled])` selector 的 specificity 高於原本的 `.lang-suggest__dismiss`，覆蓋透明背景、文字色與圓角。
- 舊的全域 `button` margin 沒有被關閉按鈕 reset，造成 × 向上偏移。
- 單層 flex 排版配合不換行 CTA，對較長翻譯與窄螢幕不夠穩定。
- 提示文案雖然是目標語言，主句與在地化後的關閉標籤沒有完整標記目標 `lang`。

## 主要變更

### 1. Banner 視覺重新設計（`css/main.css`）

- 改用既有 `--paper-raised`、`--ink`、`--accent`、`--rule` 等設計 token，深淺主題自動對應。
- 改為精簡卡片式 grid 排版，加入 accent 左側線、語言圖示與清楚的文字層級。
- CTA 使用品牌色、底線與方向箭頭，補上 hover 與 keyboard focus 狀態。
- 桌面寬度限制為閱讀友善的卡片尺寸；保留 fixed positioning，顯示時不造成 layout shift。
- 支援 `safe-area-inset-bottom`，並在 377–660px 的文章頁將 Banner 移到分享按鈕上方。
- 480px 以下改用左右固定間距，避免內容或操作區超出 viewport。

### 2. 修正關閉按鈕樣式衝突

- 使用足以隔離舊全域按鈕規則的精準 selector，完整 reset background、margin、padding、border 與 shadow。
- 改為 44 × 44px 觸控區，搭配輕量 SVG X 圖示。
- 補上 hover 與 `:focus-visible` 狀態，維持鍵盤及觸控操作可用性。

### 3. 語意與在地化改善（`_includes/layouts/base.njk`、`.eleventy.js`、`src/main.js`）

- Banner 加入 `aria-live="polite"` 與 `aria-labelledby`，不會自動搶走焦點。
- 裝飾性語言圖示與關閉圖示標記為 `aria-hidden`。
- 將整個提示標記為實際建議語言，讓主句與關閉標籤使用正確的讀屏語音。
- 將 `suggestDismiss` 一併序列化，關閉按鈕的 `aria-label` 會跟隨建議語言在地化。
- 保留既有語言比對、hreflang 連結、無自動跳轉，以及 `localStorage.langSuggestDismissed` 關閉記錄。

### 4. 測試補強

- 新增 JSDOM 測試，涵蓋最佳語言選擇、目標語言與控制項在地化、關閉記錄，以及不應顯示的情境。
- 驗證建置後 HTML 保留預設 hidden、live region、圖示、內容容器與完整多語系字串。
- 驗證 PurgeCSS 後仍保留高 specificity 的關閉按鈕 reset，防止紅色按鈕樣式回歸。

## 使用者與開發者影響

- 使用者會看到與全站一致、層級更清楚的語言建議卡片。
- 深色模式不再依靠 Banner 專屬硬編碼色彩。
- 關閉按鈕恢復為低干擾控制，不再出現紅底與位置偏移。
- 手機及窄螢幕不會遮住文章分享操作。
- 讀屏器可用正確語言朗讀提示與關閉標籤。
- 語言版本產生、SEO / hreflang 與導頁規則沒有改變。

## 驗證

- `npm run build` 通過
- 76 個站台測試通過
- 40 個翻譯守門測試通過
- `git diff --check` 通過
- 本機 Eleventy + Rollup watch server 驗證完成

## 備註

- 本分支直接基於 main 建立。
- 本 PR 僅調整語言建議 Banner，不改變語言版本的產生、比對或 SEO 行為。
- #212 也修改 `base.njk`、`css/main.css`，並包含舊 Banner 的 `width: max-content` 修正；若 #212 先合併，rebase 時應以本 PR 的完整 `width: min(...)` grid 實作取代該單行修正。
- Banner 關閉後仍維持既有的同網域、跨頁面隱藏行為。
