### PR TITLE
[Stack 1/4] refactor(tags): 92 個 canonical 主題正規化＋check-tags CI＋24 條 legacy 301

### DIFF
--- a/_11ty/tag-taxonomy.js
+++ b/_11ty/tag-taxonomy.js
@@ -1,0 +1,399 @@
+"use strict";
+
+const DEFAULT_LANG = "zh-TW";
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const LEGACY_SLUG_RE = /^[a-z0-9]+(?:[.-][a-z0-9]+)*$/;
+
+function normalizeLookupValue(value) {
+  return String(value || "")
+    .normalize("NFKC")
+    .trim()
+    .replace(/\s+/g, " ")
+    .toLocaleLowerCase("en-US");
+}
+
+function compileTaxonomy(taxonomy) {
+  const errors = [];
+  const topics = [];
+  const byCanonical = new Map();
+  const byLookup = new Map();
+  const bySlug = new Map();
+  const retired = new Map();
+  const policy = (taxonomy && taxonomy.policy) || {};
+
+  if (!taxonomy || taxonomy.schemaVersion !== 1) {
+    errors.push("schemaVersion must be 1");
+  }
+  if (!taxonomy || !taxonomy.topics || Array.isArray(taxonomy.topics)) {
+    errors.push("topics must be an object keyed by canonical tag label");
+  }
+
+  for (const field of [
+    "minTagsPerPost",
+    "maxTagsPerPost",
+    "categoryMinPosts",
+    "categoryMinAuthors",
+  ]) {
+    if (!Number.isInteger(policy[field]) || policy[field] < 1) {
+      errors.push(`policy.${field} must be a positive integer`);
+    }
+  }
+  if (
+    Number.isInteger(policy.minTagsPerPost) &&
+    Number.isInteger(policy.maxTagsPerPost) &&
+    policy.minTagsPerPost > policy.maxTagsPerPost
+  ) {
+    errors.push("policy.minTagsPerPost cannot exceed maxTagsPerPost");
+  }
+
+  const topicEntries = Object.entries((taxonomy && taxonomy.topics) || {});
+  for (const [canonical, definition] of topicEntries) {
+    if (!canonical || canonical.trim() !== canonical) {
+      errors.push(`invalid canonical tag label ${JSON.stringify(canonical)}`);
+      continue;
+    }
+    const slug = definition && definition.slug;
+    if (!SLUG_RE.test(slug || "")) {
+      errors.push(`${canonical}: slug must match ${SLUG_RE}`);
+      continue;
+    }
+    if (byCanonical.has(canonical)) {
+      errors.push(`duplicate canonical tag ${canonical}`);
+      continue;
+    }
+    if (bySlug.has(slug)) {
+      errors.push(`${canonical}: slug ${slug} is already used by ${bySlug.get(slug)}`);
+      continue;
+    }
+    const aliases = definition.aliases || [];
+    if (!Array.isArray(aliases) || aliases.some((alias) => typeof alias !== "string")) {
+      errors.push(`${canonical}: aliases must be an array of strings`);
+      continue;
+    }
+    const legacySlugs = definition.legacySlugs || [];
+    if (
+      !Array.isArray(legacySlugs) ||
+      legacySlugs.some((legacySlug) => typeof legacySlug !== "string")
+    ) {
+      errors.push(`${canonical}: legacySlugs must be an array of strings`);
+      continue;
+    }
+    const topic = {
+      id: slug,
+      canonical,
+      slug,
+      aliases: aliases.slice(),
+      legacySlugs: legacySlugs.slice(),
+    };
+    topics.push(topic);
+    byCanonical.set(canonical, topic);
+    bySlug.set(slug, canonical);
+  }
+
+  const byLegacySlug = new Map();
+  for (const topic of topics) {
+    for (const legacySlug of topic.legacySlugs) {
+      if (!LEGACY_SLUG_RE.test(legacySlug)) {
+        errors.push(
+          `${topic.canonical}: legacy slug ${JSON.stringify(
+            legacySlug
+          )} must match ${LEGACY_SLUG_RE}`
+        );
+        continue;
+      }
+      if (legacySlug === topic.slug) {
+        errors.push(
+          `${topic.canonical}: legacy slug ${legacySlug} is already its canonical slug`
+        );
+        continue;
+      }
+      if (bySlug.has(legacySlug)) {
+        errors.push(
+          `${topic.canonical}: legacy slug ${legacySlug} conflicts with the canonical slug for ${bySlug.get(
+            legacySlug
+          )}`
+        );
+        continue;
+      }
+      if (byLegacySlug.has(legacySlug)) {
+        errors.push(
+          `${topic.canonical}: legacy slug ${legacySlug} is already used by ${byLegacySlug.get(
+            legacySlug
+          )}`
+        );
+        continue;
+      }
+      byLegacySlug.set(legacySlug, topic.canonical);
+    }
+  }
+
+  const registerLookup = (value, canonical, source) => {
+    const key = normalizeLookupValue(value);
+    if (!key) {
+      errors.push(`${canonical}: ${source} cannot be empty`);
+      return;
+    }
+    const previous = byLookup.get(key);
+    if (previous && previous !== canonical) {
+      errors.push(
+        `${canonical}: ${source} ${JSON.stringify(value)} conflicts with ${previous}`
+      );
+      return;
+    }
+    byLookup.set(key, canonical);
+  };
+
+  for (const topic of topics) {
+    registerLookup(topic.canonical, topic.canonical, "canonical label");
+  }
+  for (const topic of topics) {
+    for (const alias of topic.aliases) {
+      registerLookup(alias, topic.canonical, "alias");
+    }
+  }
+
+  for (const [value, definition] of Object.entries(
+    (taxonomy && taxonomy.retired) || {}
+  )) {
+    const key = normalizeLookupValue(value);
+    if (!key) {
+      errors.push("retired tag value cannot be empty");
+      continue;
+    }
+    if (byLookup.has(key)) {
+      errors.push(`retired tag ${value} conflicts with active tag ${byLookup.get(key)}`);
+      continue;
+    }
+    retired.set(key, {
+      value,
+      replacement:
+        definition && typeof definition.replacement === "string"
+          ? definition.replacement
+          : null,
+      reason: (definition && definition.reason) || "This tag is retired.",
+    });
+  }
+
+  if (errors.length > 0) {
+    const error = new Error(`Invalid tag taxonomy:\n- ${errors.join("\n- ")}`);
+    error.issues = errors;
+    throw error;
+  }
+
+  return {
+    policy,
+    topics,
+    byCanonical,
+    byLookup,
+    byLegacySlug,
+    retired,
+  };
+}
+
+function buildLegacyTagRedirects(taxonomy) {
+  const registry = compileTaxonomy(taxonomy);
+  return registry.topics
+    .flatMap((topic) =>
+      topic.legacySlugs.map((legacySlug) => ({
+        from: `/tags/${legacySlug}/`,
+        to: `/tags/${topic.slug}/`,
+        status: 301,
+      }))
+    )
+    .sort((left, right) => left.from.localeCompare(right.from, "en"));
+}
+
+function extractFrontmatter(raw) {
+  const match = String(raw || "").match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return match ? match[1] : null;
+}
+
+function singleLineTagsIssue(raw) {
+  const frontmatter = extractFrontmatter(raw);
+  if (frontmatter === null) {
+    return "missing YAML frontmatter";
+  }
+  const tagLines = frontmatter
+    .split(/\r?\n/)
+    .filter((line) => /^tags\s*:/.test(line));
+  if (tagLines.length !== 1 || !/^tags\s*:\s*\[[^\]]*\]\s*$/.test(tagLines[0])) {
+    return "tags must use one top-level flow-array line, for example tags: [React, CSS]";
+  }
+  return null;
+}
+
+function validateTagRecord(record, taxonomy) {
+  const registry = compileTaxonomy(taxonomy);
+  const issues = [];
+  const path = record.path || record.inputPath || "<unknown>";
+  const lineIssue = singleLineTagsIssue(record.raw);
+  if (lineIssue) {
+    issues.push({ code: "tags-format", path, message: lineIssue });
+  }
+
+  const tags = record.tags;
+  if (!Array.isArray(tags)) {
+    issues.push({ code: "tags-type", path, message: "tags must parse as an array" });
+    return issues;
+  }
+  if (
+    tags.length < registry.policy.minTagsPerPost ||
+    tags.length > registry.policy.maxTagsPerPost
+  ) {
+    issues.push({
+      code: "tags-count",
+      path,
+      message: `tags must contain ${registry.policy.minTagsPerPost}–${registry.policy.maxTagsPerPost} values; found ${tags.length}`,
+    });
+  }
+
+  const seen = new Set();
+  for (const tag of tags) {
+    if (typeof tag !== "string" || !tag.trim()) {
+      issues.push({
+        code: "tag-type",
+        path,
+        message: `tag ${JSON.stringify(tag)} must be a non-empty string`,
+      });
+      continue;
+    }
+    const active = registry.byCanonical.get(tag);
+    if (!active) {
+      const lookup = normalizeLookupValue(tag);
+      const expected = registry.byLookup.get(lookup);
+      const retired = registry.retired.get(lookup);
+      if (expected) {
+        issues.push({
+          code: "tag-noncanonical",
+          path,
+          tag,
+          expected,
+          message: `${JSON.stringify(tag)} is not canonical; use ${JSON.stringify(expected)}`,
+        });
+      } else if (retired) {
+        issues.push({
+          code: "tag-retired",
+          path,
+          tag,
+          expected: retired.replacement,
+          message: `${JSON.stringify(tag)} is retired. ${retired.reason}`,
+        });
+      } else {
+        issues.push({
+          code: "tag-unknown",
+          path,
+          tag,
+          message: `${JSON.stringify(tag)} is not registered in tagTaxonomy.json`,
+        });
+      }
+      continue;
+    }
+    if (seen.has(tag)) {
+      issues.push({
+        code: "tag-duplicate",
+        path,
+        tag,
+        message: `${JSON.stringify(tag)} appears more than once`,
+      });
+    }
+    seen.add(tag);
+  }
+  return issues;
+}
+
+function topicUrlFor(canonical, taxonomy, lang = DEFAULT_LANG) {
+  const topic = compileTaxonomy(taxonomy).byCanonical.get(canonical);
+  if (!topic) return null;
+  const prefix = lang && lang !== DEFAULT_LANG ? `/${lang}` : "";
+  return `${prefix}/tags/${topic.slug}/`;
+}
+
+function buildTopicMap(posts, taxonomy, options = {}) {
+  const registry = compileTaxonomy(taxonomy);
+  const lang = options.lang || DEFAULT_LANG;
+  const inheritedCandidates = options.candidateIds || null;
+  const stats = new Map();
+
+  for (const post of posts || []) {
+    const data = post.data || {};
+    const uniqueTags = new Set(
+      (Array.isArray(data.tags) ? data.tags : []).filter((tag) =>
+        registry.byCanonical.has(tag)
+      )
+    );
+    for (const canonical of uniqueTags) {
+      if (!stats.has(canonical)) {
+        stats.set(canonical, { posts: [], authors: new Set() });
+      }
+      const stat = stats.get(canonical);
+      stat.posts.push(post);
+      if (data.author) stat.authors.add(data.author);
+    }
+  }
+
+  return [...stats.entries()]
+    .map(([canonical, stat]) => {
+      const topic = registry.byCanonical.get(canonical);
+      const directCandidate =
+        stat.posts.length >= registry.policy.categoryMinPosts &&
+        stat.authors.size >= registry.policy.categoryMinAuthors;
+      return {
+        id: topic.id,
+        canonical,
+        slug: topic.slug,
+        aliases: topic.aliases.slice(),
+        lang,
+        url: topicUrlFor(canonical, taxonomy, lang),
+        posts: stat.posts.slice(),
+        postCount: stat.posts.length,
+        authors: [...stat.authors].sort(),
+        authorCount: stat.authors.size,
+        isCategoryCandidate: inheritedCandidates
+          ? inheritedCandidates.has(topic.id)
+          : directCandidate,
+      };
+    })
+    .sort(
+      (a, b) =>
+        Number(b.isCategoryCandidate) - Number(a.isCategoryCandidate) ||
+        b.postCount - a.postCount ||
+        a.canonical.localeCompare(b.canonical, "en")
+    );
+}
+
+function topicVersions(topicPages, topicId) {
+  return (topicPages || [])
+    .filter((page) => page.id === topicId)
+    .map((page) => ({ lang: page.lang, url: page.url, title: page.canonical }));
+}
+
+function tagIndexVersions(langs) {
+  return (langs || []).map((lang) => ({
+    lang,
+    url: lang === DEFAULT_LANG ? "/tags/" : `/${lang}/tags/`,
+  }));
+}
+
+function sameTags(left, right) {
+  return (
+    Array.isArray(left) &&
+    Array.isArray(right) &&
+    left.length === right.length &&
+    left.every((tag, index) => tag === right[index])
+  );
+}
+
+module.exports = {
+  DEFAULT_LANG,
+  normalizeLookupValue,
+  compileTaxonomy,
+  extractFrontmatter,
+  singleLineTagsIssue,
+  validateTagRecord,
+  buildLegacyTagRedirects,
+  buildTopicMap,
+  topicUrlFor,
+  topicVersions,
+  tagIndexVersions,
+  sameTags,
+};

--- a/_data/tagRedirects.js
+++ b/_data/tagRedirects.js
@@ -1,0 +1,6 @@
+"use strict";
+
+const taxonomy = require("./tagTaxonomy.json");
+const { buildLegacyTagRedirects } = require("../_11ty/tag-taxonomy");
+
+module.exports = buildLegacyTagRedirects(taxonomy);

--- a/_data/tagTaxonomy.json
+++ b/_data/tagTaxonomy.json
@@ -1,0 +1,209 @@
+{
+  "schemaVersion": 1,
+  "policy": {
+    "minTagsPerPost": 1,
+    "maxTagsPerPost": 5,
+    "categoryMinPosts": 8,
+    "categoryMinAuthors": 3
+  },
+  "topics": {
+    "AI": { "slug": "ai" },
+    "API Documentation": {
+      "slug": "api-documentation",
+      "aliases": ["API-doc", "api-doc"],
+      "legacySlugs": ["api-doc"]
+    },
+    "Array": { "slug": "array" },
+    "Async": { "slug": "async" },
+    "Automation": { "slug": "automation" },
+    "Await": { "slug": "await" },
+    "AWS": { "slug": "aws" },
+    "Babel": { "slug": "babel" },
+    "Backend": {
+      "slug": "backend",
+      "aliases": ["back-end", "back end"],
+      "legacySlugs": ["back-end"]
+    },
+    "Blockchain": {
+      "slug": "blockchain",
+      "aliases": ["block-chain"],
+      "legacySlugs": ["block-chain"]
+    },
+    "Boshiamy": { "slug": "boshiamy" },
+    "Chrome Extension": {
+      "slug": "chrome-extension",
+      "legacySlugs": ["google-extension"]
+    },
+    "CI/CD": { "slug": "ci-cd" },
+    "Circular Dependency": { "slug": "circular-dependency" },
+    "CLI": { "slug": "cli" },
+    "Collaborative Writing": {
+      "slug": "collaborative-writing",
+      "legacySlugs": ["collaborative"]
+    },
+    "Compiled Language": { "slug": "compiled-language" },
+    "Cookie": { "slug": "cookie" },
+    "CSRF": { "slug": "csrf" },
+    "CSS": { "slug": "css" },
+    "Data Visualization": {
+      "slug": "data-visualization",
+      "aliases": ["data-vis"],
+      "legacySlugs": ["data-vis"]
+    },
+    "Deep Copy": { "slug": "deep-copy" },
+    "Deployment": {
+      "slug": "deployment",
+      "aliases": ["deploy"],
+      "legacySlugs": ["deploy"]
+    },
+    "Design Patterns": {
+      "slug": "design-patterns",
+      "legacySlugs": ["pattern"]
+    },
+    "DevOps": { "slug": "devops" },
+    "Django": { "slug": "django" },
+    "django-allauth": { "slug": "django-allauth" },
+    "dotenv": { "slug": "dotenv" },
+    "Eleventy": { "slug": "eleventy" },
+    "Encoding": {
+      "slug": "encoding",
+      "aliases": ["encode"],
+      "legacySlugs": ["encode"]
+    },
+    "ESLint": { "slug": "eslint" },
+    "FormatJS": { "slug": "formatjs" },
+    "Framework": { "slug": "framework" },
+    "Frontend": {
+      "slug": "frontend",
+      "aliases": ["Front-end", "front-end", "front end"],
+      "legacySlugs": ["front-end"]
+    },
+    "Gatsby Plugin": {
+      "slug": "gatsby-plugin",
+      "aliases": ["Gatsby-Plugin"]
+    },
+    "Gatus": { "slug": "gatus" },
+    "Git": { "slug": "git" },
+    "Git Flow": {
+      "slug": "git-flow",
+      "legacySlugs": ["flow"]
+    },
+    "GitHub": { "slug": "github" },
+    "GitHub Actions": {
+      "slug": "github-actions",
+      "aliases": ["github-actions"]
+    },
+    "Go": {
+      "slug": "go",
+      "aliases": ["golang"],
+      "legacySlugs": ["golang"]
+    },
+    "Google": { "slug": "google" },
+    "gRPC": { "slug": "grpc" },
+    "Heroku": { "slug": "heroku" },
+    "HTML": { "slug": "html" },
+    "HTTP": { "slug": "http" },
+    "Image": { "slug": "image" },
+    "Internationalization": {
+      "slug": "internationalization",
+      "aliases": ["i18n", "internationalisation"],
+      "legacySlugs": ["i18n"]
+    },
+    "Interpreted Language": { "slug": "interpreted-language" },
+    "JavaScript": {
+      "slug": "javascript",
+      "aliases": ["js"],
+      "legacySlugs": ["js"]
+    },
+    "LeetCode": { "slug": "leetcode" },
+    "LINE Bot": {
+      "slug": "line-bot",
+      "aliases": ["line-bot"]
+    },
+    "Markdown": { "slug": "markdown" },
+    "Mentor": { "slug": "mentor" },
+    "Monitoring": { "slug": "monitoring" },
+    "Monorepo": { "slug": "monorepo" },
+    "multipart/form-data": { "slug": "multipart-form-data" },
+    "Next.js": {
+      "slug": "next-js",
+      "aliases": ["nextjs"],
+      "legacySlugs": ["next.js"]
+    },
+    "Node.js": {
+      "slug": "node-js",
+      "aliases": ["nodejs"],
+      "legacySlugs": ["nodejs"]
+    },
+    "nodemon": { "slug": "nodemon" },
+    "npm": { "slug": "npm" },
+    "OpenAPI": { "slug": "openapi" },
+    "p5.js": {
+      "slug": "p5-js",
+      "aliases": ["p5"],
+      "legacySlugs": ["p5"]
+    },
+    "Performance": { "slug": "performance" },
+    "Product Management": {
+      "slug": "product-management",
+      "legacySlugs": ["pm"]
+    },
+    "Python": { "slug": "python" },
+    "QR Code": {
+      "slug": "qr-code",
+      "aliases": ["qrcode"],
+      "legacySlugs": ["qrcode"]
+    },
+    "Raycast": { "slug": "raycast" },
+    "React": { "slug": "react" },
+    "React Hook Form": { "slug": "react-hook-form" },
+    "React Intl": {
+      "slug": "react-intl",
+      "legacySlugs": ["intl"]
+    },
+    "React Memo": {
+      "slug": "react-memo",
+      "legacySlugs": ["memo"]
+    },
+    "RFC": { "slug": "rfc" },
+    "RFC 7578": { "slug": "rfc-7578" },
+    "Salary": { "slug": "salary" },
+    "SEO": { "slug": "seo" },
+    "Sequelize": { "slug": "sequelize" },
+    "Shallow Copy": { "slug": "shallow-copy" },
+    "Structured Data": {
+      "slug": "structured-data",
+      "legacySlugs": ["schema"]
+    },
+    "Swagger Editor": { "slug": "swagger-editor" },
+    "Swagger UI": { "slug": "swagger-ui" },
+    "Technical Writing": { "slug": "technical-writing" },
+    "Terminal": { "slug": "terminal" },
+    "Todo List": {
+      "slug": "todo-list",
+      "aliases": ["todo-list"]
+    },
+    "TypeScript": { "slug": "typescript" },
+    "Typing": { "slug": "typing" },
+    "UnoCSS": { "slug": "unocss" },
+    "Vim": { "slug": "vim" },
+    "VS Code Extension": {
+      "slug": "vs-code-extension",
+      "aliases": ["vs-code-plugin", "VS Code Plugin"],
+      "legacySlugs": ["vs-code-plugin"]
+    },
+    "Vue": { "slug": "vue" },
+    "Warp": { "slug": "warp" },
+    "WeakMap": {
+      "slug": "weakmap",
+      "aliases": ["weap-map", "weak-map"],
+      "legacySlugs": ["weap-map"]
+    }
+  },
+  "retired": {
+    "article": {
+      "replacement": null,
+      "reason": "Content format is not a technical topic. Retag each article by subject."
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,24 +8,26 @@
   },
   "scripts": {
     "clean": "node scripts/clean-output.js",
-    "build": "npm run clean && npm run js-build && eleventy && npm run test",
+    "build": "npm run clean && npm run check-tags && npm run js-build && eleventy && npm run test",
     "watch": "concurrently \"eleventy --serve\" \"npm run js-build-watch\"",
     "serve": "eleventy --serve",
     "js-build": "rollup -c rollup.config.js",
     "js-build-watch": "rollup -c rollup.config.js -w",
     "debug": "DEBUG=* eleventy && npm run test",
-    "test": "npm run test:site && npm run test:translations",
+    "test": "npm run test:site && npm run test:translations && npm run check-tags",
     "test:site": "node scripts/assert-site-built.js && mocha test/test*.js",
     "test-watch": "mocha test/test*.js --watch",
     "check-translations": "node scripts/check-translations.js",
     "check-translations:all": "node scripts/check-translations.js --all",
+    "check-tags": "node scripts/check-tags.js",
     "test:translations": "node scripts/check-translations.test.js && npm run check-translations:all"
   },
   "pre-push": [
     "build"
   ],
   "pre-commit": [
-    "check-translations"
+    "check-translations",
+    "check-tags"
   ],
   "repository": {
     "type": "git",

--- a/posts/YongChen/gatsby-generic-plugin.md
+++ b/posts/YongChen/gatsby-generic-plugin.md
@@ -1,7 +1,7 @@
 ---
 title: 來做一個 Gatsby Generic Plugin 吧
 date: 2021-11-15
-tags: [Gatsby-Plugin]
+tags: [Gatsby Plugin]
 author: YongChen
 layout: layouts/post.njk
 ---

--- a/posts/benben/01-article.en.md
+++ b/posts/benben/01-article.en.md
@@ -1,7 +1,7 @@
 ---
 title: Anyone Can Write — From Notes to Articles
 date: 2021-08-22
-tags: [article]
+tags: [Technical Writing]
 author: benben
 layout: layouts/post.njk
 lang: en

--- a/posts/benben/01-article.ja.md
+++ b/posts/benben/01-article.ja.md
@@ -1,7 +1,7 @@
 ---
 title: 誰でも記事が書ける —— メモから記事へ
 date: 2021-08-22
-tags: [article]
+tags: [Technical Writing]
 author: benben
 layout: layouts/post.njk
 lang: ja

--- a/posts/benben/01-article.md
+++ b/posts/benben/01-article.md
@@ -1,7 +1,7 @@
 ---
 title: 人人都可以寫文章 - 從筆記到文章
 date: 2021-08-22
-tags: [article]
+tags: [Technical Writing]
 author: benben
 layout: layouts/post.njk
 lang: zh-TW

--- a/posts/benben/01-article.zh-CN.md
+++ b/posts/benben/01-article.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: 人人都可以写文章 —— 从笔记到文章
 date: 2021-08-22
-tags: [article]
+tags: [Technical Writing]
 author: benben
 layout: layouts/post.njk
 lang: zh-CN

--- a/posts/benben/02-framework.en.md
+++ b/posts/benben/02-framework.en.md
@@ -1,7 +1,7 @@
 ---
 title: Why Use a Framework — What's the Best Answer You've Heard?
 date: 2021-09-19
-tags: [framework]
+tags: [Framework]
 author: benben
 layout: layouts/post.njk
 image: https://www.saaspegasus.com/static/images/web/modern-javascript/2008-vs-2021.png

--- a/posts/benben/02-framework.ja.md
+++ b/posts/benben/02-framework.ja.md
@@ -1,7 +1,7 @@
 ---
 title: なぜフレームワークを使うのか —— 今まで聞いた中で一番良い答えは？
 date: 2021-09-19
-tags: [framework]
+tags: [Framework]
 author: benben
 layout: layouts/post.njk
 image: https://www.saaspegasus.com/static/images/web/modern-javascript/2008-vs-2021.png

--- a/posts/benben/02-framework.md
+++ b/posts/benben/02-framework.md
@@ -1,7 +1,7 @@
 ---
 title: 為什麼要使用框架 - 你聽過最好的答案是什麼？
 date: 2021-09-19
-tags: [framework]
+tags: [Framework]
 author: benben
 layout: layouts/post.njk
 image: https://www.saaspegasus.com/static/images/web/modern-javascript/2008-vs-2021.png

--- a/posts/benben/02-framework.zh-CN.md
+++ b/posts/benben/02-framework.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: 为什么要使用框架 —— 你听过最好的答案是什么？
 date: 2021-09-19
-tags: [framework]
+tags: [Framework]
 author: benben
 layout: layouts/post.njk
 image: https://www.saaspegasus.com/static/images/web/modern-javascript/2008-vs-2021.png

--- a/posts/benben/03-collaborative-writing.en.md
+++ b/posts/benben/03-collaborative-writing.en.md
@@ -1,7 +1,7 @@
 ---
 title: Collaborative Notes Within Collaborative Notes — JavaScript30 as an Example
 date: 2021-10-26
-tags: [JavaScript, collaborative]
+tags: [JavaScript, Collaborative Writing]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/ZmEEvep.png

--- a/posts/benben/03-collaborative-writing.ja.md
+++ b/posts/benben/03-collaborative-writing.ja.md
@@ -1,7 +1,7 @@
 ---
 title: 共同ノートの中の共同ノート —— JavaScript30 を例に
 date: 2021-10-26
-tags: [JavaScript, collaborative]
+tags: [JavaScript, Collaborative Writing]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/ZmEEvep.png

--- a/posts/benben/03-collaborative-writing.md
+++ b/posts/benben/03-collaborative-writing.md
@@ -1,7 +1,7 @@
 ---
 title: 共筆中的共筆 - 以 JavaScript30 為例
 date: 2021-10-26
-tags: [JavaScript, collaborative]
+tags: [JavaScript, Collaborative Writing]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/ZmEEvep.png

--- a/posts/benben/03-collaborative-writing.zh-CN.md
+++ b/posts/benben/03-collaborative-writing.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: 共笔中的共笔 —— 以 JavaScript30 为例
 date: 2021-10-26
-tags: [JavaScript, collaborative]
+tags: [JavaScript, Collaborative Writing]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/ZmEEvep.png

--- a/posts/benben/05-p5-js.en.md
+++ b/posts/benben/05-p5-js.en.md
@@ -1,7 +1,7 @@
 ---
 title: Let's Draw Something — A P5.js Introduction
 date: 2022-05-03
-tags: [p5]
+tags: [p5.js]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/nlXgHMj.png

--- a/posts/benben/05-p5-js.ja.md
+++ b/posts/benben/05-p5-js.ja.md
@@ -1,7 +1,7 @@
 ---
 title: 絵を描いてみよう —— P5.js 入門
 date: 2022-05-03
-tags: [p5]
+tags: [p5.js]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/nlXgHMj.png

--- a/posts/benben/05-p5-js.md
+++ b/posts/benben/05-p5-js.md
@@ -1,7 +1,7 @@
 ---
 title: 來畫個圖吧 - P5.js 入門
 date: 2022-05-03
-tags: [p5]
+tags: [p5.js]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/nlXgHMj.png

--- a/posts/benben/05-p5-js.zh-CN.md
+++ b/posts/benben/05-p5-js.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: 来画个图吧 —— P5.js 入门
 date: 2022-05-03
-tags: [p5]
+tags: [p5.js]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/nlXgHMj.png

--- a/posts/benben/06-uno-css.en.md
+++ b/posts/benben/06-uno-css.en.md
@@ -1,7 +1,7 @@
 ---
 title: Uno CSS — The Rising Star to Unify Them All?
 date: 2022-05-18
-tags: [CSS, unoCSS]
+tags: [CSS, UnoCSS]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/XRsgu8H.png

--- a/posts/benben/06-uno-css.ja.md
+++ b/posts/benben/06-uno-css.ja.md
@@ -1,7 +1,7 @@
 ---
 title: Uno CSS —— 天下を統一する明日のスター？
 date: 2022-05-18
-tags: [CSS, unoCSS]
+tags: [CSS, UnoCSS]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/XRsgu8H.png

--- a/posts/benben/06-uno-css.md
+++ b/posts/benben/06-uno-css.md
@@ -1,7 +1,7 @@
 ---
 title: Uno CSS - 一統天下的明日之星？
 date: 2022-05-18
-tags: [CSS, unoCSS]
+tags: [CSS, UnoCSS]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/XRsgu8H.png

--- a/posts/benben/06-uno-css.zh-CN.md
+++ b/posts/benben/06-uno-css.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: Uno CSS —— 统一天下的明日之星？
 date: 2022-05-18
-tags: [CSS, unoCSS]
+tags: [CSS, UnoCSS]
 author: benben
 layout: layouts/post.njk
 image: https://i.imgur.com/XRsgu8H.png

--- a/posts/benben/07-could-i-be-a-mentor-enough.en.md
+++ b/posts/benben/07-could-i-be-a-mentor-enough.en.md
@@ -1,7 +1,7 @@
 ---
 title: RE [Frontend Guide Program] — Can I Be a Mentor Too?
 date: 2022-06-30
-tags: [mentor, Front-end]
+tags: [Mentor, Frontend]
 author: benben
 layout: layouts/post.njk
 image: https://camo.githubusercontent.com/c110c0c2bf1812ae1c8669b897e8d8a724fc29cea1bed87c34fe43fc67ba85a6/68747470733a2f2f692e696d6775722e636f6d2f515935767466422e706e67

--- a/posts/benben/07-could-i-be-a-mentor-enough.ja.md
+++ b/posts/benben/07-could-i-be-a-mentor-enough.ja.md
@@ -1,7 +1,7 @@
 ---
 title: RE [フロントエンドガイドプログラム] —— 私にもメンターになれる？
 date: 2022-06-30
-tags: [mentor, Front-end]
+tags: [Mentor, Frontend]
 author: benben
 layout: layouts/post.njk
 image: https://camo.githubusercontent.com/c110c0c2bf1812ae1c8669b897e8d8a724fc29cea1bed87c34fe43fc67ba85a6/68747470733a2f2f692e696d6775722e636f6d2f515935767466422e706e67

--- a/posts/benben/07-could-i-be-a-mentor-enough.md
+++ b/posts/benben/07-could-i-be-a-mentor-enough.md
@@ -1,7 +1,7 @@
 ---
 title: RE [前端引路人計劃] - 我也能夠當個 mentor 嗎？
 date: 2022-06-30
-tags: [mentor, Front-end]
+tags: [Mentor, Frontend]
 author: benben
 layout: layouts/post.njk
 image: https://camo.githubusercontent.com/c110c0c2bf1812ae1c8669b897e8d8a724fc29cea1bed87c34fe43fc67ba85a6/68747470733a2f2f692e696d6775722e636f6d2f515935767466422e706e67

--- a/posts/benben/07-could-i-be-a-mentor-enough.zh-CN.md
+++ b/posts/benben/07-could-i-be-a-mentor-enough.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: RE [前端引路人计划] —— 我也能够当个 mentor 吗？
 date: 2022-06-30
-tags: [mentor, Front-end]
+tags: [Mentor, Frontend]
 author: benben
 layout: layouts/post.njk
 image: https://camo.githubusercontent.com/c110c0c2bf1812ae1c8669b897e8d8a724fc29cea1bed87c34fe43fc67ba85a6/68747470733a2f2f692e696d6775722e636f6d2f515935767466422e706e67

--- a/posts/benben/08-vue-composition-api-and-react-hook.en.md
+++ b/posts/benben/08-vue-composition-api-and-react-hook.en.md
@@ -1,7 +1,7 @@
 ---
 title: Vue3 Composition API & React hooks
 date: 2022-07-30
-tags: [Front-end, react, vue]
+tags: [Frontend, React, Vue]
 author: benben
 layout: layouts/post.njk
 image: https://dev-to-uploads.s3.amazonaws.com/i/296z018ivuyy4p3954at.png

--- a/posts/benben/08-vue-composition-api-and-react-hook.ja.md
+++ b/posts/benben/08-vue-composition-api-and-react-hook.ja.md
@@ -1,7 +1,7 @@
 ---
 title: Vue3 Composition API & React hooks
 date: 2022-07-30
-tags: [Front-end, react, vue]
+tags: [Frontend, React, Vue]
 author: benben
 layout: layouts/post.njk
 image: https://dev-to-uploads.s3.amazonaws.com/i/296z018ivuyy4p3954at.png

--- a/posts/benben/08-vue-composition-api-and-react-hook.md
+++ b/posts/benben/08-vue-composition-api-and-react-hook.md
@@ -1,7 +1,7 @@
 ---
 title: Vue3 Composition API & React hooks
 date: 2022-07-30
-tags: [Front-end, react, vue]
+tags: [Frontend, React, Vue]
 author: benben
 layout: layouts/post.njk
 image: https://dev-to-uploads.s3.amazonaws.com/i/296z018ivuyy4p3954at.png

--- a/posts/benben/08-vue-composition-api-and-react-hook.zh-CN.md
+++ b/posts/benben/08-vue-composition-api-and-react-hook.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: Vue3 Composition API & React hooks
 date: 2022-07-30
-tags: [Front-end, react, vue]
+tags: [Frontend, React, Vue]
 author: benben
 layout: layouts/post.njk
 image: https://dev-to-uploads.s3.amazonaws.com/i/296z018ivuyy4p3954at.png

--- a/posts/benben/09-how-to-speed-up-typing.en.md
+++ b/posts/benben/09-how-to-speed-up-typing.en.md
@@ -1,7 +1,7 @@
 ---
 title: How to Improve Your Typing Speed — From Beginner to Super Beginner
 date: 2022-10-16
-tags: [typing, vs-code-plugin]
+tags: [Typing, VS Code Extension]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/rJWJgRQ1i.gif

--- a/posts/benben/09-how-to-speed-up-typing.ja.md
+++ b/posts/benben/09-how-to-speed-up-typing.ja.md
@@ -1,7 +1,7 @@
 ---
 title: タイピング速度をどう上げるか —— 初心者から超初心者へ
 date: 2022-10-16
-tags: [typing, vs-code-plugin]
+tags: [Typing, VS Code Extension]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/rJWJgRQ1i.gif

--- a/posts/benben/09-how-to-speed-up-typing.md
+++ b/posts/benben/09-how-to-speed-up-typing.md
@@ -1,7 +1,7 @@
 ---
 title: 如何提升打字速度 - 從初心者轉職超級初心者
 date: 2022-10-16
-tags: [typing, vs-code-plugin]
+tags: [Typing, VS Code Extension]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/rJWJgRQ1i.gif

--- a/posts/benben/09-how-to-speed-up-typing.zh-CN.md
+++ b/posts/benben/09-how-to-speed-up-typing.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: 如何提升打字速度 —— 从初心者转职超级初心者
 date: 2022-10-16
-tags: [typing, vs-code-plugin]
+tags: [Typing, VS Code Extension]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/rJWJgRQ1i.gif

--- a/posts/benben/10-one-year-and-two-month-experience.en.md
+++ b/posts/benben/10-one-year-and-two-month-experience.en.md
@@ -1,7 +1,7 @@
 ---
 title: Frontend Noob — Career-Change Reflection at 1 Year and 2 Months
 date: 2023-02-01
-tags: [Front-end, salary]
+tags: [Frontend, Salary]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/SJOHgbO3j.jpg

--- a/posts/benben/10-one-year-and-two-month-experience.ja.md
+++ b/posts/benben/10-one-year-and-two-month-experience.ja.md
@@ -1,7 +1,7 @@
 ---
 title: フロントエンドの雑魚 —— 転職 1 年と 2 ヶ月の振り返り
 date: 2023-02-01
-tags: [Front-end, salary]
+tags: [Frontend, Salary]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/SJOHgbO3j.jpg

--- a/posts/benben/10-one-year-and-two-month-experience.md
+++ b/posts/benben/10-one-year-and-two-month-experience.md
@@ -1,7 +1,7 @@
 ---
 title: 前端菜雞 - 轉職 1 年又 2 個月心得
 date: 2023-02-01
-tags: [Front-end, salary]
+tags: [Frontend, Salary]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/SJOHgbO3j.jpg

--- a/posts/benben/10-one-year-and-two-month-experience.zh-CN.md
+++ b/posts/benben/10-one-year-and-two-month-experience.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: 前端菜鸡 —— 转职 1 年又 2 个月心得
 date: 2023-02-01
-tags: [Front-end, salary]
+tags: [Frontend, Salary]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/SJOHgbO3j.jpg

--- a/posts/benben/11-vim-for-beginners.en.md
+++ b/posts/benben/11-vim-for-beginners.en.md
@@ -1,7 +1,7 @@
 ---
 title: Vim for beginners
 date: 2023-05-07
-tags: [vim]
+tags: [Vim]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/BkbJbumEh.gif

--- a/posts/benben/11-vim-for-beginners.ja.md
+++ b/posts/benben/11-vim-for-beginners.ja.md
@@ -1,7 +1,7 @@
 ---
 title: Vim for beginners
 date: 2023-05-07
-tags: [vim]
+tags: [Vim]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/BkbJbumEh.gif

--- a/posts/benben/11-vim-for-beginners.md
+++ b/posts/benben/11-vim-for-beginners.md
@@ -1,7 +1,7 @@
 ---
 title: Vim for beginners
 date: 2023-05-07
-tags: [vim]
+tags: [Vim]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/BkbJbumEh.gif

--- a/posts/benben/11-vim-for-beginners.zh-CN.md
+++ b/posts/benben/11-vim-for-beginners.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: Vim for beginners
 date: 2023-05-07
-tags: [vim]
+tags: [Vim]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/BkbJbumEh.gif

--- a/posts/benben/12-warp.en.md
+++ b/posts/benben/12-warp.en.md
@@ -1,7 +1,7 @@
 ---
 title: Warp | Your 21st Century AI Terminal
 date: 2023-05-31
-tags: [warp, terminal, ai]
+tags: [Warp, Terminal, AI]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/HJsA77LE3.gif

--- a/posts/benben/12-warp.ja.md
+++ b/posts/benben/12-warp.ja.md
@@ -1,7 +1,7 @@
 ---
 title: Warp | あなたの 21 世紀 AI ターミナル
 date: 2023-05-31
-tags: [warp, terminal, ai]
+tags: [Warp, Terminal, AI]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/HJsA77LE3.gif

--- a/posts/benben/12-warp.md
+++ b/posts/benben/12-warp.md
@@ -1,7 +1,7 @@
 ---
 title: Warp | 你的 21 世紀 AI Terminal
 date: 2023-05-31
-tags: [warp, terminal, ai]
+tags: [Warp, Terminal, AI]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/HJsA77LE3.gif

--- a/posts/benben/12-warp.zh-CN.md
+++ b/posts/benben/12-warp.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: Warp | 你的 21 世纪 AI Terminal
 date: 2023-05-31
-tags: [warp, terminal, ai]
+tags: [Warp, Terminal, AI]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/HJsA77LE3.gif

--- a/posts/benben/13-boshiamy.en.md
+++ b/posts/benben/13-boshiamy.en.md
@@ -1,7 +1,7 @@
 ---
 title: Still Learning in This Day and Age | Boshiamy Input Method
 date: 2023-08-31
-tags: [boshiamy]
+tags: [Boshiamy]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/B1HXrmRTn.gif

--- a/posts/benben/13-boshiamy.ja.md
+++ b/posts/benben/13-boshiamy.ja.md
@@ -1,7 +1,7 @@
 ---
 title: この時代にまだ学んでる | 嘸蝦米入力メソッド
 date: 2023-08-31
-tags: [boshiamy]
+tags: [Boshiamy]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/B1HXrmRTn.gif

--- a/posts/benben/13-boshiamy.md
+++ b/posts/benben/13-boshiamy.md
@@ -1,7 +1,7 @@
 ---
 title: 什麼時代了還在學 | 嘸蝦米輸入法
 date: 2023-08-31
-tags: [boshiamy]
+tags: [Boshiamy]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/B1HXrmRTn.gif

--- a/posts/benben/13-boshiamy.zh-CN.md
+++ b/posts/benben/13-boshiamy.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: 什么时代了还在学 | 嘸蝦米输入法
 date: 2023-08-31
-tags: [boshiamy]
+tags: [Boshiamy]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/B1HXrmRTn.gif

--- a/posts/benben/14-2023-wrapped.en.md
+++ b/posts/benben/14-2023-wrapped.en.md
@@ -1,7 +1,7 @@
 ---
 title: 2023 Year-End Wrap-Up | Goals, Efficiency, Balance
 date: 2023-12-30
-tags: [Front-end]
+tags: [Frontend]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/rydsCO3Da.png

--- a/posts/benben/14-2023-wrapped.ja.md
+++ b/posts/benben/14-2023-wrapped.ja.md
@@ -1,7 +1,7 @@
 ---
 title: 2023 年度振り返り | 目標、効率、バランス
 date: 2023-12-30
-tags: [Front-end]
+tags: [Frontend]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/rydsCO3Da.png

--- a/posts/benben/14-2023-wrapped.md
+++ b/posts/benben/14-2023-wrapped.md
@@ -1,7 +1,7 @@
 ---
 title: 2023 年度回顧 | 目標、效率、平衡
 date: 2023-12-30
-tags: [Front-end]
+tags: [Frontend]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/rydsCO3Da.png

--- a/posts/benben/14-2023-wrapped.zh-CN.md
+++ b/posts/benben/14-2023-wrapped.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: 2023 年度回顾 | 目标、效率、平衡
 date: 2023-12-30
-tags: [Front-end]
+tags: [Frontend]
 author: benben
 layout: layouts/post.njk
 image: https://hackmd.io/_uploads/rydsCO3Da.png

--- a/posts/benben/15-raycast-101.en.md
+++ b/posts/benben/15-raycast-101.en.md
@@ -1,7 +1,7 @@
 ---
 title: Raycast | An Incomplete Handbook
 date: 2025-07-31
-tags: [raycast, ai]
+tags: [Raycast, AI]
 author: benben
 layout: layouts/post.njk
 image: https://img.youtube.com/vi/NuIpZoQwuVY/0.jpg

--- a/posts/benben/15-raycast-101.ja.md
+++ b/posts/benben/15-raycast-101.ja.md
@@ -1,7 +1,7 @@
 ---
 title: Raycast | 不完全マニュアル
 date: 2025-07-31
-tags: [raycast, ai]
+tags: [Raycast, AI]
 author: benben
 layout: layouts/post.njk
 image: https://img.youtube.com/vi/NuIpZoQwuVY/0.jpg

--- a/posts/benben/15-raycast-101.md
+++ b/posts/benben/15-raycast-101.md
@@ -1,7 +1,7 @@
 ---
 title: Raycast | 不完全手冊
 date: 2025-07-31
-tags: [raycast, ai]
+tags: [Raycast, AI]
 author: benben
 layout: layouts/post.njk
 image: https://img.youtube.com/vi/NuIpZoQwuVY/0.jpg

--- a/posts/benben/15-raycast-101.zh-CN.md
+++ b/posts/benben/15-raycast-101.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: Raycast | 不完全手册
 date: 2025-07-31
-tags: [raycast, ai]
+tags: [Raycast, AI]
 author: benben
 layout: layouts/post.njk
 image: https://img.youtube.com/vi/NuIpZoQwuVY/0.jpg

--- a/posts/benben/16-reduce.en.md
+++ b/posts/benben/16-reduce.en.md
@@ -1,7 +1,7 @@
 ---
 title: 'Reduce | The Complete Handbook'
 date: 2026-05-16
-tags: [JavaScript, array]
+tags: [JavaScript, Array]
 author: benben
 layout: layouts/post.njk
 lang: en

--- a/posts/benben/16-reduce.ja.md
+++ b/posts/benben/16-reduce.ja.md
@@ -1,7 +1,7 @@
 ---
 title: 'Reduce | 完全マニュアル'
 date: 2026-05-16
-tags: [JavaScript, array]
+tags: [JavaScript, Array]
 author: benben
 layout: layouts/post.njk
 lang: ja

--- a/posts/benben/16-reduce.md
+++ b/posts/benben/16-reduce.md
@@ -1,7 +1,7 @@
 ---
 title: Reduce | 完全手冊
 date: 2026-05-16
-tags: [JavaScript, array]
+tags: [JavaScript, Array]
 author: benben
 layout: layouts/post.njk
 lang: zh-TW

--- a/posts/benben/16-reduce.zh-CN.md
+++ b/posts/benben/16-reduce.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: 'Reduce | 完全手册'
 date: 2026-05-16
-tags: [JavaScript, array]
+tags: [JavaScript, Array]
 author: benben
 layout: layouts/post.njk
 lang: zh-CN

--- a/posts/cian/base64-qrcode.md
+++ b/posts/cian/base64-qrcode.md
@@ -1,7 +1,7 @@
 ---
 title: 淺談 Base64 與應用實例分享
 date: 2021-10-21
-tags: [encode, HTML, image, QRcode]
+tags: [Encoding, HTML, Image, QR Code]
 author: cian
 layout: layouts/post.njk
 ---

--- a/posts/cian/grpc-streaming-n-http2.md
+++ b/posts/cian/grpc-streaming-n-http2.md
@@ -1,7 +1,7 @@
 ---
 title: gRPC 和 HTTP/2 Streaming
 date: 2021-10-03
-tags: [back-end, golang, gRPC, HTTP]
+tags: [Backend, Go, gRPC, HTTP]
 author: cian
 layout: layouts/post.njk
 ---

--- a/posts/cian/grpc-unary.md
+++ b/posts/cian/grpc-unary.md
@@ -1,7 +1,7 @@
 ---
 title: 使用 Golang 建立一個 gRPC 架構
 date: 2021-08-28
-tags: [back-end, JavaScript, golang]
+tags: [Backend, JavaScript, Go]
 author: cian
 layout: layouts/post.njk
 ---

--- a/posts/clay/next-seo.md
+++ b/posts/clay/next-seo.md
@@ -1,7 +1,7 @@
 ---
 title: next-seo 初體驗
 date: 2021-08-30
-tags: [JavaScript, next.js, SEO, schema]
+tags: [JavaScript, Next.js, SEO, Structured Data]
 author: clay
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/2022-03-27.md
+++ b/posts/cwc329/2022-03-27.md
@@ -1,7 +1,7 @@
 ---
 title: TS, JS 漫談 - 編譯與直譯
 date: 2022-03-27
-tags: [JavaScript, typescript, 'compiled language', 'interpreted language']
+tags: [JavaScript, TypeScript, Compiled Language, Interpreted Language]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/async-await-tips.md
+++ b/posts/cwc329/async-await-tips.md
@@ -1,7 +1,7 @@
 ---
 title: async/await 到底在等什麼？
 date: 2021-11-22
-tags: [JavaScript, async, await]
+tags: [JavaScript, Async, Await]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/circular-dependency.md
+++ b/posts/cwc329/circular-dependency.md
@@ -1,7 +1,7 @@
 ---
 title: 淺談工作上遇到的 Circular Dependency
 date: 2022-01-30
-tags: [JavaScript, 'circular dependency', eslint]
+tags: [JavaScript, Circular Dependency, ESLint]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/dev-tools-2.md
+++ b/posts/cwc329/dev-tools-2.md
@@ -1,7 +1,7 @@
 ---
 title: 優化舊有專案（二）：加入 CI/CD with github actions
 date: 2022-02-27
-tags: [back-end, 'CI/CD', 'github actions', heroku]
+tags: [Backend, CI/CD, GitHub Actions, Heroku]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/dev-tools.md
+++ b/posts/cwc329/dev-tools.md
@@ -1,7 +1,7 @@
 ---
 title: 優化舊有專案（一）：加入 dotenv, nodemon, babel 優化開發
 date: 2021-08-22
-tags: [back-end, JavaScript, dotenv, babel, nodemon]
+tags: [Backend, JavaScript, dotenv, Babel, nodemon]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/dig-in-source-code.md
+++ b/posts/cwc329/dig-in-source-code.md
@@ -1,7 +1,7 @@
 ---
 title: 原始碼探索
 date: 2021-09-18
-tags: [back-end, JavaScript, sequelize]
+tags: [Backend, JavaScript, Sequelize]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/django-url-shortener-dev-log.md
+++ b/posts/cwc329/django-url-shortener-dev-log.md
@@ -1,7 +1,7 @@
 ---
 title: 克服 Django-allauth 開發問題
 date: 2025-01-07
-tags: [python, django, django-allauth, csrf, cookie]
+tags: [Python, Django, django-allauth, CSRF, Cookie]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/gatus-demo.md
+++ b/posts/cwc329/gatus-demo.md
@@ -1,7 +1,7 @@
 ---
 title: Gatus demo
 date: 2022-09-08
-tags: [Gatus, monitoring, devops]
+tags: [Gatus, Monitoring, DevOps]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/improve-jest-coverage-report.md
+++ b/posts/cwc329/improve-jest-coverage-report.md
@@ -1,7 +1,7 @@
 ---
 title: 改善 CI/CD 中的 jest-coverage-report
 date: 2023-03-26
-tags: [devops, 'github actions', 'CI/CD']
+tags: [DevOps, GitHub Actions, CI/CD]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/leetcode-subsets-golang-slice.md
+++ b/posts/cwc329/leetcode-subsets-golang-slice.md
@@ -1,7 +1,7 @@
 ---
 title: Leetcode Subsets and Golang Slice
 date: 2024-08-28
-tags: [golang, leetcode]
+tags: [Go, LeetCode]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/monorepo.md
+++ b/posts/cwc329/monorepo.md
@@ -1,7 +1,7 @@
 ---
 title: monorepo 之我見
 date: 2021-12-26
-tags: [monorepo]
+tags: [Monorepo]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/multipart-form-data.md
+++ b/posts/cwc329/multipart-form-data.md
@@ -1,7 +1,7 @@
 ---
 title: multipart/form-data 初探
 date: 2022-04-30
-tags: ["RFC 7578", OpenAPI, multipart/form-data, RFC]
+tags: [RFC 7578, OpenAPI, multipart/form-data, RFC]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/cwc329/swagger-ui.md
+++ b/posts/cwc329/swagger-ui.md
@@ -1,7 +1,7 @@
 ---
 title: 初探 swagger-ui
 date: 2021-10-24
-tags: [swagger-ui, swagger-editor, API-doc, OpenAPI, npm]
+tags: [Swagger UI, Swagger Editor, API Documentation, OpenAPI, npm]
 author: cwc329
 layout: layouts/post.njk
 ---

--- a/posts/lavi/blog-log.md
+++ b/posts/lavi/blog-log.md
@@ -1,7 +1,7 @@
 ---
 title: 用 11ty 寫部落格的心得
 date: 2021-10-31
-tags: ["Eleventy", "JavaScript"]
+tags: [Eleventy, JavaScript]
 author: lavi
 layout: layouts/post.njk
 ---
@@ -284,7 +284,6 @@ template 本身有透過 `<meta>` 來做 [CSP](https://developer.mozilla.org/en-
 除此之外也還有一些樣式上的 bug 要處理就是。不過總算是有一個自己的平台可以開始累積內容 🙂。
 
 Big guy is john，感謝大家的觀看。
-
 
 
 

--- a/posts/lavi/deploy-and-cloud.md
+++ b/posts/lavi/deploy-and-cloud.md
@@ -1,7 +1,7 @@
 ---
 title: 從本地到雲端，淺談部署和各種部署姿勢
 date: 2021-08-12
-tags: [deploy]
+tags: [Deployment]
 author: lavi
 layout: layouts/post.njk
 ---

--- a/posts/lavi/react-ref-reference.md
+++ b/posts/lavi/react-ref-reference.md
@@ -1,7 +1,7 @@
 ---
 title: React Ref 的一點研究
 date: 2021-09-27
-tags: [react]
+tags: [React]
 author: lavi
 layout: layouts/post.njk
 ---
@@ -686,7 +686,6 @@ function Parent () {
 - [React.fowardRef](https://reactjs.org/docs/react-api.html#reactforwardref)
 - [Refs and the DOM](https://reactjs.org/docs/refs-and-the-dom.html)
 - [Forwarding Refs](https://reactjs.org/docs/forwarding-refs.html)
-
 
 
 

--- a/posts/minw/d3-intro.md
+++ b/posts/minw/d3-intro.md
@@ -1,7 +1,7 @@
 ---
 title: 再看 D3.js
 date: 2021-10-03
-tags: [data-vis]
+tags: [Data Visualization]
 author: minw
 layout: layouts/post.njk
 ---

--- a/posts/minw/nest-js-intro.md
+++ b/posts/minw/nest-js-intro.md
@@ -1,7 +1,7 @@
 ---
 title: 初探用 Nest.js 做出一個 CRUD 服務
 date: 2021-08-08
-tags: [back-end]
+tags: [Backend]
 author: minw
 layout: layouts/post.njk
 ---

--- a/posts/minw/nest-js-migration.md
+++ b/posts/minw/nest-js-migration.md
@@ -1,7 +1,7 @@
 ---
 title: 實作 Nest.js 中的 Migration 與 Seeder
 date: 2021-09-05
-tags: [back-end]
+tags: [Backend]
 author: minw
 layout: layouts/post.njk
 ---

--- a/posts/minw/product-interest.md
+++ b/posts/minw/product-interest.md
@@ -1,7 +1,7 @@
 ---
 title: 從開發到產品的心得
 date: 2021-11-07
-tags: [pm]
+tags: [Product Management]
 author: minw
 layout: layouts/post.njk
 ---

--- a/posts/ruofan/express-firestore.md
+++ b/posts/ruofan/express-firestore.md
@@ -1,7 +1,7 @@
 ---
 title: 用 Fireorm interact with Cloud Firestore
 date: 2021-12-17
-tags: [back-end]
+tags: [Backend]
 author: ruofan
 layout: layouts/post.njk
 image: /img/posts/ruofan/cloud-firestore.png

--- a/posts/ruofan/fcm.md
+++ b/posts/ruofan/fcm.md
@@ -1,7 +1,7 @@
 ---
 title: web Push Notifications
 date: 2022-03-13
-tags: [Front-end]
+tags: [Frontend]
 author: ruofan
 layout: layouts/post.njk
 ---

--- a/posts/ruofan/firestore.md
+++ b/posts/ruofan/firestore.md
@@ -1,7 +1,7 @@
 ---
 title: 儲存資料到 firestore 前，需要注意哪些事？
 date: 2022-04-16
-tags: [back-end]
+tags: [Backend]
 author: ruofan
 layout: layouts/post.njk
 ---

--- a/posts/ruofan/go-RESTful-api.md
+++ b/posts/ruofan/go-RESTful-api.md
@@ -1,7 +1,7 @@
 ---
 title: a simple RESTful api with Go
 date: 2022-01-01
-tags: [back-end]
+tags: [Backend]
 author: ruofan
 layout: layouts/post.njk
 image: /img/posts/ruofan/go-1.png

--- a/posts/ruofan/k6-load-testing.md
+++ b/posts/ruofan/k6-load-testing.md
@@ -1,7 +1,7 @@
 ---
 title: 用 k6 為 api 做 Load Testing
 date: 2021-08-07
-tags: [back-end]
+tags: [Backend]
 author: ruofan
 layout: layouts/post.njk
 image: https://k6.io/static/d34aede268b85c2821a801227fc9e696/80926/cloud-stub.webp
@@ -248,4 +248,3 @@ export default function () {
 
 
 在閱讀文章時如果有遇到什麼問題，或是有什麼建議，都歡迎留言告訴我，謝謝。😃
-

--- a/posts/ruofan/mongoose-aggregate.md
+++ b/posts/ruofan/mongoose-aggregate.md
@@ -1,7 +1,7 @@
 ---
 title: mongoose 中的 aggregate
 date: 2021-10-03
-tags: [back-end]
+tags: [Backend]
 author: ruofan
 layout: layouts/post.njk
 image: /img/posts/ruofan/mongoose.png

--- a/posts/ruofan/neo4j.md
+++ b/posts/ruofan/neo4j.md
@@ -1,7 +1,7 @@
 ---
 title: At a glance of Neo4j
 date: 2022-10-09
-tags: [back-end]
+tags: [Backend]
 author: ruofan
 layout: layouts/post.njk
 ---

--- a/posts/ruofan/new-architecture-react-native.md
+++ b/posts/ruofan/new-architecture-react-native.md
@@ -1,7 +1,7 @@
 ---
 title: New Architecture of Rreac Native
 date: 2025-01-26
-tags: [Front-end]
+tags: [Frontend]
 author: ruofan
 layout: layouts/post.njk
 ---

--- a/posts/ruofan/next-auth.md
+++ b/posts/ruofan/next-auth.md
@@ -1,7 +1,7 @@
 ---
 title: 用 NextAuth 實作第三方登入
 date: 2021-12-04
-tags: [Front-end]
+tags: [Frontend]
 author: ruofan
 layout: layouts/post.njk
 ---

--- a/posts/ruofan/postgresql-datatypes.md
+++ b/posts/ruofan/postgresql-datatypes.md
@@ -1,7 +1,7 @@
 ---
 title: HSTORE  vs JSONB in PostgreSQL
 date: 2022-06-29
-tags: [back-end]
+tags: [Backend]
 author: ruofan
 layout: layouts/post.njk
 image: /img/posts/ruofan/postgres.png

--- a/posts/ruofan/react-native.md
+++ b/posts/ruofan/react-native.md
@@ -1,7 +1,7 @@
 ---
 title: Setup your react native project
 date: 2022-08-13
-tags: [Front-end]
+tags: [Frontend]
 author: ruofan
 layout: layouts/post.njk
 ---

--- a/posts/ruofan/react-quill.md
+++ b/posts/ruofan/react-quill.md
@@ -1,7 +1,7 @@
 ---
 title: render quill delta 的方式
 date: 2021-11-07
-tags: [Front-end]
+tags: [Frontend]
 author: ruofan
 layout: layouts/post.njk
 ---

--- a/posts/ruofan/scroll-driven-animations.md
+++ b/posts/ruofan/scroll-driven-animations.md
@@ -1,7 +1,7 @@
 ---
 title: Scroll-driven Animations
 date: 2023-10-19
-tags: [Front-end]
+tags: [Frontend]
 author: ruofan
 layout: layouts/post.njk
 ---

--- a/posts/ruofan/svelte.md
+++ b/posts/ruofan/svelte.md
@@ -1,7 +1,7 @@
 ---
 title: svelte 結合 firebase 實作登入
 date: 2021-09-04
-tags: [Front-end]
+tags: [Frontend]
 author: ruofan
 layout: layouts/post.njk
 image: https://i.imgur.com/JIy4LhV.png

--- a/posts/ruofan/vue-infinite-scroll.md
+++ b/posts/ruofan/vue-infinite-scroll.md
@@ -1,7 +1,7 @@
 ---
 title: 用 Vue 實作 Infinite Scroll
 date: 2022-02-06
-tags: [Front-end]
+tags: [Frontend]
 author: ruofan
 layout: layouts/post.njk
 

--- a/posts/ruofan/xlsx.md
+++ b/posts/ruofan/xlsx.md
@@ -1,7 +1,7 @@
 ---
 title: 用 sheetJS 匯出 excel
 date: 2022-05-22
-tags: [Front-end]
+tags: [Frontend]
 author: ruofan
 layout: layouts/post.njk
 ---

--- a/posts/simon198/css-naming-conventions.md
+++ b/posts/simon198/css-naming-conventions.md
@@ -1,7 +1,7 @@
 ---
 title: 探討幾種常見的 CSS 命名慣例
 date: 2021-08-29
-tags: [Front-end, CSS]
+tags: [Frontend, CSS]
 author: simon198
 layout: layouts/post.njk
 ---

--- a/posts/simon198/google-searching-tips.md
+++ b/posts/simon198/google-searching-tips.md
@@ -1,7 +1,7 @@
 ---
 title: 如何準確的 Google 到想要的內容
 date: 2021-09-28
-tags: [google]
+tags: [Google]
 author: simon198
 layout: layouts/post.njk
 ---

--- a/posts/sixwings/deploy-nodejs-to-AWS-EB-beginner's-guide.md
+++ b/posts/sixwings/deploy-nodejs-to-AWS-EB-beginner's-guide.md
@@ -1,7 +1,7 @@
 ---
 title: 在 AWS EB 上部署 Nodejs 網站的入門指南
 date: 2021-10-05
-tags: [back-end,nodejs,AWS]
+tags: [Backend, Node.js, AWS]
 author: sixwings
 layout: layouts/post.njk
 ---

--- a/posts/sixwings/update-github-repo-from-template.md
+++ b/posts/sixwings/update-github-repo-from-template.md
@@ -1,7 +1,7 @@
 ---
 title: 如何從 GitHub Template 更新 repo？
 date: 2021-09-05
-tags: [github]
+tags: [GitHub]
 author: sixwings
 layout: layouts/post.njk
 ---

--- a/posts/tian/git-flow.en.md
+++ b/posts/tian/git-flow.en.md
@@ -1,7 +1,7 @@
 ---
 title: "GitFlow as I Understand It"
 date: 2021-10-28
-tags: [git, flow]
+tags: [Git, Git Flow]
 author: tian
 layout: layouts/post.njk
 lang: en

--- a/posts/tian/git-flow.ja.md
+++ b/posts/tian/git-flow.ja.md
@@ -1,7 +1,7 @@
 ---
 title: "私が理解している GitFlow"
 date: 2021-10-28
-tags: [git, flow]
+tags: [Git, Git Flow]
 author: tian
 layout: layouts/post.njk
 lang: ja

--- a/posts/tian/git-flow.md
+++ b/posts/tian/git-flow.md
@@ -1,7 +1,7 @@
 ---
 title: 我所理解的 GitFlow
 date: 2021-10-28
-tags: [git, flow]
+tags: [Git, Git Flow]
 author: tian
 layout: layouts/post.njk
 lang: zh-TW

--- a/posts/tian/git-flow.zh-CN.md
+++ b/posts/tian/git-flow.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 title: "我所理解的 GitFlow"
 date: 2021-10-28
-tags: [git, flow]
+tags: [Git, Git Flow]
 author: tian
 layout: layouts/post.njk
 lang: zh-CN

--- a/posts/tian/react-intl-automation.md
+++ b/posts/tian/react-intl-automation.md
@@ -1,7 +1,7 @@
 ---
 title: 如何使用 react-intl + babel plugin 自動化產出多國語系檔？
 date: 2022-01-31
-tags: [react, intl, internationalization, i18n, automation, babel, js, formatjs, ast]
+tags: [React Intl, Internationalization, Babel, FormatJS, Automation]
 author: tian
 layout: layouts/post.njk
 ---

--- a/posts/tian/ts-react-pattern-nested-todo-list.md
+++ b/posts/tian/ts-react-pattern-nested-todo-list.md
@@ -1,7 +1,7 @@
 ---
 title: 現代前端開發 - 那些我使用過的 Pattern 和 工具
 date: 2021-10-04
-tags: [typescript, react, react-hook-form, pattern, Todo-list, Front-end]
+tags: [TypeScript, React, React Hook Form, Design Patterns, Todo List]
 author: tian
 layout: layouts/post.njk
 ---

--- a/posts/tian/you-might-not-need-react-memo.md
+++ b/posts/tian/you-might-not-need-react-memo.md
@@ -1,7 +1,7 @@
 ---
 title: 你可能不需要 React Memo
 date: 2021-08-29
-tags: [performance, react, memo]
+tags: [Performance, React, React Memo]
 author: tian
 layout: layouts/post.njk
 ---

--- a/posts/umer/cookie-sameparty.md
+++ b/posts/umer/cookie-sameparty.md
@@ -1,7 +1,7 @@
 ---
 title: 介紹 Cookie 的新屬性 SameParty
 date: 2021-10-05
-tags: [cookie, google]
+tags: [Cookie, Google]
 author: umer
 layout: layouts/post.njk
 ---

--- a/posts/umer/google-extension.md
+++ b/posts/umer/google-extension.md
@@ -1,7 +1,7 @@
 ---
 title: 初探 Google extension
 date: 2021-09-09
-tags: [JavaScript, google-extension]
+tags: [JavaScript, Chrome Extension]
 author: umer
 layout: layouts/post.njk
 ---

--- a/posts/umer/line-bot.md
+++ b/posts/umer/line-bot.md
@@ -1,7 +1,7 @@
 ---
 title: 結合 Line bot 與 twitter 爬蟲的研究紀錄 實戰篇
 date: 2021-08-15
-tags: [JavaScript, line-bot]
+tags: [JavaScript, LINE Bot]
 author: umer
 layout: layouts/post.njk
 ---

--- a/posts/umer/weak-map.md
+++ b/posts/umer/weak-map.md
@@ -1,7 +1,7 @@
 ---
 title: 介紹 WeakMap
 date: 2021-11-12
-tags: [JavaScript, weap-map]
+tags: [JavaScript, WeakMap]
 author: umer
 layout: layouts/post.njk
 ---

--- a/posts/xiang/advanced-todo-list.md
+++ b/posts/xiang/advanced-todo-list.md
@@ -1,7 +1,7 @@
 ---
 title: 進階版 To do list
 date: 2021-09-12
-tags: [Front-end, JavaScript, Todo-list]
+tags: [Frontend, JavaScript, Todo List]
 author: xiang
 layout: layouts/post.njk
 image: https://blog.errorbaker.tw/img/posts/xiang/todo-03.png

--- a/posts/xiang/block-chain-01.md
+++ b/posts/xiang/block-chain-01.md
@@ -1,7 +1,7 @@
 ---
 title: 帶你入門區塊鏈（ㄧ）
 date: 2022-03-06
-tags: [block-chain, article]
+tags: [Blockchain]
 author: xiang
 layout: layouts/post.njk
 image:

--- a/posts/xiang/block-chain-02.md
+++ b/posts/xiang/block-chain-02.md
@@ -1,7 +1,7 @@
 ---
 title: 帶你入門區塊鏈（二）
 date: 2022-05-01
-tags: [block-chain, article]
+tags: [Blockchain]
 author: xiang
 layout: layouts/post.njk
 image:

--- a/posts/xiang/build-webcomponent-element.md
+++ b/posts/xiang/build-webcomponent-element.md
@@ -1,7 +1,7 @@
 ---
 title: 如何使用 Web Component 技術來製作元件
 date: 2021-11-07
-tags: [Front-end, JavaScript]
+tags: [Frontend, JavaScript]
 author: xiang
 layout: layouts/post.njk
 image:

--- a/posts/xiang/build-webcomponent-to-table.md
+++ b/posts/xiang/build-webcomponent-to-table.md
@@ -1,7 +1,7 @@
 ---
 title: 用 Web Component 製作客製化表格元件
 date: 2021-08-15
-tags: [Front-end, JavaScript]
+tags: [Frontend, JavaScript]
 author: xiang
 layout: layouts/post.njk
 image: https://blog.errorbaker.tw/img/posts/xiang/wc-table.png

--- a/posts/xiang/console-log.md
+++ b/posts/xiang/console-log.md
@@ -1,7 +1,7 @@
 ---
 title: 好玩 && 好用的 console log 技巧
 date: 2021-12-12
-tags: [Front-end, JavaScript]
+tags: [Frontend, JavaScript]
 author: xiang
 layout: layouts/post.njk
 image:

--- a/posts/xiang/cooperate-with-engineer-part2.md
+++ b/posts/xiang/cooperate-with-engineer-part2.md
@@ -1,7 +1,7 @@
 ---
 title: 從與工程師共事，到與工程師共識（二）
 date: 2022-02-06
-tags: [Front-end, back-end, article]
+tags: [Frontend, Backend]
 author: xiang
 layout: layouts/post.njk
 image:

--- a/posts/xiang/cooperate-with-engineer.md
+++ b/posts/xiang/cooperate-with-engineer.md
@@ -1,7 +1,7 @@
 ---
 title: 從與工程師共事，到與工程師共識（ㄧ）
 date: 2022-01-09
-tags: [Front-end, back-end, article]
+tags: [Frontend, Backend]
 author: xiang
 layout: layouts/post.njk
 image:

--- a/posts/xiang/debug-case-01.md
+++ b/posts/xiang/debug-case-01.md
@@ -1,7 +1,7 @@
 ---
 title: Debug 系列 01
 date: 2021-10-10
-tags: [Front-end, JavaScript]
+tags: [Frontend, JavaScript]
 author: xiang
 layout: layouts/post.njk
 image:

--- a/posts/xiang/ga-basic.md
+++ b/posts/xiang/ga-basic.md
@@ -1,7 +1,7 @@
 ---
 title: 前端開發需了解的 GA 基礎
 date: 2022-11-05
-tags: [Front-end, article]
+tags: [Frontend]
 author: xiang
 layout: layouts/post.njk
 image:

--- a/posts/xiang/package-vue-project.md
+++ b/posts/xiang/package-vue-project.md
@@ -1,7 +1,7 @@
 ---
 title: 實作專案套件化
 date: 2022-04-03
-tags: [Front-end, article]
+tags: [Frontend]
 author: xiang
 layout: layouts/post.njk
 image:

--- a/scripts/check-tags.js
+++ b/scripts/check-tags.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+const taxonomy = require("../_data/tagTaxonomy.json");
+const langs = require("../_data/langs.json");
+const {
+  DEFAULT_LANG,
+  buildTopicMap,
+  compileTaxonomy,
+  extractFrontmatter,
+  sameTags,
+  validateTagRecord,
+} = require("../_11ty/tag-taxonomy");
+
+function walk(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(directory, entry.name);
+    return entry.isDirectory() ? walk(fullPath) : [fullPath];
+  });
+}
+
+function parsePost(filePath) {
+  const raw = fs.readFileSync(filePath, "utf8");
+  const frontmatter = extractFrontmatter(raw);
+  if (frontmatter === null) {
+    return { path: filePath, raw, data: null, parseIssue: "missing YAML frontmatter" };
+  }
+  try {
+    return {
+      path: filePath.split(path.sep).join("/"),
+      raw,
+      data: yaml.safeLoad(frontmatter) || {},
+      parseIssue: null,
+    };
+  } catch (error) {
+    return {
+      path: filePath,
+      raw,
+      data: null,
+      parseIssue: `invalid YAML frontmatter: ${error.message}`,
+    };
+  }
+}
+
+function sourcePathFor(post) {
+  const lang = post.data && post.data.lang;
+  if (!lang || lang === DEFAULT_LANG) return post.path;
+  if (!langs.includes(lang)) return null;
+  const suffix = `.${lang}.md`;
+  return post.path.endsWith(suffix)
+    ? `${post.path.slice(0, -suffix.length)}.md`
+    : null;
+}
+
+function auditPosts(postsDirectory = "posts") {
+  const taxonomyRegistry = compileTaxonomy(taxonomy);
+  const posts = walk(postsDirectory)
+    .filter((filePath) => filePath.endsWith(".md"))
+    .sort()
+    .map(parsePost);
+  const issues = [];
+
+  for (const post of posts) {
+    if (post.parseIssue) {
+      issues.push({ code: "frontmatter", path: post.path, message: post.parseIssue });
+      continue;
+    }
+    issues.push(
+      ...validateTagRecord(
+        { path: post.path, raw: post.raw, tags: post.data.tags },
+        taxonomy
+      )
+    );
+  }
+
+  const byPath = new Map(posts.map((post) => [post.path, post]));
+  for (const translation of posts.filter(
+    (post) => post.data && post.data.lang && post.data.lang !== DEFAULT_LANG
+  )) {
+    const sourcePath = sourcePathFor(translation);
+    const source = sourcePath && byPath.get(sourcePath);
+    if (!source || !source.data) {
+      issues.push({
+        code: "translation-source",
+        path: translation.path,
+        message: "translated post has no matching source post",
+      });
+      continue;
+    }
+    if (!sameTags(source.data.tags, translation.data.tags)) {
+      issues.push({
+        code: "translation-tags",
+        path: translation.path,
+        message: `tags must exactly match ${source.path}: ${JSON.stringify(
+          source.data.tags
+        )}`,
+      });
+    }
+  }
+
+  const sourcePosts = posts.filter(
+    (post) =>
+      post.data &&
+      (!post.data.lang || post.data.lang === DEFAULT_LANG) &&
+      post.data.draft !== true &&
+      post.data.draft !== "true"
+  );
+  const topicMap = buildTopicMap(
+    sourcePosts.map((post) => ({
+      inputPath: post.path,
+      url: `/${post.path.replace(/\.md$/, "/")}`,
+      data: post.data,
+    })),
+    taxonomy
+  );
+  const usedCanonical = new Set(topicMap.map((topic) => topic.canonical));
+  const unusedTopics = taxonomyRegistry.topics
+    .map((topic) => topic.canonical)
+    .filter((canonical) => !usedCanonical.has(canonical));
+
+  return { issues, posts, sourcePosts, topicMap, unusedTopics };
+}
+
+function formatIssue(issue) {
+  return `  ${issue.path}\n    [${issue.code}] ${issue.message}`;
+}
+
+function main() {
+  let report;
+  try {
+    report = auditPosts(path.join(process.cwd(), "posts"));
+  } catch (error) {
+    console.error(`\n✖ Tag taxonomy is invalid\n\n${error.message}\n`);
+    process.exit(1);
+  }
+
+  if (report.issues.length > 0) {
+    console.error(`\n✖ Tag checks failed (${report.issues.length})\n`);
+    console.error(report.issues.map(formatIssue).join("\n"));
+    console.error("");
+    process.exit(1);
+  }
+
+  const assignments = report.sourcePosts.reduce(
+    (sum, post) => sum + post.data.tags.length,
+    0
+  );
+  console.log(
+    `✓ Tag checks passed: ${report.sourcePosts.length} source posts, ` +
+      `${report.topicMap.length} topics, ${assignments} assignments`
+  );
+  const candidates = report.topicMap.filter((topic) => topic.isCategoryCandidate);
+  if (candidates.length > 0) {
+    console.log("  Category candidates (advisory only):");
+    for (const topic of candidates) {
+      console.log(
+        `  - ${topic.canonical}: ${topic.postCount} posts / ${topic.authorCount} authors`
+      );
+    }
+  }
+  if (report.unusedTopics.length > 0) {
+    console.log(`  Unused registered topics: ${report.unusedTopics.join(", ")}`);
+  }
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  auditPosts,
+  parsePost,
+  sourcePathFor,
+};

--- a/tag-redirects.njk
+++ b/tag-redirects.njk
@@ -1,0 +1,8 @@
+---
+permalink: _redirects
+eleventyExcludeFromCollections: true
+sitemapExclude: true
+---
+{% for redirect in tagRedirects -%}
+{{ redirect.from }} {{ redirect.to }} {{ redirect.status }}!
+{% endfor -%}

--- a/test/test-tags.js
+++ b/test/test-tags.js
@@ -1,0 +1,144 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const taxonomy = require("../_data/tagTaxonomy.json");
+const { auditPosts } = require("../scripts/check-tags");
+const {
+  buildLegacyTagRedirects,
+  buildTopicMap,
+  compileTaxonomy,
+  sameTags,
+  topicUrlFor,
+  validateTagRecord,
+} = require("../_11ty/tag-taxonomy");
+
+function record(tags, line = `tags: [${tags.join(", ")}]`) {
+  return {
+    path: "posts/test/example.md",
+    tags,
+    raw: `---\ntitle: Example\n${line}\nauthor: test\n---\nBody\n`,
+  };
+}
+
+function syntheticPosts(count, authorCount) {
+  return Array.from({ length: count }, (_, index) => ({
+    url: `/posts/test/${index}/`,
+    data: {
+      author: `author-${index % authorCount}`,
+      tags: ["React", "posts"],
+    },
+  }));
+}
+
+describe("tag taxonomy", () => {
+  it("has a valid, complete registry with stable explicit slugs", () => {
+    const registry = compileTaxonomy(taxonomy);
+    assert.equal(registry.topics.length, 92);
+    assert.equal(topicUrlFor("Frontend", taxonomy), "/tags/frontend/");
+    assert.equal(topicUrlFor("Node.js", taxonomy), "/tags/node-js/");
+    assert.equal(topicUrlFor("Git", taxonomy, "ja"), "/ja/tags/git/");
+  });
+
+  it("requires a canonical one-line array containing one to five unique tags", () => {
+    assert.deepEqual(validateTagRecord(record(["React", "CSS"]), taxonomy), []);
+
+    const blockStyle = validateTagRecord(
+      record(["React", "CSS"], "tags:\n  - React\n  - CSS"),
+      taxonomy
+    );
+    assert.ok(blockStyle.some((issue) => issue.code === "tags-format"));
+
+    const tooMany = validateTagRecord(
+      record(["React", "CSS", "HTML", "JavaScript", "Vue", "Frontend"]),
+      taxonomy
+    );
+    assert.ok(tooMany.some((issue) => issue.code === "tags-count"));
+
+    const duplicate = validateTagRecord(record(["React", "React"]), taxonomy);
+    assert.ok(duplicate.some((issue) => issue.code === "tag-duplicate"));
+  });
+
+  it("reports aliases and retired values without silently rewriting content", () => {
+    const alias = validateTagRecord(record(["Front-end"]), taxonomy);
+    assert.equal(alias[0].code, "tag-noncanonical");
+    assert.equal(alias[0].expected, "Frontend");
+
+    const retired = validateTagRecord(record(["article"]), taxonomy);
+    assert.equal(retired[0].code, "tag-retired");
+    assert.equal(retired[0].expected, null);
+  });
+
+  it("defines only verified pre-canonicalization URL redirects", () => {
+    const redirects = buildLegacyTagRedirects(taxonomy);
+    assert.equal(redirects.length, 24);
+    assert.deepEqual(
+      redirects.find((redirect) => redirect.from === "/tags/front-end/"),
+      { from: "/tags/front-end/", to: "/tags/frontend/", status: 301 }
+    );
+    assert.deepEqual(
+      redirects.find((redirect) => redirect.from === "/tags/next.js/"),
+      { from: "/tags/next.js/", to: "/tags/next-js/", status: 301 }
+    );
+
+    const sources = redirects.map((redirect) => redirect.from);
+    assert.equal(new Set(sources).size, redirects.length);
+    assert.equal(sources.includes("/tags/article/"), false);
+    assert.equal(sources.includes("/tags/ast/"), false);
+    assert.equal(sources.some((source) => /^\/(?:en|ja|zh-CN)\//.test(source)), false);
+
+    const canonicalUrls = new Set(
+      compileTaxonomy(taxonomy).topics.map((topic) => `/tags/${topic.slug}/`)
+    );
+    assert.equal(
+      redirects.every(
+        (redirect) => redirect.status === 301 && canonicalUrls.has(redirect.to)
+      ),
+      true
+    );
+  });
+
+  it("uses both post and distinct-author thresholds for category candidates", () => {
+    assert.equal(buildTopicMap(syntheticPosts(7, 3), taxonomy)[0].isCategoryCandidate, false);
+    assert.equal(buildTopicMap(syntheticPosts(8, 2), taxonomy)[0].isCategoryCandidate, false);
+    assert.equal(buildTopicMap(syntheticPosts(8, 3), taxonomy)[0].isCategoryCandidate, true);
+  });
+
+  it("compares source and translation tags exactly, including order", () => {
+    assert.equal(sameTags(["Git", "Git Flow"], ["Git", "Git Flow"]), true);
+    assert.equal(sameTags(["Git", "Git Flow"], ["Git Flow", "Git"]), false);
+  });
+
+  it("keeps the checked-in corpus canonical and fully registered", () => {
+    const report = auditPosts("posts");
+    assert.deepEqual(report.issues, []);
+    assert.deepEqual(report.unusedTopics, []);
+    assert.equal(report.sourcePosts.length, 82);
+    assert.deepEqual(
+      report.topicMap
+        .filter((topic) => topic.isCategoryCandidate)
+        .map((topic) => [topic.canonical, topic.postCount, topic.authorCount]),
+      [
+        ["Frontend", 23, 4],
+        ["JavaScript", 20, 7],
+        ["Backend", 17, 6],
+      ]
+    );
+  });
+});
+
+describe("built topic pages", () => {
+  it("publishes permanent redirects for the verified legacy tag URLs", () => {
+    const lines = fs
+      .readFileSync("_site/_redirects", "utf8")
+      .split(/\r?\n/)
+      .filter(Boolean);
+    assert.equal(lines.length, 24);
+    assert.ok(lines.includes("/tags/front-end/ /tags/frontend/ 301!"));
+    assert.ok(lines.includes("/tags/next.js/ /tags/next-js/ 301!"));
+    assert.equal(lines.some((line) => line.startsWith("/tags/article/ ")), false);
+    assert.equal(lines.some((line) => line.startsWith("/tags/ast/ ")), false);
+    assert.equal(lines.some((line) => /^\/(?:en|ja|zh-CN)\//.test(line)), false);
+  });
+
+});


### PR DESCRIPTION
## 概述

把全站 tags 收斂為 92 個 canonical 主題：127 篇來源／譯文 frontmatter 正規化、新增 taxonomy 資料與 CI 強制檢查、為既有舊 slug 產生 24 條 301。本層是 4 層 stack 的第一層，純資料＋驗證，**不含任何 UI 變更**，可獨立部署。

## 變更內容

- `_data/tagTaxonomy.json`：92 topics、固定 slug、aliases 與 legacySlugs；`_11ty/tag-taxonomy.js` 提供驗證／查詢工具
- 127 篇 posts frontmatter：tags 統一 canonical label（單行 `tags: [...]`、每篇 1–5 個、不重複、譯文與來源完全一致含順序）
- `scripts/check-tags.js` 掛進 `build`、`test` 與 pre-commit，違規即擋
- `tag-redirects.njk` ＋ `_data/tagRedirects.js`：建置產生 `_site/_redirects`，24 條已驗證舊 slug 301（`front-end→frontend`、`golang→go`、`js→javascript`…）
- `test/test-tags.js`：taxonomy registry、格式／數量／重複／alias／retired 驗證、譯文一致性、24 條 redirect 斷言

## 驗證

- `npm run build` exit 0，96 tests passing；`✓ Tag checks passed: 82 source posts, 92 topics, 166 assignments`
- 舊 tags 模板照常運作：canonical label 經 slug filter 自動產生新 URL（`/tags/frontend/` 等），舊 URL 由 `_redirects` 301
- sitemap 無 404 連結

## 影響範圍與部署安全性

- 對讀者可見的變化：tag 顯示名稱統一（如 `front-end`→`Frontend`）、tag 頁 URL 改為 canonical slug（舊 URL 301）
- 分類候選（Frontend 23 篇／4 人、JavaScript 20／7、Backend 17／6）僅為建議報告，不自動升級

## 缺口審計（本層有意不做）

- 19 篇只有 Frontend／Backend 大類的文章：leaf topic 需人工補標，未依標題猜測
- 主題地圖 UI 在 Stack 3；本層 tag 頁維持舊版全文展開樣式

## 合併順序

Stack 順序：**1/4（本 PR）→ 2/4 i18n 文案 → 3/4 UI → 4/4 搜尋**。本 PR 合併後，請把 Stack 2/4 的 base 重新指向 main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)