### PR TITLE
ci: add opencode github agent workflow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,31 @@
+name: opencode-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode-go/qwen3.7-plus
+          prompt: |
+            Review this pull request.
+            - If it touches posts/, verify frontmatter and translation fields comply with AGENTS.md.
+            - Check markdown structure, internal links, and image paths.
+            - Flag concrete issues; keep the review concise.

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+        with:
+          model: opencode-go/qwen3.7-plus

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,25 @@ export
 .vscode/
 .idea/
 
-# Local AI tooling
+# Local AI tooling (caches / sessions / history)
+# NOTE: .agents/ stays tracked (project-shared skills/commands)
+# Shared rules files also stay tracked: .cursorrules, .windsurfrules, CLAUDE.md, AGENTS.md, .github/copilot-instructions.md
 .claude/
 .zcode/
+.opencode/
+.cursor/
+.windsurf/
+.codeium/
+.continue/
+.cody/
+.supermaven/
+.tabnine/
+.copilot/
+.gemini/
+.kiro/
+.qwen/
+.roo/
+.cline/
+.zed/
+.idx/
+.aider*

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,20 @@
-_site/
+# Dependencies
 node_modules/
-.DS_Store
+
+# Build output
+_site/
 js/min.js
 js/min.js.map
+export
+
+# Deploy
+.netlify/
+
+# OS / editor
+.DS_Store
 .vscode/
 .idea/
-.netlify/
-export
+
+# Local AI tooling
 .claude/
+.zcode/


### PR DESCRIPTION
Adds `.github/workflows/opencode.yml` generated by `opencode github install`.

- Provider: OpenCode Go (`opencode-go/qwen3.7-plus`)
- Trigger: `/oc` / `/opencode` comments on issues & PRs (and review line comments)
- Permissions: read-only (`id-token: write`); writes go through the OpenCode GitHub App token

**Before merge (manual):**
- [x] Add repo/org secret `OPENCODE_API_KEY` (Settings → Secrets and variables → Actions)
- [x] Confirm the OpenCode GitHub App is installed on `Lidemy/error-baker-blog`

**After merge, test with:** comment `/oc summarize` on any issue.

Ref: https://opencode.ai/docs/github/