### PR TITLE
fix(i18n): 作者頁語言切換器全灰且無 hreflang (#231)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -400,6 +400,37 @@ module.exports = function (eleventyConfig) {
     }));
   });
 
+  // Author pages: the zh-TW author page /posts/<author>/ is the hand-written
+  // posts/<author>/index.njk; a per-language /<lang>/posts/<author>/ exists only
+  // when collections.authorLangPages has that (lang, author) pair. List only
+  // the versions that actually exist so the switcher and hreflang never point
+  // at an empty page. `translationKey` is the sentinel `authors/<author>`.
+  eleventyConfig.addFilter(
+    "authorVersions",
+    function (langsArr, authorLangPages, translationKey) {
+      const author = (translationKey || "").replace(/^authors\//, "");
+      if (!author || author === translationKey) return [];
+      const localized = new Set(
+        (authorLangPages || [])
+          .filter((p) => p.author === author)
+          .map((p) => p.lang)
+      );
+      const versions = [];
+      for (const code of langsArr || []) {
+        if (code === DEFAULT_LANG || localized.has(code)) {
+          versions.push({
+            lang: code,
+            url:
+              code === DEFAULT_LANG
+                ? `/posts/${author}/`
+                : `/${code}/posts/${author}/`,
+          });
+        }
+      }
+      return versions;
+    }
+  );
+
   // Return only controlled pagination records missing from collections.all.
   // Never return collections.all itself here: computed draft exclusions are
   // applied later in Eleventy's lifecycle and must remain handled by Eleventy.

--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,6 +1,7 @@
 .DS_Store
 .agents/
 .claude/
+.zcode/
 .github/
 .netlify/
 _site/

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -4,6 +4,12 @@
   {%- set langVersions = collections.siteLangsWithPublishedPosts | homeVersions %}
 {%- elif translationKey == 'about' %}
   {%- set langVersions = collections.siteLangsWithPublishedPosts | aboutVersions %}
+{%- elif translationKey and translationKey.startsWith('authors/') %}
+  {#- Author pages are paginated shell templates (like home/about), so build
+      their version set deterministically from authorLangPages instead of the
+      translations collection. Only zh-TW + langs with a generated page are
+      listed, so the switcher/hreflang never link to an empty author page. #}
+  {%- set langVersions = collections.siteLangsWithPublishedPosts | authorVersions(collections.authorLangPages, translationKey) %}
 {%- elif translationKey %}
   {%- set langVersions = collections.translations[translationKey] %}
 {%- else %}

--- a/author-langs.njk
+++ b/author-langs.njk
@@ -11,6 +11,7 @@ permalink: "/{{ ap.lang }}/posts/{{ ap.author }}/"
 eleventyComputed:
   lang: "{{ ap.lang }}"
   title: "{{ metadata.authors[ap.author].name }}"
+  translationKey: "authors/{{ ap.author }}"
 ---
 {% set postslist = collections.posts | filterByLang(ap.lang) | sortByPublishedDate %}
 {% set author = ap.author %}

--- a/posts/YongChen/index.njk
+++ b/posts/YongChen/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
-title: YongChen 
+title: YongChen
+translationKey: authors/YongChen
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/benben/index.njk
+++ b/posts/benben/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: Benben 的文章列表
+translationKey: authors/benben
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/cian/index.njk
+++ b/posts/cian/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: Cian
+translationKey: authors/cian
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/clay/index.njk
+++ b/posts/clay/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: Clay 的文章列表
+translationKey: authors/clay
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/cwc329/index.njk
+++ b/posts/cwc329/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: cwc329 的文章列表
+translationKey: authors/cwc329
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/lavi/index.njk
+++ b/posts/lavi/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: Lavi 的文章列表
+translationKey: authors/lavi
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/minw/index.njk
+++ b/posts/minw/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
-title: minw 
+title: minw
+translationKey: authors/minw
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/ruofan/index.njk
+++ b/posts/ruofan/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: Ruofan
+translationKey: authors/ruofan
 eleventyExcludeFromCollections: true
 ---
 <p>嗨，我是 ruofan</p>

--- a/posts/simon198/index.njk
+++ b/posts/simon198/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
-title: minw 
+title: minw
+translationKey: authors/simon198
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/sixwings/index.njk
+++ b/posts/sixwings/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: sixwings 的文章列表
+translationKey: authors/sixwings
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/tian/index.njk
+++ b/posts/tian/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: 那些我笨拙可愛的時刻
+translationKey: authors/tian
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/umer/index.njk
+++ b/posts/umer/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: Umer 的文章列表
+translationKey: authors/umer
 eleventyExcludeFromCollections: true
 ---
 

--- a/posts/xiang/index.njk
+++ b/posts/xiang/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/home.njk
 title: Xiang 的文章列表
+translationKey: authors/xiang
 eleventyExcludeFromCollections: true
 ---
 


### PR DESCRIPTION
## 關聯 issue

Closes #231 — 作者頁（`/posts/<author>/` 與各語系 `/<lang>/posts/<author>/`）的語言切換器壞掉且完全沒有 hreflang。

## 根因

作者頁模板（13 個 `posts/*/index.njk` + `author-langs.njk`）**沒有 `translationKey`**，而 `base.njk` 只對有 `translationKey` 的頁面組 `langVersions`，導致：

- **切換器**（`base.njk:248-256`）：沒有 `langVersions` → 所有非當前語系一律渲染成 `is-disabled`。
- **hreflang**（`base.njk:82-89`）：gate 在 `langVersions.length > 1` → 完全不輸出 `<link rel=alternate>`。

但各語系作者頁其實都存在（由 `author-langs.njk` 生成）。

## 修法

照 issue 建議，仿 `home`/`about` 的 sentinel 模式，但額外保證只列出「實際存在」的版本：

1. **`.eleventy.js`** — 新增 `authorVersions` filter。與 `homeVersions`/`aboutVersions` 不同的是，它只放「zh-TW（永遠有）+ `collections.authorLangPages` 裡有的語系」，避免切換器或 hreflang 指向空頁面。
2. **`_includes/layouts/base.njk`** — 加一個 sentinel 分支：`translationKey.startsWith('authors/')` 時走 `authorVersions`。
3. **13 個 `posts/*/index.njk`** — 各加 `translationKey: authors/<author>`（順手清掉 `minw` / `YongChen` 標題尾端多餘空白）。
4. **`author-langs.njk`** — `eleventyComputed` 動態算 `translationKey: "authors/{{ ap.author }}"`。

## 順帶修

- **`.eleventyignore`** 補上 `.zcode/`。`.agents/` 與 `.claude/` 早已列入，但 ZCode 的 plan 暫存檔（`.zcode/plans/*.md`）會被 Eleventy 當 Liquid 樣板解析而炸掉 `npm run build`，連帶讓 `pre-push` hook 失敗。AGENTS.md 明文支援 ZCode，補這行讓代理工作流程的本機 build 正常。

## 安全性確認

- `collections.translations` 全站只有兩處消費者（`base.njk:8`、`post.njk:75`），都是 keyed lookup `[translationKey]`，**沒有任何地方遍歷所有 key** → 新增 `authors/<author>` key 不會洩漏到任何列表。
- sitemap / RSS / JSON-LD **都不讀** `translationKey` 或 `langVersions`，作者頁輸出不會被額外改動。
- `eleventyExcludeFromCollections: true` 無法用來擋 translationKey（Eleventy 0.12 在 `TemplateMap.js:259` 直接把該頁從 `getAll()` 移除），故必須用 sentinel 條件式處理。

## 驗證

- ✅ `npm run build`（含 40 個翻譯測試 + mocha site tests）全綠。
- ✅ `/en/posts/benben/` 切換器：繁中、日本語、简体中文皆可點，English 為當前（原本全灰）。
- ✅ 作者頁 hreflang 與文章頁同水準：`/posts/benben/` 有 5 個 `rel=alternate`（zh-TW/en/ja/zh-CN + x-default），與 `/posts/benben/01-article/` 一致。
- ✅ 無譯文的作者（clay）zh-TW 頁仍維持 3 個 disabled、0 個 hreflang（正確，未虚假輸出）。
- ✅ 有完整三語譯文的作者（tian）en 頁切換器四語都正常。
- ✅ `pre-push` build hook 通過。

## 不在範圍

- 不處理作者頁 bio 段落的在地化差異（issue 已點名為另一議題）。