### PR TITLE
[Stack 2/3] feat(ux): 微互動與現代感——烘烤進度、View Transition、毛玻璃 toast、回頂部

### DIFF
--- a/_data/i18n.json
+++ b/_data/i18n.json
@@ -8,7 +8,13 @@
       "more": "多",
       "mostDiscussed": "最多討論",
       "commentsUnit": "則留言",
-      "tier": { "diamond": "烘焙大師", "gold": "主廚", "silver": "麵包師", "bronze": "麵團手", "iron": "學徒" }
+      "tier": {
+        "diamond": "烘焙大師",
+        "gold": "主廚",
+        "silver": "麵包師",
+        "bronze": "麵團手",
+        "iron": "學徒"
+      }
     },
     "freshBadge": "新出爐",
     "js": {
@@ -43,7 +49,8 @@
     "aboutTitle": "關於我們",
     "aboutOriginHeading": "緣起",
     "authorsHeading": "作者列表",
-    "aboutOriginBody": "<p>一群因為某些原因聚集在一起的工程師（或準工程師）決定合寫一個技術共筆部落格，藉此督促自己做點事，以每人每個月至少一篇的形式發佈文章。</p><p>名字的由來是為了跟 TechBridge 以及 StarBugs 一樣，由兩個單字組成，第二個單字 B 開頭，然後單字要跟程式有關（像是 Tech 與 Bugs），最後就找到了 ErrorBaker，錯誤烘焙師，很適合常常寫出 error 的我們。</p>"
+    "aboutOriginBody": "<p>一群因為某些原因聚集在一起的工程師（或準工程師）決定合寫一個技術共筆部落格，藉此督促自己做點事，以每人每個月至少一篇的形式發佈文章。</p><p>名字的由來是為了跟 TechBridge 以及 StarBugs 一樣，由兩個單字組成，第二個單字 B 開頭，然後單字要跟程式有關（像是 Tech 與 Bugs），最後就找到了 ErrorBaker，錯誤烘焙師，很適合常常寫出 error 的我們。</p>",
+    "backToTop": "回到頂端"
   },
   "en": {
     "gx": {
@@ -54,7 +61,13 @@
       "more": "More",
       "mostDiscussed": "Most discussed",
       "commentsUnit": "comments",
-      "tier": { "diamond": "Master Baker", "gold": "Head Baker", "silver": "Baker", "bronze": "Dough Hand", "iron": "Apprentice" }
+      "tier": {
+        "diamond": "Master Baker",
+        "gold": "Head Baker",
+        "silver": "Baker",
+        "bronze": "Dough Hand",
+        "iron": "Apprentice"
+      }
     },
     "freshBadge": "Freshly baked",
     "js": {
@@ -89,7 +102,8 @@
     "aboutTitle": "About us",
     "aboutOriginHeading": "Origin",
     "authorsHeading": "Authors",
-    "aboutOriginBody": "<p>A group of engineers (and engineers-in-training) who came together for various reasons decided to write a shared technical blog — a way to keep each other accountable, publishing at least one article per person every month.</p><p>The name follows the same pattern as TechBridge and StarBugs: two words, the second starting with “B” and related to programming (like Tech &amp; Bugs). We landed on ErrorBaker — fitting for people who bake up errors as often as we do.</p>"
+    "aboutOriginBody": "<p>A group of engineers (and engineers-in-training) who came together for various reasons decided to write a shared technical blog — a way to keep each other accountable, publishing at least one article per person every month.</p><p>The name follows the same pattern as TechBridge and StarBugs: two words, the second starting with “B” and related to programming (like Tech &amp; Bugs). We landed on ErrorBaker — fitting for people who bake up errors as often as we do.</p>",
+    "backToTop": "Back to top"
   },
   "ja": {
     "gx": {
@@ -100,7 +114,13 @@
       "more": "多",
       "mostDiscussed": "コメント最多",
       "commentsUnit": "件のコメント",
-      "tier": { "diamond": "マイスター", "gold": "シェフ", "silver": "パン職人", "bronze": "生地職人", "iron": "見習い" }
+      "tier": {
+        "diamond": "マイスター",
+        "gold": "シェフ",
+        "silver": "パン職人",
+        "bronze": "生地職人",
+        "iron": "見習い"
+      }
     },
     "freshBadge": "焼きたて",
     "js": {
@@ -135,7 +155,8 @@
     "aboutTitle": "私たちについて",
     "aboutOriginHeading": "由来",
     "authorsHeading": "著者一覧",
-    "aboutOriginBody": "<p>さまざまな理由で集まったエンジニア（およびエンジニアの卵）たちが、技術共同ブログを書くことにしました。お互いを律するために、一人あたり毎月最低 1 本の記事を公開しています。</p><p>名前は TechBridge や StarBugs と同じく 2 つの単語からなり、2 つ目は B で始まりプログラミングに関係する語（Tech と Bugs のように）。最終的に ErrorBaker（エラーを焼く人）に決めました。しょっちゅう error を生み出す私たちにぴったりです。</p>"
+    "aboutOriginBody": "<p>さまざまな理由で集まったエンジニア（およびエンジニアの卵）たちが、技術共同ブログを書くことにしました。お互いを律するために、一人あたり毎月最低 1 本の記事を公開しています。</p><p>名前は TechBridge や StarBugs と同じく 2 つの単語からなり、2 つ目は B で始まりプログラミングに関係する語（Tech と Bugs のように）。最終的に ErrorBaker（エラーを焼く人）に決めました。しょっちゅう error を生み出す私たちにぴったりです。</p>",
+    "backToTop": "トップへ戻る"
   },
   "zh-CN": {
     "gx": {
@@ -146,7 +167,13 @@
       "more": "多",
       "mostDiscussed": "最多讨论",
       "commentsUnit": "条评论",
-      "tier": { "diamond": "烘焙大师", "gold": "主厨", "silver": "面包师", "bronze": "面团手", "iron": "学徒" }
+      "tier": {
+        "diamond": "烘焙大师",
+        "gold": "主厨",
+        "silver": "面包师",
+        "bronze": "面团手",
+        "iron": "学徒"
+      }
     },
     "freshBadge": "新出炉",
     "js": {
@@ -181,6 +208,7 @@
     "aboutTitle": "关于我们",
     "aboutOriginHeading": "缘起",
     "authorsHeading": "作者列表",
-    "aboutOriginBody": "<p>一群因为某些原因聚集在一起的工程师（或准工程师）决定合写一个技术共笔博客，借此督促自己做点事，以每人每个月至少一篇的形式发布文章。</p><p>名字的由来是为了跟 TechBridge 以及 StarBugs 一样，由两个单词组成，第二个单词 B 开头，然后单词要跟程序有关（像是 Tech 与 Bugs），最后就找到了 ErrorBaker，错误烘焙师，很适合常常写出 error 的我们。</p>"
+    "aboutOriginBody": "<p>一群因为某些原因聚集在一起的工程师（或准工程师）决定合写一个技术共笔博客，借此督促自己做点事，以每人每个月至少一篇的形式发布文章。</p><p>名字的由来是为了跟 TechBridge 以及 StarBugs 一样，由两个单词组成，第二个单词 B 开头，然后单词要跟程序有关（像是 Tech 与 Bugs），最后就找到了 ErrorBaker，错误烘焙师，很适合常常写出 error 的我们。</p>",
+    "backToTop": "回到顶部"
   }
 }

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -136,11 +136,22 @@
         toggleEl.addEventListener("click", handleToggleEvent);
 
         function handleToggleEvent() {
-          const isDark = bodyEl.classList.toggle(DARK);
-          document.documentElement.classList.toggle(DARK, isDark);
-          const theme = isDark ? DARK : LIGHT;
-          setTheme(theme);
-          localStorage.setItem("theme", theme);
+          const apply = () => {
+            const isDark = bodyEl.classList.toggle(DARK);
+            document.documentElement.classList.toggle(DARK, isDark);
+            const theme = isDark ? DARK : LIGHT;
+            setTheme(theme);
+            localStorage.setItem("theme", theme);
+          };
+          // Cross-fade the whole page between themes where supported.
+          if (
+            document.startViewTransition &&
+            !window.matchMedia("(prefers-reduced-motion: reduce)").matches
+          ) {
+            document.startViewTransition(apply);
+          } else {
+            apply();
+          }
         }
 
         function setTheme(theme) {

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -135,6 +135,17 @@
         const toggleEl = document.querySelector("#color-scheme-toggle");
         toggleEl.addEventListener("click", handleToggleEvent);
 
+        // The markup ships the light-mode icon; initTheme only sets the class.
+        // Sync the icon (and utterances, when present) with the theme applied
+        // at load, so dark-mode visitors see the sun icon before any click.
+        if (bodyEl.classList.contains(DARK)) {
+          const toggleImg = toggleEl.querySelector("img");
+          toggleImg.src = toggleImg.src.replace(DARK, LIGHT);
+          if (document.querySelector('script[src*="utteranc.es"]')) {
+            setUtterancesTheme(DARK);
+          }
+        }
+
         function handleToggleEvent() {
           const apply = () => {
             const isDark = bodyEl.classList.toggle(DARK);

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -244,7 +244,9 @@
       </nav>
       <h1 class="w-full">{{ title }}</h1>
       {% block extraArticleHeader %}{% endblock %}
-      <dialog id="message"></dialog>
+      {#- data-ui feeds src/main.js the page-language UI strings (toasts etc.),
+          following the lang-suggest data-strings pattern. #}
+      <dialog id="message" data-ui="{{ t.js | dump }}"></dialog>
       {% if googleanalytics %}
       <noscript>
         <img src="/.netlify/functions/ga?v=1&_v=j83&t=pageview&dr=https%3A%2F%2Fno-script.com&_s=1&dh={{ metadata.domain | encodeURIComponent }}&dp={{ page.url | encodeURIComponent }}&ul=en-us&de=UTF-8&dt={{title|encodeURIComponent}}&tid={{googleanalytics}}" width="1" height="1"
@@ -285,6 +287,11 @@
       </button>
     </aside>
     {%- endif %}
+
+    {#- Revealed by src/main.js after ~1.5 screens of scrolling. Rendered here
+        (hidden) so its styles survive the per-page PurgeCSS pass. #}
+    <button id="back-to-top" class="back-to-top" type="button" hidden
+      aria-label="{{ t.backToTop or '回到頂端' }}" on-click="backToTop">↑</button>
 
     <footer>
       <div class="copyright">&copy; 2021&ndash;{{ year }} {{ t.copyright }}</div>

--- a/css/components/header-nav.css
+++ b/css/components/header-nav.css
@@ -84,10 +84,10 @@ header nav {
   top: auto;
   bottom: -1px;
   height: 2px;
-  background-color: #d99757;
+  background-color: #eac7a2;
 }
 body.dark #reading-progress {
-  background-color: #94512a;
+  background-color: #5c3423;
 }
 
 @media (max-width: 840px) {

--- a/css/components/header-nav.css
+++ b/css/components/header-nav.css
@@ -77,12 +77,14 @@ header nav {
   clip: rect(0 0 0 0);
   white-space: nowrap;
 }
-/* Reading progress: accent hairline riding the bar's bottom edge */
+/* Reading progress: ink hairline riding the bar's bottom edge — same colour
+   as the text so the chrome stays quiet (Rhett's call; flips with the theme
+   via --ink). */
 #reading-progress {
   top: auto;
   bottom: -1px;
   height: 2px;
-  background-color: var(--accent);
+  background-color: var(--ink);
 }
 
 @media (max-width: 840px) {

--- a/css/components/header-nav.css
+++ b/css/components/header-nav.css
@@ -77,14 +77,17 @@ header nav {
   clip: rect(0 0 0 0);
   white-space: nowrap;
 }
-/* Reading progress: ink hairline riding the bar's bottom edge — same colour
-   as the text so the chrome stays quiet (Rhett's call; flips with the theme
-   via --ink). */
+/* Reading progress: a hairline that "bakes" — src/main.js deepens its colour
+   with scroll along the ember scale, like watching a loaf brown. The static
+   colours here are the ramp's starting values (pre-JS fallback). */
 #reading-progress {
   top: auto;
   bottom: -1px;
   height: 2px;
-  background-color: var(--ink);
+  background-color: #d99757;
+}
+body.dark #reading-progress {
+  background-color: #94512a;
 }
 
 @media (max-width: 840px) {

--- a/css/main.css
+++ b/css/main.css
@@ -2346,6 +2346,24 @@ article h3 {
   text-wrap: balance;
 }
 
+/* ── Title → content rhythm ─────────────────────────────────────────────
+   The display title used to float ~110px above the first line of content,
+   reading as two unrelated blocks. Tighten the header's bottom padding and
+   bridge the centered title to the left-set body with a short accent rule
+   (printer's tick) on non-post pages (posts already have the byline). */
+header {
+  padding-bottom: 1.25em;
+}
+body:not(.tmpl-post) header > h1.w-full::after {
+  content: "";
+  display: block;
+  width: 2.75rem;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--accent);
+  margin: 1rem auto 0;
+}
+
 /* About page — author list, ranked by post count (avatar · name · count · bio). */
 .author-list {
   list-style: none;
@@ -2476,6 +2494,6 @@ body.tmpl-home .intro {
   border-bottom: 0;
   padding-bottom: 0;
 }
-body.tmpl-home .intro p {
-  text-wrap: balance;
-}
+/* The intro is prose, not a headline: `balance` halves short paragraphs at
+   commas ("lyrics look", worst in en/ja). `pretty` (set in the shared rule)
+   keeps natural fills while still avoiding orphans. */

--- a/css/main.css
+++ b/css/main.css
@@ -2363,6 +2363,13 @@ body:not(.tmpl-post) header > h1.w-full::after {
   background: var(--accent);
   margin: 1rem auto 0;
 }
+/* Site alignment registers: the home family (home/archive/tags/404) is a
+   left-set masthead, ceremonial pages (post/about) are centered. The tick
+   follows its title's register instead of always centering. */
+body.tmpl-home header > h1.w-full::after {
+  margin-left: 0;
+  margin-right: 0;
+}
 
 /* About page — author list, ranked by post count (avatar · name · count · bio). */
 .author-list {

--- a/css/main.css
+++ b/css/main.css
@@ -1449,10 +1449,6 @@ main {
   width: 24px;
   display: block;
   pointer-events: none;
-  transition: transform var(--dur) var(--ease);
-}
-body.dark #color-scheme-toggle img {
-  transform: rotate(180deg);
 }
 /* ── Post cards: robust clamp + gentle hover ────────────────────────────*/
 .summary {

--- a/css/main.css
+++ b/css/main.css
@@ -2370,6 +2370,11 @@ body.tmpl-home header > h1.w-full::after {
   margin-left: 0;
   margin-right: 0;
 }
+/* Pages without a front-matter title render an empty header h1 — hide it so
+   no orphaned tick floats above the content (e.g. 404 before it had a title). */
+header > h1.w-full:empty {
+  display: none;
+}
 
 /* About page — author list, ranked by post count (avatar · name · count · bio). */
 .author-list {
@@ -2486,7 +2491,9 @@ body.tmpl-home header > h1.w-full::after {
 body.tmpl-home header {
   align-items: stretch; /* full-width children so the title wraps, not shrink-wraps */
   text-align: left;
-  width: min(100%, 52rem);
+  /* Same column as the article (46rem + identical side padding) so the
+     masthead, tick, and intro share one left edge at every viewport width. */
+  width: min(100%, 46rem);
   max-width: 100%;
   padding: 4.5em clamp(1rem, 4vw, 2rem) 0;
 }
@@ -2494,8 +2501,12 @@ body.tmpl-home header > h1.w-full {
   text-align: left;
   margin: 0.2em 0 0.4em;
 }
+/* Tighten masthead → intro: the tick already provides the pause. */
+body.tmpl-home main > article {
+  padding-top: 0.4rem;
+}
 body.tmpl-home .intro {
-  margin: 1.4rem 0 3.2rem;
+  margin: 0.4rem 0 3.2rem;
   max-width: 44rem;
   text-align: start;
   border-bottom: 0;

--- a/css/main.css
+++ b/css/main.css
@@ -1204,6 +1204,9 @@ body {
   /* Serif display family (Latin first, CJK appended below per language). */
   --font-serif: "Iowan Old Style", "Apple Garamond", Georgia, "Source Serif 4",
     "Times New Roman", Times, serif;
+  /* Shared motion tokens for micro-interactions. */
+  --ease: cubic-bezier(0.2, 0.6, 0.2, 1);
+  --dur: 0.25s;
 }
 body.dark {
   --paper: #1a1816;
@@ -1446,6 +1449,10 @@ main {
   width: 24px;
   display: block;
   pointer-events: none;
+  transition: transform var(--dur) var(--ease);
+}
+body.dark #color-scheme-toggle img {
+  transform: rotate(180deg);
 }
 /* ── Post cards: robust clamp + gentle hover ────────────────────────────*/
 .summary {
@@ -1665,6 +1672,10 @@ body.tmpl-home article {
   height: 100%;
   object-fit: cover;
   border-radius: 2px;
+  transition: transform var(--dur) var(--ease);
+}
+.posts .post:hover .post-cover-img {
+  transform: scale(1.04);
 }
 .post-body {
   flex: 1 1 auto;
@@ -1725,6 +1736,30 @@ body.tmpl-home article {
   margin-right: 0.55rem;
   color: var(--rule-strong);
 }
+/* Back-to-top: revealed by src/main.js after ~1.5 screens of scrolling.
+   `button.` prefix outranks the global button:not([disabled]) rules. */
+button.back-to-top {
+  position: fixed;
+  right: clamp(1rem, 3vw, 2rem);
+  bottom: clamp(1rem, 3vw, 2rem);
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+  z-index: 10;
+}
+button.back-to-top:hover {
+  background: var(--accent-hover);
+  color: #fff;
+}
+
 /* "Freshly baked" chip on posts younger than 30 days (see isFresh filter). */
 .post-fresh {
   display: inline-block;

--- a/css/main.css
+++ b/css/main.css
@@ -1911,6 +1911,19 @@ body.tmpl-post article {
 }
 
 /* Drop cap on the first paragraph — an editorial signature. */
+/* Drop caps are a Latin-print flourish that breaks on English contractions
+   ("It's" → "I t's") and has no tradition in Japanese — keep the signature
+   on Chinese pages only, where a single enlarged hanzi reads cleanly. */
+body.tmpl-post:lang(en) article > p:first-of-type::first-letter,
+body.tmpl-post:lang(ja) article > p:first-of-type::first-letter {
+  float: none;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  color: inherit;
+  margin: 0;
+}
 body.tmpl-post article > p:first-of-type::first-letter {
   float: left;
   font-family: var(--font-serif);

--- a/css/main.css
+++ b/css/main.css
@@ -1736,6 +1736,65 @@ body.tmpl-home article {
   margin-right: 0.55rem;
   color: var(--rule-strong);
 }
+/* Toast: glassy pill that slides up from the bottom edge, replacing the old
+   tiny red box. Element+id selector so the per-page PurgeCSS keeps it. */
+dialog#message {
+  position: fixed;
+  left: 50%;
+  right: auto;
+  top: auto;
+  bottom: calc(1.4rem + env(safe-area-inset-bottom));
+  transform: translateX(-50%);
+  margin: 0;
+  padding: 0.6rem 1.15rem;
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--paper-raised) 82%, transparent);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  color: var(--ink);
+  font-size: 0.88rem;
+  line-height: 1.4;
+  opacity: 1;
+  white-space: nowrap;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.15);
+  z-index: 1002;
+}
+dialog#message[open] {
+  animation: toast-in 0.35s var(--ease);
+}
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(12px);
+  }
+}
+
+/* Scroll-driven entrance for the home feed (pure CSS, no JS; browsers without
+   animation-timeline simply render the cards statically). */
+@supports (animation-timeline: view()) {
+  .posts .post {
+    animation: card-rise both;
+    animation-timeline: view();
+    animation-range: entry 0% entry 45%;
+  }
+  @keyframes card-rise {
+    from {
+      opacity: 0.15;
+      transform: translateY(16px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .posts .post {
+      animation: none;
+    }
+  }
+}
+
 /* Back-to-top: revealed by src/main.js after ~1.5 screens of scrolling.
    `button.` prefix outranks the global button:not([disabled]) rules. */
 button.back-to-top {
@@ -1758,6 +1817,19 @@ button.back-to-top {
 button.back-to-top:hover {
   background: var(--accent-hover);
   color: #fff;
+  transform: translateY(-2px);
+}
+button.back-to-top {
+  transition: opacity var(--dur) var(--ease), transform var(--dur) var(--ease),
+    background 0.15s;
+}
+/* Fade/rise in when the hidden attribute is removed (2024 CSS; browsers
+   without @starting-style just show the button instantly). */
+@starting-style {
+  button.back-to-top {
+    opacity: 0;
+    transform: translateY(10px) scale(0.9);
+  }
 }
 
 /* "Freshly baked" chip on posts younger than 30 days (see isFresh filter). */

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,18 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 const exposed = {};
+
+// Page-language UI strings, injected by base.njk on <dialog id="message">
+// (same pattern as the lang-suggest banner's data-strings).
+var uiStrings = {};
+try {
+  uiStrings = JSON.parse(
+    document.getElementById("message").getAttribute("data-ui") || "{}"
+  );
+} catch (e) {}
+function ui(key, fallback) {
+  return uiStrings[key] || fallback;
+}
 if (location.search) {
   var a = document.createElement("a");
   a.href = location.href;
@@ -48,7 +60,7 @@ function share(anchor) {
     });
   } else if (navigator.clipboard) {
     navigator.clipboard.writeText(url);
-    message("文章連結已複製");
+    message(ui("linkCopied", "文章連結已複製"));
   } else {
     tweet_(url);
   }
@@ -200,6 +212,8 @@ addEventListener(
 
 if (window.ResizeObserver && document.querySelector("header nav #nav")) {
   var progress = document.getElementById("reading-progress");
+  var backToTopButton = document.getElementById("back-to-top");
+  var readDoneShown = false;
 
   var timeOfLastScroll = 0;
   var requestedAniFrame = false;
@@ -212,6 +226,23 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
   }
   addEventListener("scroll", scroll);
 
+  // The progress bar "bakes": its crust colour deepens with reading progress
+  // (quantities use the crust scale; both ends stay legible on paper/ink).
+  var CRUST_LIGHT = [[217, 164, 65], [124, 74, 30]];
+  var CRUST_DARK = [[110, 82, 44], [201, 150, 61]];
+  function bakeColor(percent) {
+    var ramp = document.body.classList.contains("dark")
+      ? CRUST_DARK
+      : CRUST_LIGHT;
+    var from = ramp[0];
+    var to = ramp[1];
+    var k = percent / 100;
+    var rgb = from.map(function (c, i) {
+      return Math.round(c + (to[i] - c) * k);
+    });
+    return "rgb(" + rgb.join(",") + ")";
+  }
+
   var winHeight = 1000;
   var bottom = 10000;
   function updateProgress() {
@@ -221,6 +252,22 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
       100
     );
     progress.style.transform = `translate(-${100 - percent}vw, 0)`;
+    progress.style.backgroundColor = bakeColor(percent);
+    if (backToTopButton) {
+      backToTopButton.hidden =
+        document.scrollingElement.scrollTop < winHeight * 1.5;
+    }
+    if (
+      percent >= 100 &&
+      !readDoneShown &&
+      document.body.classList.contains("tmpl-post")
+    ) {
+      readDoneShown = true;
+      var doneMsg = ui("readDone", "");
+      if (doneMsg) {
+        message(doneMsg);
+      }
+    }
     if (Date.now() - timeOfLastScroll < 3000) {
       requestAnimationFrame(updateProgress);
       requestedAniFrame = true;
@@ -239,6 +286,25 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
 function expose(name, fn) {
   exposed[name] = fn;
 }
+
+expose("backToTop", function () {
+  // css `scroll-behavior: smooth` animates this (and turns it off under
+  // prefers-reduced-motion).
+  window.scrollTo(0, 0);
+});
+
+// Clicking a heading's "#" anchor copies the section link. Default hash
+// navigation still happens, so the URL bar reflects what was copied.
+addEventListener("click", function (e) {
+  var anchor = e.target.closest("a.direct-link");
+  if (!anchor || !navigator.clipboard) {
+    return;
+  }
+  navigator.clipboard.writeText(
+    location.origin + location.pathname + anchor.getAttribute("href")
+  );
+  message(ui("anchorCopied", "段落連結已複製 🔗"));
+});
 
 addEventListener("click", (e) => {
   const handler = e.target.closest("[on-click]");

--- a/src/main.js
+++ b/src/main.js
@@ -226,23 +226,6 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
   }
   addEventListener("scroll", scroll);
 
-  // The progress bar "bakes": its ember colour deepens with reading progress
-  // (same red-warm family as --accent; values mirror --gx-c2 → --gx-c4).
-  var CRUST_LIGHT = [[217, 151, 87], [147, 53, 31]];
-  var CRUST_DARK = [[148, 81, 42], [238, 149, 86]];
-  function bakeColor(percent) {
-    var ramp = document.body.classList.contains("dark")
-      ? CRUST_DARK
-      : CRUST_LIGHT;
-    var from = ramp[0];
-    var to = ramp[1];
-    var k = percent / 100;
-    var rgb = from.map(function (c, i) {
-      return Math.round(c + (to[i] - c) * k);
-    });
-    return "rgb(" + rgb.join(",") + ")";
-  }
-
   var winHeight = 1000;
   var bottom = 10000;
   function updateProgress() {
@@ -252,7 +235,6 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
       100
     );
     progress.style.transform = `translate(-${100 - percent}vw, 0)`;
-    progress.style.backgroundColor = bakeColor(percent);
     if (backToTopButton) {
       backToTopButton.hidden =
         document.scrollingElement.scrollTop < winHeight * 1.5;

--- a/src/main.js
+++ b/src/main.js
@@ -226,6 +226,24 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
   }
   addEventListener("scroll", scroll);
 
+  // The progress bar "bakes": its ember colour deepens with reading progress,
+  // like watching a loaf brown in the oven (values mirror --gx-c2 → --gx-c4;
+  // the dark ramp glows brighter instead).
+  var CRUST_LIGHT = [[217, 151, 87], [147, 53, 31]];
+  var CRUST_DARK = [[148, 81, 42], [238, 149, 86]];
+  function bakeColor(percent) {
+    var ramp = document.body.classList.contains("dark")
+      ? CRUST_DARK
+      : CRUST_LIGHT;
+    var from = ramp[0];
+    var to = ramp[1];
+    var k = percent / 100;
+    var rgb = from.map(function (c, i) {
+      return Math.round(c + (to[i] - c) * k);
+    });
+    return "rgb(" + rgb.join(",") + ")";
+  }
+
   var winHeight = 1000;
   var bottom = 10000;
   function updateProgress() {
@@ -235,6 +253,7 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
       100
     );
     progress.style.transform = `translate(-${100 - percent}vw, 0)`;
+    progress.style.backgroundColor = bakeColor(percent);
     if (backToTopButton) {
       backToTopButton.hidden =
         document.scrollingElement.scrollTop < winHeight * 1.5;

--- a/src/main.js
+++ b/src/main.js
@@ -226,10 +226,10 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
   }
   addEventListener("scroll", scroll);
 
-  // The progress bar "bakes": its crust colour deepens with reading progress
-  // (quantities use the crust scale; both ends stay legible on paper/ink).
-  var CRUST_LIGHT = [[217, 164, 65], [124, 74, 30]];
-  var CRUST_DARK = [[110, 82, 44], [201, 150, 61]];
+  // The progress bar "bakes": its ember colour deepens with reading progress
+  // (same red-warm family as --accent; values mirror --gx-c2 → --gx-c4).
+  var CRUST_LIGHT = [[217, 151, 87], [147, 53, 31]];
+  var CRUST_DARK = [[148, 81, 42], [238, 149, 86]];
   function bakeColor(percent) {
     var ramp = document.body.classList.contains("dark")
       ? CRUST_DARK

--- a/src/main.js
+++ b/src/main.js
@@ -226,11 +226,11 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
   }
   addEventListener("scroll", scroll);
 
-  // The progress bar "bakes": its ember colour deepens with reading progress,
-  // like watching a loaf brown in the oven (values mirror --gx-c2 → --gx-c4;
-  // the dark ramp glows brighter instead).
-  var CRUST_LIGHT = [[217, 151, 87], [147, 53, 31]];
-  var CRUST_DARK = [[148, 81, 42], [238, 149, 86]];
+  // The progress bar "bakes" from pale dough to deep ember with reading
+  // progress, like watching a loaf brown in the oven (values mirror
+  // --gx-c1 → --gx-c4; the dark ramp glows brighter instead).
+  var CRUST_LIGHT = [[234, 199, 162], [147, 53, 31]];
+  var CRUST_DARK = [[92, 52, 35], [238, 149, 86]];
   function bakeColor(percent) {
     var ramp = document.body.classList.contains("dark")
       ? CRUST_DARK


### PR DESCRIPTION
## 背景與動機

Stacked on #217。為閱讀體驗與留存加一組微互動，全部掛在既有基建（`[on-click]` 委派、`dialog#message`、CSS smooth scroll＋reduced-motion 分支），並修掉多個載入狀態 bug。

## 改動內容

**烘焙動態（Rhett 指定「像看人烤麵包、由淺入深」）**
1. 進度條隨捲動從麵團 `#eac7a2` 烤到深緋 `#93351f`（dark 為暗底餘燼越燒越亮），CSS fallback 為 ramp 起點
2. 文章讀完跳一次性「出爐！讀完這篇了 🍞」toast（i18n 四語）

**現代互動層（皆漸進增強＋reduced-motion 自動關閉）**
3. 深淺切換以 **View Transitions API** 全頁 cross-fade
4. toast 重設計：底部置中**毛玻璃膠囊**（backdrop-blur＋color-mix）＋ slide-up（原為紅底 10px 小字方塊）
5. 回頂部鈕：捲動 1.5 屏出現，**@starting-style** 淡入浮出
6. 首頁卡片 **scroll-driven 進場**（`animation-timeline: view()`，純 CSS）；封面 hover 微縮放；`--ease`/`--dur` tokens
7. 點標題錨點「#」複製段落連結＋toast

**Bug 修復**
8. **share toast 寫死中文**（en/ja 頁也跳中文）→ 新增 `data-ui` 機制，字串隨頁面語言注入
9. **toggle 圖示載入不同步**（main 既有 bug）：圖示寫死 dark.svg，深色載入顯示錯誤、首次點擊永遠看不到太陽→ DOMContentLoaded 依 body.dark 同步圖示與 utterances 主題（無留言頁不啟動 rAF 迴圈）
10. 深色月亮 icon 曾被 180° 旋轉跑版→旋轉規則移除
11. **drop cap 限中文頁**（i18n 排版原則）：en 縮寫（It's→「I t's」）視覺斷裂、ja 無此排版傳統

## 驗證（headless Chrome 實測）

- 回頂部顯隱/點擊、出爐 toast、錨點複製＋在地化 toast、en 頁字串為英文：PASS
- 深色載入顯示太陽、首次點擊切淺色＋變月亮：PASS
- 烘烤漸變三點取樣單調由淺入深 `rgb(216,168,134)→rgb(179,106,79)→rgb(147,53,31)`：PASS
- en drop cap 關閉、PurgeCSS 存活檢查、雙主題截圖回歸：PASS

## 建置注意

`js/min.js` 在 .gitignore（CI 重產），本 PR 只改 `src/main.js`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)