### PR TITLE
fix: prevent incomplete multi-character sanitization (CodeQL alert #4)

### DIFF
--- a/_11ty/summary.js
+++ b/_11ty/summary.js
@@ -1,7 +1,14 @@
 const tag = "<!-- summary -->"
 const hasSummary = content => content.split(tag).length === 3;
 const excerpt = (content) => content.split(tag)[1];
-const delHtmlTag = str => str.replace(/<[^>]+>/g,"");
+const delHtmlTag = str => {
+  let previous;
+  do {
+    previous = str;
+    str = str.replace(/<[^>]+>/g, "");
+  } while (str !== previous);
+  return str;
+};
 const contentInfo = content => {
     const htmlPart = excerpt(content.post)
     const startIndex = htmlPart.indexOf('<!--')


### PR DESCRIPTION
## 問題

CodeQL code scanning alert #4: `js/incomplete-multi-character-sanitization`

`_11ty/summary.js` 中的 `delHtmlTag` 函式使用單一 regex 替換來移除 HTML tags：

```js
const delHtmlTag = str => str.replace(/<[^>]+>/g,"");
```

這種方式可能被嵌套的 HTML 標籤繞過。例如輸入：
```
<scr<script>>ipt>alert(1)
```

第一次替換會移除 `<script>`，結果變成：
```
<script>alert(1)
```

這是一個 HTML element injection 漏洞。

## 修復方式

使用 do-while 迴圈反覆執行 regex 替換，直到字串不再改變為止。這樣可以確保所有 HTML 標籤都被完全移除，不會因為替換後重新組合而產生新的標籤。

```js
const delHtmlTag = str => {
  let previous;
  do {
    previous = str;
    str = str.replace(/<[^>]+>/g, "");
  } while (str !== previous);
  return str;
};
```

這符合 CodeQL 建議的修復方式：「applying the regular expression replacement repeatedly until no more replacements can be performed」。

## 參考

- https://github.com/Lidemy/error-baker-blog/security/code-scanning/4
- CWE-20: Improper Input Validation
- CWE-80: Improper Neutralization of Script-Related HTML Sequences
