### PR TITLE
fix(test): raise utterances suite timeout to stop CI flake

### DIFF
--- a/test/test-comment-threads.js
+++ b/test/test-comment-threads.js
@@ -71,7 +71,12 @@ describe("commentThreads.json (legacy thread map)", () => {
   });
 });
 
-describe("utterances embed binding", () => {
+describe("utterances embed binding", function () {
+  // These scans build a JSDOM for every emitted page that embeds utterances,
+  // so they scale with the number of posts. The 2s mocha default is too tight
+  // under CI load and flakes intermittently (e.g. same commit passing on push
+  // but timing out on pull_request) — give the suite real headroom.
+  this.timeout(15000);
   it("pins every legacy-mapped post to its issue number", () => {
     for (const [key, number] of Object.entries(THREADS)) {
       const embed = embedFor(key);


### PR DESCRIPTION
## Problem
`Build and test` flakes on `pull_request` with a timeout in `test-comment-threads.js`:

```
1) utterances embed binding
     keys every embed by a source path, never by the page title:
   Error: Timeout of 2000ms exceeded.
```

The test is **synchronous** (no `done()`/Promise), so the 2000ms "timeout" just means it runs slow — it isn't stuck.

## Root cause
`utterancesPages()` builds a full JSDOM (incl. CSS parsing) for **every emitted page that embeds utterances**, so the scan scales with the number of posts (~**992ms** locally). The 2s mocha default is too tight under CI load.

Evidence it's flaky and content-independent: the **same commit passed on `push` but timed out on `pull_request`**, and the change touches no template/post logic.

## Fix
Give the whole `utterances embed binding` suite 15s of headroom (inner `it`s inherit it):

```diff
-describe("utterances embed binding", () => {
+describe("utterances embed binding", function () {
+  // These scans build a JSDOM for every emitted page that embeds utterances,
+  // so they scale with the number of posts. The 2s mocha default is too tight
+  // under CI load and flakes intermittently — give the suite real headroom.
+  this.timeout(15000);
```

## Verification
- Full site suite: **87 passing** locally.
- The slow test still runs in ~1s; 15s gives ~15x headroom for CI variance.
