### PR TITLE
fix: prevent incomplete multi-character sanitization in delHtmlTag

### DIFF
--- a/_11ty/summary.js
+++ b/_11ty/summary.js
@@ -1,7 +1,14 @@
 const tag = "<!-- summary -->"
 const hasSummary = content => content.split(tag).length === 3;
 const excerpt = (content) => content.split(tag)[1];
-const delHtmlTag = str => str.replace(/<[^>]+>/g,"");
+const delHtmlTag = str => {
+  let previous;
+  do {
+    previous = str;
+    str = str.replace(/<[^>]+>/g, "");
+  } while (str !== previous);
+  return str;
+};
 const contentInfo = content => {
     const htmlPart = excerpt(content.post)
     const startIndex = htmlPart.indexOf('<!--')


### PR DESCRIPTION
## Summary
Fixes CodeQL security alert #4: Incomplete multi-character sanitization (js/incomplete-multi-character-sanitization)

## Problem
The `delHtmlTag` function in `_11ty/summary.js` used a single-pass regex replacement to strip HTML tags. This could be bypassed with nested patterns like `<scr<script>>ipt>alert(1)` which would become `<script>alert(1)` after one pass.

## Solution
Apply the regex replacement repeatedly in a loop until the string stabilizes (no more changes occur). This ensures all HTML tags are completely removed, preventing the reintroduction of dangerous patterns.

## Changes
- Modified `delHtmlTag` function to use a do-while loop that continues replacing until no more changes occur
- This follows the CodeQL recommendation for fixing incomplete multi-character sanitization

## Security Impact
Prevents potential XSS attacks through nested HTML tag injection in summary excerpts.