### PR TITLE
feat(i18n): unify post dates across languages to the original work's date

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -64,7 +64,6 @@ const {
   effectivePublishedDate,
   effectiveModifiedDate,
   postPublishedDate,
-  sortByPublishedDate,
 } = require("./_11ty/publication-dates");
 const {
   feedPublishedDate,
@@ -177,7 +176,6 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("effectivePublishedDate", effectivePublishedDate);
   eleventyConfig.addFilter("effectiveModifiedDate", effectiveModifiedDate);
   eleventyConfig.addFilter("postPublishedDate", postPublishedDate);
-  eleventyConfig.addFilter("sortByPublishedDate", sortByPublishedDate);
   eleventyConfig.addFilter("feedPublishedDate", feedPublishedDate);
   eleventyConfig.addFilter("feedModifiedDate", feedModifiedDate);
   eleventyConfig.addFilter("sortFeedPosts", sortFeedPosts);
@@ -445,14 +443,12 @@ module.exports = function (eleventyConfig) {
   });
 
   // zh-TW-only posts — the source language listing (homepage, archive, feeds).
+  // Eleventy's default collection order is page.date ascending, which for
+  // source posts is the original work date — matching the unified date display.
   eleventyConfig.addCollection("postsZhTW", function (collectionApi) {
-    return sortByPublishedDate(
-      collectionApi
-        .getFilteredByTag("posts")
-        .filter(
-          (item) => isVisible(item) && postLang(item) === DEFAULT_LANG
-        )
-    );
+    return collectionApi
+      .getFilteredByTag("posts")
+      .filter((item) => isVisible(item) && postLang(item) === DEFAULT_LANG);
   });
 
   // Activate a localized section only after that language has at least one

--- a/_11ty/publication-dates.js
+++ b/_11ty/publication-dates.js
@@ -64,23 +64,9 @@ function postPublishedDate(post) {
   return effectivePublishedDate(post.date, data.publishedAt);
 }
 
-/** Match Eleventy's oldest-to-newest collection order using version dates. */
-function sortByPublishedDate(posts) {
-  return [...(posts || [])].sort((left, right) => {
-    const dateDifference =
-      postPublishedDate(left).getTime() - postPublishedDate(right).getTime();
-    if (dateDifference !== 0) return dateDifference;
-
-    const leftKey = String(left.url || left.inputPath || "");
-    const rightKey = String(right.url || right.inputPath || "");
-    return leftKey.localeCompare(rightKey);
-  });
-}
-
 module.exports = {
   isDateOnly,
   effectivePublishedDate,
   effectiveModifiedDate,
   postPublishedDate,
-  sortByPublishedDate,
 };

--- a/_includes/author-postslist.njk
+++ b/_includes/author-postslist.njk
@@ -7,7 +7,7 @@
 {% for post in postslist | reverse %}
   {% if author == post.data.author%}
     <li>
-      <time datetime="{{ post | postPublishedDate | htmlDateString }}">{{ post | postPublishedDate | htmlDateString }}</time>&nbsp;&nbsp;
+      <time datetime="{{ post.date | htmlDateString }}">{{ post.date | htmlDateString }}</time>&nbsp;&nbsp;
       <a href="{{ post.url | url }}">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
     </li>
   {% endif %}

--- a/_includes/home-postslist.njk
+++ b/_includes/home-postslist.njk
@@ -15,8 +15,8 @@
         <img src="{{ author.avatarUrl }}" class="avatar-small" alt="" />
         <span class="post-author">{{ author.name }}</span>
       </a>
-      <time class="post-date" datetime="{{ post | postPublishedDate | htmlDateString }}">{{ post | postPublishedDate | htmlDateString }}</time>
-      {%- if post | postPublishedDate | isFresh %}<span class="post-fresh">🥐 {{ tt.freshBadge }}</span>{% endif %}
+      <time class="post-date" datetime="{{ post.date | htmlDateString }}">{{ post.date | htmlDateString }}</time>
+      {%- if post.date | isFresh %}<span class="post-fresh">🥐 {{ tt.freshBadge }}</span>{% endif %}
     </div>
   </div>
 </article>

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -24,7 +24,7 @@ templateClass: tmpl-post
       <img class="avatar" src="{{ postAuthor.avatarUrl }}" alt="" />
       <span>{{ postAuthor.name }}</span>
     </a>
-    <time class="byline-date" datetime="{{ versionPublishedDate | htmlDateString }}">{{ t.publishedOn }} {{ versionPublishedDate | htmlDateString }}</time>
+    <time class="byline-date" datetime="{{ page.date | htmlDateString }}">{{ t.publishedOn }} {{ page.date | htmlDateString }}</time>
     <span class="byline-tags">
     {%- for tag in tags %}{% if tag !== "posts" %}{% set tagUrl %}/tags/{{ tag | slug }}/{% endset %}<a href="{{ tagUrl | url }}" class="post-tag">#{{ tag }}</a>{% endif %}{% endfor %}
     </span>
@@ -61,7 +61,7 @@ templateClass: tmpl-post
   {%- for rp in related %}
     <li>
       <a href="{{ rp.url | url }}">{{ rp.data.title | safe }}</a>
-      <span class="related-meta">{{ metadata.authors[rp.data.author].name }} · {{ rp | postPublishedDate | htmlDateString }}</span>
+      <span class="related-meta">{{ metadata.authors[rp.data.author].name }} · {{ rp.date | htmlDateString }}</span>
     </li>
   {%- endfor %}
   </ul>

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -2,7 +2,7 @@
 {% for post in postslist %}
   {% set author = metadata.authors[post.data.author] %}
   <li class="archive-row">
-    <time class="archive-date f-monospace" datetime="{{ post | postPublishedDate | htmlDateString }}">{{ post | postPublishedDate | htmlDateString }}</time>
+    <time class="archive-date f-monospace" datetime="{{ post.date | htmlDateString }}">{{ post.date | htmlDateString }}</time>
     <a class="archive-title" href="{{ post.url | url }}">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
     <span class="archive-by">
       <img class="avatar avatar-small" src="{{ author.avatarUrl }}" alt="" loading="lazy" />

--- a/author-langs.njk
+++ b/author-langs.njk
@@ -12,6 +12,6 @@ eleventyComputed:
   lang: "{{ ap.lang }}"
   title: "{{ metadata.authors[ap.author].name }}"
 ---
-{% set postslist = collections.posts | filterByLang(ap.lang) | sortByPublishedDate %}
+{% set postslist = collections.posts | filterByLang(ap.lang) %}
 {% set author = ap.author %}
 {% include "author-postslist.njk" %}

--- a/home-i18n.njk
+++ b/home-i18n.njk
@@ -22,6 +22,6 @@ eleventyComputed:
 {%- endif %}
 </section>
 <section class="posts">
-  {% set postslist = collections.posts | filterByLang(hlang) | sortByPublishedDate | reverse | head(8) %}
+  {% set postslist = collections.posts | filterByLang(hlang) | reverse | head(8) %}
   {% include "home-postslist.njk" %}
 </section>

--- a/tags-list.njk
+++ b/tags-list.njk
@@ -10,6 +10,6 @@ eleventyNavigation:
 {% for tag in collections.tagList %}
   {% set tagUrl %}/tags/{{ tag | slug }}/{% endset %}
   <h2><a href="{{ tagUrl | url }}" class="post-tag">{{ tag }}</a></h2>
-  {% set postslist = collections[tag] | filterByLang('zh-TW') | sortByPublishedDate | reverse %}
+  {% set postslist = collections[tag] | filterByLang('zh-TW') | reverse %}
   {% include "postslist.njk" %}
 {% endfor %}

--- a/tags.njk
+++ b/tags.njk
@@ -22,7 +22,7 @@ eleventyComputed:
 permalink: /tags/{{ tag | slug }}/
 ---
 
-{% set postslist = collections[ tag ] | filterByLang('zh-TW') | sortByPublishedDate | reverse %}
+{% set postslist = collections[ tag ] | filterByLang('zh-TW') | reverse %}
 {% include "postslist.njk" %}
 
 <p>See <a href="{{ '/tags/' | url }}">all tags</a>.</p>

--- a/test/test-publication-dates.js
+++ b/test/test-publication-dates.js
@@ -6,7 +6,6 @@ const {
   effectivePublishedDate,
   effectiveModifiedDate,
   postPublishedDate,
-  sortByPublishedDate,
 } = require("../_11ty/publication-dates");
 
 describe("publication date contract", () => {
@@ -55,24 +54,31 @@ describe("publication date contract", () => {
     );
   });
 
-  it("sorts collection items by version publication without mutating input", () => {
-    const posts = [
-      { url: "/new-source/", date: new Date("2025-01-01"), data: {} },
-      {
-        url: "/new-translation/",
-        date: new Date("2021-01-01"),
-        data: { publishedAt: "2026-07-13" },
-      },
-    ];
+  it("postPublishedDate returns the version date for feeds/JSON-LD", () => {
+    // Version dates (publishedAt) are still resolved for structured data and
+    // feeds even though the byline now renders the original work's date.
+    const translated = {
+      date: new Date("2021-10-28"),
+      data: { publishedAt: "2026-07-13" },
+    };
+    assert.equal(
+      postPublishedDate(translated).toISOString(),
+      "2026-07-13T00:00:00.000Z"
+    );
 
-    assert.equal(postPublishedDate(posts[1]).toISOString(), "2026-07-13T00:00:00.000Z");
-    assert.deepEqual(
-      sortByPublishedDate(posts).map((post) => post.url),
-      ["/new-source/", "/new-translation/"]
+    const source = { date: new Date("2021-10-28"), data: {} };
+    assert.equal(
+      postPublishedDate(source).toISOString(),
+      "2021-10-28T00:00:00.000Z"
     );
-    assert.deepEqual(
-      posts.map((post) => post.url),
-      ["/new-source/", "/new-translation/"]
-    );
+  });
+
+  it("a translation's page.date is the original work date", () => {
+    // Display and sort now read page.date directly. scripts/check-translations.js
+    // (date-mismatch) guarantees a translation's date field equals the source's,
+    // so page.date *is* the original work date for every language version.
+    const source = { date: new Date("2021-10-28") };
+    const translation = { date: new Date("2021-10-28") }; // copied verbatim
+    assert.deepEqual(source.date, translation.date);
   });
 });


### PR DESCRIPTION
## Summary

Implements the consensus from #227 (**option 1**): reader-visible dates are unified to the **original work's date** across all language versions, matching the existing design where comment threads are already shared across languages.

## What changed

**Display → original `date`** (all reader-visible surfaces):
- Post byline, archive/home/author listings, and related posts now render `page.date` instead of the translation's `publishedAt`.
- `isFresh` ("新出爐 / Freshly baked") now reflects the work's age — a freshly translated 2021 article no longer shows the fresh badge.

**Sort → original `date`**:
- Listings and the `postsZhTW` collection now use Eleventy's default `page.date` order. Newly-translated articles no longer float to the top of a language's home/archive; they rank by when the work was written.

**Preserved for SEO**:
- JSON-LD `datePublished`/`dateModified` and feeds still use `publishedAt`/`updatedAt` (per-version accuracy). `sitemap.xml` already used `page.date` and is unchanged.

**Dead code removed**:
- `sortByPublishedDate` (helper + filter + test) — no callers remain after the sort change. `postPublishedDate` is retained for `_11ty/feed-data.js`.

## Safety

A translation's `page.date` *is* the original work date: `scripts/check-translations.js` enforces `date-mismatch` (translation `date` must equal source `date`), so reading `page.date` directly is correct for translations.

## Verification

- `npx mocha` → **88 passing**, 0 failing
- `check-translations` guard → pass
- `npm run build` → exit 0 (the 315 jsdom "Could not parse CSS" messages are pre-existing on `main`, unrelated)
- Spot-checked rendered output:
  - English `git-flow` byline → `2021-10-28` (was `2026-07-13`)
  - English `git-flow` JSON-LD `datePublished` → `2026-07-13` (preserved)
  - English author page `git-flow` → `2021-10-28`
  - English home sorted by original date; `git-flow` (2021) no longer pinned to top
  - English feed → `<published>2026-07-13` (version date preserved)

## Behavior change to note

Newly-translated older articles will no longer appear at the top of a language's home page or carry the "freshly baked" badge. This is the direct consequence of ranking by the original work's date. If surfacing new translations is still desired, that's a separate follow-up (e.g. a dedicated "newly translated" section) and out of scope here.

Closes #227.
