### PR TITLE
[Stack 3/4] feat(ui): editorial header、閱讀工具、主題地圖與 404 在地化

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -60,6 +60,13 @@ const isDraftFrontmatter = require("./_11ty/draftFlag");
 const { buildAiCrawlRules } = require("./_11ty/aiCrawlPolicy");
 const { commentCountsByPath } = require("./_11ty/discussions");
 const { CSS_FILES } = require("./_11ty/css-bundle");
+const TAG_TAXONOMY = require("./_data/tagTaxonomy.json");
+const {
+  buildTopicMap,
+  tagIndexVersions,
+  topicUrlFor,
+  topicVersions,
+} = require("./_11ty/tag-taxonomy");
 const {
   effectivePublishedDate,
   effectiveModifiedDate,
@@ -157,6 +164,14 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter("cssmin", function (code) {
     return new CleanCSS({}).minify(code).styles;
   });
+
+  // Canonical topic URLs never depend on Eleventy's slug filter: changing a
+  // display label cannot silently move an established topic page.
+  eleventyConfig.addFilter("tagUrl", function (canonical, lang) {
+    return topicUrlFor(canonical, TAG_TAXONOMY, lang);
+  });
+  eleventyConfig.addFilter("topicVersions", topicVersions);
+  eleventyConfig.addFilter("tagIndexVersions", tagIndexVersions);
 
   eleventyConfig.addFilter("readableDate", (dateObj) => {
     return DateTime.fromJSDate(dateObj, { zone: "utc" }).toFormat(
@@ -485,6 +500,60 @@ module.exports = function (eleventyConfig) {
       .filter((item) => isVisible(item) && postLang(item) === DEFAULT_LANG);
   });
 
+  const visiblePostsForLang = (collectionApi, lang) =>
+    collectionApi
+      .getFilteredByTag("posts")
+      .filter((item) => isVisible(item) && postLang(item) === lang);
+
+  const sourceTopicMap = (collectionApi) =>
+    buildTopicMap(
+      visiblePostsForLang(collectionApi, DEFAULT_LANG),
+      TAG_TAXONOMY,
+      { lang: DEFAULT_LANG }
+    );
+
+  // The source-language map owns corpus-wide counts and the advisory category
+  // threshold. Translations get their own post lists/counts but inherit only
+  // the candidate flag, never the source articles themselves.
+  eleventyConfig.addCollection("topicMap", function (collectionApi) {
+    return sourceTopicMap(collectionApi);
+  });
+
+  eleventyConfig.addCollection("localizedTopicMaps", function (collectionApi) {
+    const sourceMap = sourceTopicMap(collectionApi);
+    const candidateIds = new Set(
+      sourceMap.filter((topic) => topic.isCategoryCandidate).map((topic) => topic.id)
+    );
+    return activeLanguages(IS_DEVELOPMENT)
+      .filter((lang) => lang !== DEFAULT_LANG)
+      .map((lang) => ({
+        lang,
+        url: `/${lang}/tags/`,
+        topics: buildTopicMap(
+          visiblePostsForLang(collectionApi, lang),
+          TAG_TAXONOMY,
+          { lang, candidateIds }
+        ),
+      }));
+  });
+
+  eleventyConfig.addCollection("topicPages", function (collectionApi) {
+    const sourceMap = sourceTopicMap(collectionApi);
+    const candidateIds = new Set(
+      sourceMap.filter((topic) => topic.isCategoryCandidate).map((topic) => topic.id)
+    );
+    const localized = activeLanguages(IS_DEVELOPMENT)
+      .filter((lang) => lang !== DEFAULT_LANG)
+      .flatMap((lang) =>
+        buildTopicMap(
+          visiblePostsForLang(collectionApi, lang),
+          TAG_TAXONOMY,
+          { lang, candidateIds }
+        )
+      );
+    return sourceMap.concat(localized);
+  });
+
   // Activate a localized section only after that language has at least one
   // visible translated post. Draft translations count in local `--serve`
   // previews but never create empty, indexable production home/About/feed URLs.
@@ -560,8 +629,6 @@ module.exports = function (eleventyConfig) {
     }
     return map;
   });
-
-  eleventyConfig.addCollection("tagList", require("./_11ty/getTagList"));
 
   eleventyConfig.addPassthroughCopy("img");
   // Component and base CSS are build-only inputs inlined by optimize-html.

--- a/404-i18n.njk
+++ b/404-i18n.njk
@@ -1,23 +1,24 @@
 ---
-# Per-language 404 pages: /en/404.html, /ja/404.html, /zh-CN/404.html
-# (the zh-TW 404 is 404.njk at /404.html). Netlify's [[redirects]] rule with
-# status = 404 serves /<lang>/404.html for any unmatched /<lang>/* path, so a
-# reader hitting /ja/posts/bad-slug/ sees the Japanese 404 instead of zh-TW.
+# Localized not-found documents. Netlify routes missing locale-prefixed URLs
+# to these files with a real HTTP 404 status (see netlify.toml).
 layout: layouts/home.njk
-eleventyExcludeFromCollections: true
 pagination:
   data: collections.siteLangsWithPublishedPosts
   size: 1
-  alias: fplang
+  alias: notFoundLang
   filter:
     - zh-TW
-permalink: "/{{ fplang }}/404.html"
+permalink: "/{{ notFoundLang }}/404.html"
+eleventyExcludeFromCollections: true
+sitemapExclude: true
 eleventyComputed:
-  lang: "{{ fplang }}"
-  title: "{{ i18n[fplang].notFoundTitle }}"
+  lang: "{{ notFoundLang }}"
+  title: "{{ i18n[notFoundLang].notFoundTitle }}"
 ---
-<p style="font-size: 3rem" aria-hidden="true">🍞🔥</p>
 
-<p>{{ i18n[fplang].notFoundBody }}</p>
-
-<a href="{{ ('/' + fplang + '/') | url }}">{{ i18n[fplang].notFoundHome }}</a>
+{% set nt = i18n[notFoundLang] %}
+<div class="not-found">
+  <p class="not-found__mark" aria-hidden="true">🍞🔥</p>
+  <p>{{ nt.notFoundBody }}</p>
+  <p><a href="{{ ('/' + notFoundLang + '/') | url }}">{{ nt.notFoundHome }}</a></p>
+</div>

--- a/404.njk
+++ b/404.njk
@@ -2,12 +2,13 @@
 layout: layouts/home.njk
 permalink: 404.html
 eleventyExcludeFromCollections: true
+sitemapExclude: true
 eleventyComputed:
   title: "{{ i18n['zh-TW'].notFoundTitle }}"
 ---
 
-<p style="font-size: 3rem" aria-hidden="true">🍞🔥</p>
-
-<p>{{ i18n['zh-TW'].notFoundBody }}</p>
-
-<a href="{{ '/' | url }}">{{ i18n['zh-TW'].notFoundHome }}</a>
+<div class="not-found">
+  <p class="not-found__mark" aria-hidden="true">🍞🔥</p>
+  <p>{{ i18n["zh-TW"].notFoundBody }}</p>
+  <p><a href="{{ '/' | url }}">{{ i18n["zh-TW"].notFoundHome }}</a></p>
+</div>

--- a/_11ty/apply-csp.js
+++ b/_11ty/apply-csp.js
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
 const cspHashGen = require("csp-hash-generator");
 const syncPackage = require("browser-sync/package.json");
 
@@ -49,7 +49,11 @@ const addCspHash = async (rawContent, outputPath) => {
   let content = rawContent;
 
   if (outputPath && outputPath.endsWith(".html")) {
-    const dom = new JSDOM(content);
+    const dom = new JSDOM(content, {
+      // jsdom 15 reports modern CSS syntax (for example color-mix()) as a
+      // stylesheet parse warning even though the HTML DOM is valid.
+      virtualConsole: new VirtualConsole(),
+    });
     const cspAble = [
       ...dom.window.document.querySelectorAll("script[csp-hash]"),
     ];

--- a/_11ty/css-bundle.js
+++ b/_11ty/css-bundle.js
@@ -11,6 +11,8 @@ const CSS_FILES = Object.freeze([
   "css/main.css",
   "css/components/lang-suggest.css",
   "css/components/header-nav.css",
+  "css/components/reader-tools.css",
+  "css/components/not-found.css",
 ]);
 
 function readCssBundle() {

--- a/_11ty/img-dim.js
+++ b/_11ty/img-dim.js
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
 const { promisify } = require("util");
 const sizeOf = promisify(require("image-size"));
 const blurryPlaceholder = require("./blurry-placeholder");
@@ -208,7 +208,11 @@ const dimImages = async (rawContent, outputPath) => {
   let content = rawContent;
 
   if (outputPath && outputPath.endsWith(".html")) {
-    const dom = new JSDOM(content);
+    const dom = new JSDOM(content, {
+      // jsdom 15 reports modern CSS syntax (for example color-mix()) as a
+      // stylesheet parse warning even though the HTML DOM is valid.
+      virtualConsole: new VirtualConsole(),
+    });
     const images = [...dom.window.document.querySelectorAll("img,amp-img")];
 
     if (images.length > 0) {

--- a/_11ty/json-ld.js
+++ b/_11ty/json-ld.js
@@ -19,7 +19,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
 const { isDateOnly } = require("./publication-dates");
 
 function isHttpUrl(value) {
@@ -86,7 +86,11 @@ const validateJsonLd = (rawContent, outputPath) => {
   if (!outputPath || !outputPath.endsWith(".html")) return rawContent;
   if (!rawContent.includes("application/ld+json")) return rawContent;
 
-  const dom = new JSDOM(rawContent);
+  const dom = new JSDOM(rawContent, {
+    // jsdom 15 reports modern CSS syntax (for example color-mix()) as a
+    // stylesheet parse warning even though the HTML DOM is valid.
+    virtualConsole: new VirtualConsole(),
+  });
   const blocks = [
     ...dom.window.document.querySelectorAll("script[type='application/ld+json']"),
   ];

--- a/_11ty/link-target.js
+++ b/_11ty/link-target.js
@@ -1,11 +1,15 @@
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
 const BASE_URL = require("../_data/metadata.json").url;
 
 const linkTarget = async (rawContent, outputPath) => {
   let content = rawContent;
 
   if (outputPath && outputPath.endsWith(".html")) {
-    const dom = new JSDOM(content);
+    const dom = new JSDOM(content, {
+      // jsdom 15 reports modern CSS syntax (for example color-mix()) as a
+      // stylesheet parse warning even though the HTML DOM is valid.
+      virtualConsole: new VirtualConsole(),
+    });
     const links = [...dom.window.document.querySelectorAll("a")];
 
     if (links.length > 0) {

--- a/_11ty/optimize-html.js
+++ b/_11ty/optimize-html.js
@@ -93,7 +93,10 @@ const purifyCss = async (rawContent, outputPath) => {
       // Language-aware typography selectors (`:lang(ja) article` etc.) start
       // with a functional pseudo-class purgecss@2 can't match against content,
       // so the whole rule group is dropped without this.
-      whitelistPatterns: [/^:lang/],
+      // topic-card--candidate / topic-card__badge render only while a
+      // category candidate exists in the corpus; keep the whole topic-*
+      // family so a candidate-free build cannot strip their styling.
+      whitelistPatterns: [/^:lang/, /^search-/, /^topic-/],
     });
 
     const after = csso.minify(purged[0].css).css;

--- a/_data/eleventyComputed.js
+++ b/_data/eleventyComputed.js
@@ -56,6 +56,9 @@ function localizedShellPermalink(data) {
   if (/about-i18n\.njk$/.test(inputPath) && data.alang) {
     return `/${data.alang}/about/`;
   }
+  if (/404-i18n\.njk$/.test(inputPath) && data.notFoundLang) {
+    return `/${data.notFoundLang}/404.html`;
+  }
   if (/feed\/feed-i18n\.njk$/.test(inputPath) && data.flang) {
     return `/${data.flang}/feed/feed.xml`;
   }
@@ -69,9 +72,6 @@ function localizedShellPermalink(data) {
     data.ap.author
   ) {
     return `/${data.ap.lang}/posts/${data.ap.author}/`;
-  }
-  if (/404-i18n\.njk$/.test(inputPath) && data.fplang) {
-    return `/${data.fplang}/404.html`;
   }
   return null;
 }
@@ -91,13 +91,17 @@ function localizedShellPermalink(data) {
 function localizedShellIsActive(data) {
   const inputPath = data.page && data.page.inputPath;
   const localizedShell =
-    /(?:home-i18n|about-i18n|feed\/(?:feed|json)-i18n|author-langs|404-i18n)\.njk$/.test(
+    /(?:home-i18n|about-i18n|404-i18n|feed\/(?:feed|json)-i18n|author-langs)\.njk$/.test(
       inputPath || ""
     );
   if (!localizedShell) return true;
 
   const lang =
-    data.hlang || data.alang || data.flang || (data.ap && data.ap.lang) || data.fplang;
+    data.hlang ||
+    data.alang ||
+    data.notFoundLang ||
+    data.flang ||
+    (data.ap && data.ap.lang);
   const active = data.activeLangs || ["zh-TW"];
   return Boolean(lang && active.includes(lang));
 }

--- a/_data/metadata.json
+++ b/_data/metadata.json
@@ -3,7 +3,7 @@
   "url": "https://blog.errorbaker.tw",
   "ogimage": "https://blog.errorbaker.tw/img/ogimage.png",
   "domain": "blog.errorbaker.tw",
-  "description": "錯誤烘焙師，從錯誤中學習",
+  "description": "一群烘焙師，把踩過的坑烘成熱騰騰的技術麵包",
   "googleAnalyticsId": "",
   "sendWebVitals": false,
   "feed": {

--- a/_includes/gx-author-profile.njk
+++ b/_includes/gx-author-profile.njk
@@ -9,8 +9,8 @@
       {%- endif -%}
       Lv.{{ stat.level }} · {{ t.gx.tier[stat.tier] }}</span>
     {%- if stat.rank %}<span class="gx-profile__rank">#{{ stat.rank }}</span>{% endif %}
-    <span class="gx-profile__count">{{ stat.count }} {{ t.postsUnit or '篇' }}</span>
-    {%- if stat.comments %}<span class="gx-comments" title="{{ stat.comments }} {{ t.gx.commentsUnit }}">💬 {{ stat.comments }}</span>{% endif %}
+    <span class="gx-profile__count">{{ stat.count }} {{ t.postUnit if stat.count == 1 else t.postsUnit }}</span>
+    {%- if stat.comments %}<span class="gx-comments" title="{{ stat.comments }} {{ t.gx.commentUnit if stat.comments == 1 else t.gx.commentsUnit }}">💬 {{ stat.comments }}</span>{% endif %}
     {%- if stat.mostDiscussed %}<span class="gx-badge gx-badge--discussed">{{ t.gx.mostDiscussed }}</span>{% endif %}
     {%- if stat.medal %}<span class="gx-profile__medal">{{ stat.medal }}</span>{% endif %}
   </div>
@@ -21,7 +21,7 @@
   <div class="gx-cal">
     <div class="gx-periods">
       {%- for c in cal.cells %}
-      <div class="gx-period" title="{{ c.year }} Q{{ c.quarter }} · {{ c.count }} {{ t.postsUnit or '篇' }}">
+      <div class="gx-period" title="{{ c.year }} Q{{ c.quarter }} · {{ c.count }} {{ t.postUnit if c.count == 1 else t.postsUnit }}">
         <i class="gx-cell" data-level="{{ c.level }}"></i>
         <span class="gx-period__lbl"><b>{% if c.quarter == 1 or loop.first %}{{ c.year }}{% endif %}</b>Q{{ c.quarter }}</span>
       </div>

--- a/_includes/layouts/about.njk
+++ b/_includes/layouts/about.njk
@@ -36,11 +36,11 @@ templateClass: tmpl-about
           <svg class="gx-toque" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="6.5" cy="9" r="4.5"/><circle cx="12" cy="7" r="5.5"/><circle cx="17.5" cy="9" r="4.5"/><rect x="7" y="12" width="10" height="7" rx="1.5"/></svg>
           {%- endif -%}
           Lv.{{ a.level }}</span>
-        <span class="author-row__count">{{ a.count }} {{ t.postsUnit or '篇' }}</span>
-        {%- if a.comments %}<span class="gx-comments" title="{{ a.comments }} {{ t.gx.commentsUnit }}">💬 {{ a.comments }}</span>{% endif %}
+        <span class="author-row__count">{{ a.count }} {{ t.postUnit if a.count == 1 else t.postsUnit }}</span>
+        {%- if a.comments %}<span class="gx-comments" title="{{ a.comments }} {{ t.gx.commentUnit if a.comments == 1 else t.gx.commentsUnit }}">💬 {{ a.comments }}</span>{% endif %}
         {%- if a.mostDiscussed %}<span class="gx-badge gx-badge--discussed">{{ t.gx.mostDiscussed }}</span>{% endif %}
       </h3>
-      <div class="gx-bar" role="img" aria-label="{{ a.count }} {{ t.postsUnit or '篇' }}">
+      <div class="gx-bar" role="img" aria-label="{{ a.count }} {{ t.postUnit if a.count == 1 else t.postsUnit }}">
         <span class="gx-bar__fill gx-tier-{{ a.tier }}" style="width: {{ a.pct }}%"></span>
       </div>
       <p class="author-row__intro">{{ bio | safe }}</p>

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -10,6 +10,10 @@
       translations collection. Only zh-TW + langs with a generated page are
       listed, so the switcher/hreflang never link to an empty author page. #}
   {%- set langVersions = collections.siteLangsWithPublishedPosts | authorVersions(collections.authorLangPages, translationKey) %}
+{%- elif translationKey == 'tags' %}
+  {%- set langVersions = collections.siteLangsWithPublishedPosts | tagIndexVersions %}
+{%- elif topicId %}
+  {%- set langVersions = collections.topicPages | topicVersions(topicId) %}
 {%- elif translationKey %}
   {%- set langVersions = collections.translations[translationKey] %}
 {%- else %}
@@ -106,7 +110,7 @@
     <link rel="alternate" href="{{ jsonFeedPath | url }}" type="application/feed+json" title="{{ t.siteName or metadata.title }} (JSON Feed)">
 
     <link rel="preconnect" href="/" crossorigin>
-    <script async defer src="{{ "/js/min.js" | addHash }}"
+    <script defer src="{{ "/js/min.js" | addHash }}"
       {% if webvitals %}data-cwv-src="{{ "/js/web-vitals.js" | addHash }}"{% endif %}>
     </script>
     {% if googleanalytics %}
@@ -129,8 +133,11 @@
       const LIGHT = "light";
       
       (function initTheme() {
-        const currentTheme =
-          localStorage.getItem("theme") ||
+        let currentTheme;
+        try {
+          currentTheme = localStorage.getItem("theme");
+        } catch (e) {}
+        currentTheme = currentTheme ||
           (window.matchMedia("(prefers-color-scheme: dark)").matches ? DARK : LIGHT);
         if (currentTheme === DARK) {
           bodyEl.classList.add(DARK);
@@ -141,16 +148,9 @@
         const toggleEl = document.querySelector("#color-scheme-toggle");
         toggleEl.addEventListener("click", handleToggleEvent);
 
-        // The markup ships the light-mode icon; initTheme only sets the class.
-        // Sync the icon (and utterances, when present) with the theme applied
-        // at load, so dark-mode visitors see the sun icon before any click.
-        if (bodyEl.classList.contains(DARK)) {
-          const toggleImg = toggleEl.querySelector("img");
-          toggleImg.src = toggleImg.src.replace(DARK, LIGHT);
-          if (document.querySelector('script[src*="utteranc.es"]')) {
-            setUtterancesTheme(DARK);
-          }
-        }
+        // The icon shows the theme users can switch to. Keep its accessible
+        // action name and pressed state in sync with the actual theme.
+        syncThemeControl(bodyEl.classList.contains(DARK) ? DARK : LIGHT);
 
         function handleToggleEvent() {
           const apply = () => {
@@ -158,7 +158,9 @@
             document.documentElement.classList.toggle(DARK, isDark);
             const theme = isDark ? DARK : LIGHT;
             setTheme(theme);
-            localStorage.setItem("theme", theme);
+            try {
+              localStorage.setItem("theme", theme);
+            } catch (e) {}
           };
           // Cross-fade the whole page between themes where supported.
           if (
@@ -172,14 +174,21 @@
         }
 
         function setTheme(theme) {
-          const toggleImg = toggleEl.querySelector("img");
+          syncThemeControl(theme);
           if (theme === DARK) {
             setUtterancesTheme(DARK);
-            toggleImg.src = toggleImg.src.replace(DARK, LIGHT);
           } else {
             setUtterancesTheme(LIGHT);
-            toggleImg.src = toggleImg.src.replace(LIGHT, DARK);
           }
+        }
+
+        function syncThemeControl(theme) {
+          const isDark = theme === DARK;
+          toggleEl.setAttribute("aria-pressed", String(isDark));
+          toggleEl.setAttribute(
+            "aria-label",
+            isDark ? toggleEl.dataset.labelToLight : toggleEl.dataset.labelToDark
+          );
         }
 
         // Mobile nav + language menu
@@ -190,11 +199,16 @@
         function closeNav() {
           nav.classList.remove("nav-open");
           navToggle.setAttribute("aria-expanded", "false");
+          navToggle.setAttribute("aria-label", navToggle.dataset.labelOpen);
         }
 
         navToggle.addEventListener("click", () => {
           const open = nav.classList.toggle("nav-open");
           navToggle.setAttribute("aria-expanded", open);
+          navToggle.setAttribute(
+            "aria-label",
+            open ? navToggle.dataset.labelClose : navToggle.dataset.labelOpen
+          );
           if (!open && langSwitch) langSwitch.removeAttribute("open");
         });
 
@@ -222,23 +236,25 @@
       });
     </script>
     <header>
-      <nav aria-label="{{ t.menu }}">
+      <nav aria-label="{{ t.primaryNavigation }}">
         <div id="nav">
           <p class="site-title">
-            <a href="{{ homeUrl | url }}" title="Homepage">{{ t.siteName or metadata.title }}</a>
+            <a href="{{ homeUrl | url }}" title="{{ t.homeLabel }}" aria-label="{{ t.siteName or metadata.title }}">
+              {{ t.siteName or metadata.title }}
+            </a>
           </p>
-          <button id="nav-toggle" class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
-            <span class="visually-hidden">{{ t.menu }}</span>
-            <span class="nav-toggle__bars" aria-hidden="true"></span>
-          </button>
           {#- Read more about `eleventy-navigation` at https://www.11ty.dev/docs/plugins/navigation/ #}
           <div id="site-menu" class="nav__links">
-          {#- zh-TW shows the full chrome (Archive/Tags/About). Other languages
-              only have a translated About + Home, so Archive/Tags (zh-TW-only
-              browse) are hidden and About points at the per-language page. #}
+          {#- Archive remains source-language only. Tags and About have localized
+              shells whenever that language has a published translation. #}
           {%- for entry in collections.all | eleventyNavigation %}
-            {%- if pageLang == 'zh-TW' or entry.key == 'About' %}
-            {%- set navHref = ('/' + pageLang + '/about/') if (pageLang != 'zh-TW' and entry.key == 'About') else entry.url %}
+            {%- if pageLang == 'zh-TW' or entry.key == 'About' or entry.key == 'Tags' %}
+            {%- set navHref = entry.url %}
+            {%- if pageLang != 'zh-TW' and entry.key == 'About' %}
+              {%- set navHref = '/' + pageLang + '/about/' %}
+            {%- elif pageLang != 'zh-TW' and entry.key == 'Tags' %}
+              {%- set navHref = '/' + pageLang + '/tags/' %}
+            {%- endif %}
             <a class="nav__link" href="{{ navHref | url }}">{{ i18n[pageLang]['nav_' + entry.key] or entry.title }}</a>
             {%- endif %}
           {%- endfor %}
@@ -264,8 +280,32 @@
             </ul>
           </details>
           </div>
-          <button id="color-scheme-toggle" type="button" aria-label="{{ t.toggleTheme or 'switch dark mode' }}">
-            <img src="{{ '/img/dark.svg' | url }}" alt="" />
+          <button id="color-scheme-toggle" type="button" aria-pressed="false"
+            aria-label="{{ t.switchToDarkTheme }}"
+            data-label-to-dark="{{ t.switchToDarkTheme }}"
+            data-label-to-light="{{ t.switchToLightTheme }}">
+            {#- Original brand icons from img/dark.svg / img/light.svg, inlined
+                with currentColor so both themes tint them without filters. #}
+            <svg class="theme-icon theme-icon--dark" viewBox="0 0 116 125" aria-hidden="true" focusable="false">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M59.4294 2.67585C47.3407 19.8194 46.4764 43.3554 59.0134 61.6878C71.5503 80.0203 93.7972 87.7513 114.158 82.7037C110.7 87.6081 106.323 91.9892 101.078 95.5758C77.5013 111.699 45.3177 105.657 29.1942 82.0802C13.0707 58.5033 19.1129 26.3197 42.6898 10.1962C47.9343 6.60961 53.6047 4.11983 59.4294 2.67585Z"/>
+            </svg>
+            <svg class="theme-icon theme-icon--light" viewBox="0 0 150 150" aria-hidden="true" focusable="false">
+              <ellipse cx="74.7805" cy="73.7101" rx="48.0776" ry="47.0013"/>
+              <path d="M75.0001 0L87.3955 20.9888H62.6047L75.0001 0Z"/>
+              <path d="M73.855 150L61.4596 129.011L86.2504 129.011L73.855 150Z"/>
+              <path d="M150 73.3208L128.531 85.4387L128.531 61.2029L150 73.3208Z"/>
+              <path d="M131.838 22.9675L123.527 45.8005L107.456 27.3469L131.838 22.9675Z"/>
+              <path d="M132.271 127.071L108.325 120.798L125.854 103.661L132.271 127.071Z"/>
+              <path d="M-1.13718e-09 73.6849L21.4695 85.8028L21.4695 61.567L-1.13718e-09 73.6849Z"/>
+              <path d="M15.8459 19.9688L22.2622 43.3788L39.7919 26.2415L15.8459 19.9688Z"/>
+              <path d="M15.8459 127.071L39.792 120.798L22.2622 103.661L15.8459 127.071Z"/>
+            </svg>
+          </button>
+          {#- Keep the primary menu at the outer edge on mobile: the theme
+              control is a quick setting; the menu is the main navigation. #}
+          <button id="nav-toggle" class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu"
+            aria-label="{{ t.openMenu }}" data-label-open="{{ t.openMenu }}" data-label-close="{{ t.closeMenu }}">
+            <span class="nav-toggle__bars" aria-hidden="true"></span>
           </button>
         </div>
         <div id="reading-progress" aria-hidden="true"></div>
@@ -274,7 +314,8 @@
       {% block extraArticleHeader %}{% endblock %}
       {#- data-ui feeds src/main.js the page-language UI strings (toasts etc.),
           following the lang-suggest data-strings pattern. #}
-      <dialog id="message" data-ui="{{ t.js | dump }}"></dialog>
+      <dialog id="message" role="status" aria-live="polite" aria-atomic="true"
+        data-ui="{{ t.js | dump }}"></dialog>
       {% if googleanalytics %}
       <noscript>
         <img src="/.netlify/functions/ga?v=1&_v=j83&t=pageview&dr=https%3A%2F%2Fno-script.com&_s=1&dh={{ metadata.domain | encodeURIComponent }}&dp={{ page.url | encodeURIComponent }}&ul=en-us&de=UTF-8&dt={{title|encodeURIComponent}}&tid={{googleanalytics}}" width="1" height="1"
@@ -316,16 +357,23 @@
     </aside>
     {%- endif %}
 
-    {#- Revealed by src/main.js after ~1.5 screens of scrolling. Rendered here
-        (hidden) so its styles survive the per-page PurgeCSS pass. #}
-    <button id="back-to-top" class="back-to-top" type="button" hidden
-      aria-label="{{ t.backToTop or '回到頂端' }}" on-click="backToTop">↑</button>
+    {#- Back-to-top is the only fixed reading action. Article sharing lives in
+        the post flow, so neither control can cover the other or the comments. #}
+    <div class="reader-tools" hidden>
+      <button id="back-to-top" class="reader-tool back-to-top" type="button" hidden
+        aria-label="{{ t.backToTop }}" on-click="backToTop">
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M6 10l6-6 6 6M12 4v16"/>
+        </svg>
+        <span class="reader-tool__label" aria-hidden="true">{{ t.backToTop }}</span>
+      </button>
+    </div>
 
     <footer>
       <div class="copyright">&copy; 2021&ndash;{{ year }} {{ t.copyright }}</div>
       {#- Reuse the localized feedPath computed in <head> so the footer icon
           points at the current language's feed, not always the zh-TW one. #}
-      <a href="{{ feedPath | url }}" id="rss"><img  src="/img/rss-feed.svg" alt="rss feed" /></a>
+      <a href="{{ feedPath | url }}" id="rss" aria-label="{{ t.rssFeed }}"><img src="/img/rss-feed.svg" alt="" /></a>
     </footer>
 
     <!-- Current page: {{ page.url | url }} -->
@@ -336,11 +384,12 @@
           return;
         }
         isUtterancesLoaded = true
+        setUtterancesTheme(bodyEl.classList.contains(DARK) ? DARK : LIGHT)
       });
       function setUtterancesTheme(theme) {
         let utterancesIframe = document.querySelector('.utterances iframe')
-        if (!isUtterancesLoaded) {
-          return requestAnimationFrame(() => setUtterancesTheme(theme))
+        if (!isUtterancesLoaded || !utterancesIframe) {
+          return
         }
         utterancesIframe.contentWindow.postMessage({
           type: 'set-theme',

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -22,17 +22,17 @@ templateClass: tmpl-post
   <div class="byline">
     <a class="byline-author" href="{{ authorUrl }}">
       <img class="avatar" src="{{ postAuthor.avatarUrl }}" alt="" />
-      <span>{{ postAuthor.name }}</span>
+      <span><span class="byline-role">{{ t.publishedBy }}</span> {{ postAuthor.name }}</span>
     </a>
     <time class="byline-date" datetime="{{ page.date | htmlDateString }}">{{ t.publishedOn }} {{ page.date | htmlDateString }}</time>
     <span class="byline-tags">
-    {%- for tag in tags %}{% if tag !== "posts" %}{% set tagUrl %}/tags/{{ tag | slug }}/{% endset %}<a href="{{ tagUrl | url }}" class="post-tag">#{{ tag }}</a>{% endif %}{% endfor %}
+    {%- for tag in tags %}{% if tag !== "posts" %}{% set canonicalTagUrl = tag | tagUrl(pageLang) %}<a href="{{ canonicalTagUrl | url }}" class="post-tag">#{{ tag }}</a>{% endif %}{% endfor %}
     </span>
   </div>
 {% endblock %}
 
 
-{% set shareUrl = metadata.url + page.url %}
+{% set shareUrl = articleUrl %}
 
 {% block article %}
 
@@ -49,9 +49,18 @@ templateClass: tmpl-post
   <div class="author-intro">{{ authorIntro | safe }}</div>
 </section>
 
-<p>
-  <a href="{{ shareUrl | safe }}" on-click="share">{{ t.shareArticle }}</a>
-</p>
+<div class="post-share">
+  <button class="post-share__button" type="button" on-click="share"
+    data-share-url="{{ shareUrl | escape }}" aria-label="{{ t.shareArticle }}">
+    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <circle cx="18" cy="5" r="2.25"/>
+      <circle cx="6" cy="12" r="2.25"/>
+      <circle cx="18" cy="19" r="2.25"/>
+      <path d="M8 11l7.9-4.6M8 13l7.9 4.6"/>
+    </svg>
+    <span>{{ t.shareArticle }}</span>
+  </button>
+</div>
 
 {%- set related = collections.posts | filterByLang(pageLang) | relatedPosts(page, tags, author, 3) %}
 {%- if related.length %}
@@ -96,12 +105,6 @@ templateClass: tmpl-post
   async>
 </script>
 {% endif %}
-
-<share-widget>
-  <button on-click="share" aria-label="Share" href="{{ shareUrl | safe }}">
-    <div></div>
-  </button>
-</share-widget>
 
 <script type="application/ld+json">
 {

--- a/_includes/topic-map.njk
+++ b/_includes/topic-map.njk
@@ -10,12 +10,21 @@
 
   <ul class="topic-map__grid">
   {%- for topic in topicMap %}
-    <li class="topic-card{% if topic.isCategoryCandidate %} topic-card--candidate{% endif %}">
+    {#- 越烤越深：文章數映射到餘燼色階（同貢獻日曆的分級邏輯），
+        口味越熱門、左側的烘焙度縱條烤得越深。 #}
+    {%- set bake = 1 %}
+    {%- if topic.postCount >= 10 %}{% set bake = 4 %}
+    {%- elif topic.postCount >= 6 %}{% set bake = 3 %}
+    {%- elif topic.postCount >= 3 %}{% set bake = 2 %}
+    {%- endif %}
+    <li class="topic-card topic-card--bake-{{ bake }}{% if topic.isCategoryCandidate %} topic-card--candidate{% endif %}">
       <a class="topic-card__link" href="{{ topic.url | url }}">
         <span class="topic-card__heading">
           <strong>{{ topic.canonical }}</strong>
           {%- if topic.isCategoryCandidate %}
-          <span class="topic-card__badge">{{ tt.candidateLabel }}</span>
+          <span class="topic-card__badge">
+            <svg class="topic-card__toque" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><circle cx="6.5" cy="9" r="4.5"/><circle cx="12" cy="7" r="5.5"/><circle cx="17.5" cy="9" r="4.5"/><rect x="7" y="12" width="10" height="7" rx="1.5"/></svg>
+            {{- tt.candidateLabel }}</span>
           {%- endif %}
         </span>
         <span class="topic-card__stats">

--- a/_includes/topic-map.njk
+++ b/_includes/topic-map.njk
@@ -1,0 +1,35 @@
+<section class="topic-map" aria-labelledby="topic-map-heading">
+  <div class="topic-map__intro">
+    <h2 id="topic-map-heading">{{ tt.allTopics }}</h2>
+    <p>{{ tt.intro }}</p>
+    <p class="topic-map__candidate-note">
+      <span class="topic-map__candidate-dot" aria-hidden="true"></span>
+      {{ tt.candidateHint }}
+    </p>
+  </div>
+
+  <ul class="topic-map__grid">
+  {%- for topic in topicMap %}
+    <li class="topic-card{% if topic.isCategoryCandidate %} topic-card--candidate{% endif %}">
+      <a class="topic-card__link" href="{{ topic.url | url }}">
+        <span class="topic-card__heading">
+          <strong>{{ topic.canonical }}</strong>
+          {%- if topic.isCategoryCandidate %}
+          <span class="topic-card__badge">{{ tt.candidateLabel }}</span>
+          {%- endif %}
+        </span>
+        <span class="topic-card__stats">
+          {{ topic.postCount }} {{ tt.postOne if topic.postCount == 1 else tt.postMany }}
+          <span aria-hidden="true">·</span>
+          {{ topic.authorCount }} {{ tt.authorOne if topic.authorCount == 1 else tt.authorMany }}
+        </span>
+        <span class="topic-card__authors">
+        {%- for authorKey in topic.authors %}
+          {{ metadata.authors[authorKey].name }}{% if not loop.last %}、{% endif %}
+        {%- endfor %}
+        </span>
+      </a>
+    </li>
+  {%- endfor %}
+  </ul>
+</section>

--- a/about-i18n.njk
+++ b/about-i18n.njk
@@ -12,5 +12,6 @@ permalink: "/{{ alang }}/about/"
 eleventyComputed:
   lang: "{{ alang }}"
   title: "{{ i18n[alang].aboutTitle }}"
+  description: "{{ i18n[alang].aboutOriginBody | striptags | truncate(140) }}"
   translationKey: about
 ---

--- a/about/index.md
+++ b/about/index.md
@@ -1,6 +1,7 @@
 ---
 layout: layouts/about.njk
 title: 烘焙師們
+description: 我們是一群因緣際會聚在一起的工程師，也是一群互相督促持續出爐的烘焙師。每位烘焙師每月至少烤出一份技術麵包，把實作經驗分享給來訪的食客。
 lang: zh-TW
 translationKey: about
 permalink: /about/

--- a/archive.njk
+++ b/archive.njk
@@ -1,5 +1,5 @@
 ---
-title: 品項｜全部出爐
+title: 麵包櫃｜全部出爐
 layout: layouts/home.njk
 eleventyNavigation:
   key: Archive

--- a/css/components/header-nav.css
+++ b/css/components/header-nav.css
@@ -53,7 +53,42 @@ header nav {
   opacity: 1;
 }
 #color-scheme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 44px;
   margin: 0;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+}
+#color-scheme-toggle:hover {
+  background: color-mix(in srgb, var(--ink) 6%, transparent);
+  color: var(--accent);
+}
+/* Original filled brand icons (moon/sun), tinted via currentColor. 20px
+   instead of the stroked icons' 22px: filled shapes carry more optical
+   weight, so they render slightly smaller to sit level with the 2px-stroke
+   magnifier and hamburger. */
+.theme-icon {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+  pointer-events: none;
+}
+.theme-icon--light {
+  display: none;
+}
+body.dark .theme-icon--dark {
+  display: none;
+}
+body.dark .theme-icon--light {
+  display: block;
 }
 /* ID selector: must outgun the generic `button:not([disabled])` accent
    rules from the base stylesheet, same trick as #color-scheme-toggle. */

--- a/css/components/lang-suggest.css
+++ b/css/components/lang-suggest.css
@@ -116,10 +116,3 @@ body.dark .lang-suggest {
     transform: none;
   }
 }
-/* The article share control occupies the lower-right corner between 377px and
-   600px. Lift the notice above it; at 376px the share control is already hidden. */
-@media (min-width: 377px) and (max-width: 660px) {
-  body.tmpl-post .lang-suggest {
-    bottom: calc(5rem + env(safe-area-inset-bottom));
-  }
-}

--- a/css/components/not-found.css
+++ b/css/components/not-found.css
@@ -1,0 +1,27 @@
+.not-found {
+  max-width: 38rem;
+  margin: 2rem auto 4rem;
+  text-align: center;
+}
+
+.not-found__mark {
+  margin: 0 0 1rem;
+  font-size: clamp(3rem, 12vw, 5rem);
+  line-height: 1;
+}
+
+.not-found a {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.not-found a:hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+}

--- a/css/components/reader-tools.css
+++ b/css/components/reader-tools.css
@@ -1,0 +1,192 @@
+/* ════════════════════════════════════════════════════════════════════════
+   READER TOOLS — quiet, non-competing article actions
+   Share now sits in the article flow; back-to-top is the only fixed action.
+   Both use the same paper, rule, icon, and focus language while preserving
+   a 44px touch target.
+   ════════════════════════════════════════════════════════════════════════ */
+.post-share {
+  display: flex;
+  justify-content: flex-end;
+  margin: 1.25rem 0 2.5rem;
+}
+
+.post-share > button.post-share__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  min-height: 44px;
+  margin: 0;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  background: var(--paper-raised);
+  color: var(--ink-soft);
+  font-size: 0.86rem;
+  font-weight: 600;
+  line-height: 1.3;
+  cursor: pointer;
+  box-shadow: 0 3px 12px rgba(31, 29, 27, 0.07);
+  transition: border-color 0.15s ease, color 0.15s ease,
+    background 0.15s ease, transform var(--dur) var(--ease);
+}
+
+.post-share > button.post-share__button:hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 7%, var(--paper-raised));
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.post-share > button.post-share__button:active {
+  transform: translateY(0) scale(0.98);
+}
+
+.post-share > button.post-share__button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.post-share__button svg,
+.reader-tool svg {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  overflow: visible;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+.reader-tools {
+  position: fixed;
+  right: max(clamp(0.75rem, 2.5vw, 1.5rem), env(safe-area-inset-right));
+  bottom: max(clamp(0.75rem, 2.5vw, 1.5rem), env(safe-area-inset-bottom));
+  z-index: 45;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 3px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--paper-raised) 90%, transparent);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 8px 24px rgba(31, 29, 27, 0.12);
+}
+
+.reader-tools[hidden],
+.reader-tools > button.reader-tool[hidden] {
+  display: none;
+}
+
+/* This specificity intentionally outranks the starter stylesheet's generic
+   button:not([disabled]) colour rules. */
+.reader-tools > button.reader-tool {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  min-height: 44px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease, transform var(--dur) var(--ease);
+}
+
+.reader-tools > button.reader-tool:hover {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+  transform: none;
+}
+
+.reader-tools > button.reader-tool:active {
+  transform: scale(0.94);
+}
+
+.reader-tools > button.reader-tool:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  background: var(--paper-raised);
+  color: var(--accent);
+}
+
+.reader-tool__label {
+  position: absolute;
+  top: 50%;
+  right: calc(100% + 0.7rem);
+  width: max-content;
+  max-width: 12rem;
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--rule-strong);
+  border-radius: var(--radius-chip);
+  background: var(--paper-raised);
+  color: var(--ink);
+  font-size: 0.76rem;
+  font-weight: 500;
+  line-height: 1.35;
+  white-space: nowrap;
+  opacity: 0;
+  transform: translate(4px, -50%);
+  pointer-events: none;
+  box-shadow: 0 5px 16px rgba(31, 29, 27, 0.12);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.reader-tool:hover .reader-tool__label,
+.reader-tool:focus-visible .reader-tool__label {
+  opacity: 1;
+  transform: translate(0, -50%);
+}
+
+@starting-style {
+  .reader-tools > button.back-to-top:not([hidden]) {
+    opacity: 0;
+    transform: translateY(6px) scale(0.92);
+  }
+}
+
+@media (hover: none) {
+  .reader-tool__label {
+    display: none;
+  }
+
+  .post-share > button.post-share__button:hover {
+    border-color: var(--rule-strong);
+    background: var(--paper-raised);
+    color: var(--ink-soft);
+    transform: none;
+  }
+}
+
+@media (max-width: 30rem) {
+  .post-share > button.post-share__button {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .post-share > button.post-share__button,
+  .reader-tools > button.reader-tool,
+  .reader-tool__label {
+    transition: none;
+  }
+}
+
+/* Reserve the floating tools' corner below the footer line so the RSS link
+   never sits under the fixed pill when the page is scrolled to the end. */
+footer {
+  padding-bottom: calc(3em + 64px);
+}

--- a/css/main.css
+++ b/css/main.css
@@ -2469,6 +2469,22 @@ body.tmpl-home .intro {
    keeps natural fills while still avoiding orphans. */
 
 /* ── Topic map: taxonomy first, articles one level deeper ─────────────── */
+/* Ember bake scale, mirrored from the gamification ramp (gamification.css is
+   only loaded on about/author pages, so the values are restated here — same
+   dough→oven-fire stops, light and dark). More posts = a deeper-baked crust
+   bar on the card's left edge: the brand's "bakes darker" dynamic as data. */
+.topic-map {
+  --bake-1: #eac7a2;
+  --bake-2: #d99757;
+  --bake-3: #bc5b2b;
+  --bake-4: #93351f;
+}
+body.dark .topic-map {
+  --bake-1: #5c3423;
+  --bake-2: #94512a;
+  --bake-3: #c96f38;
+  --bake-4: #ee9556;
+}
 .topic-map__intro {
   max-width: 44rem;
   margin-bottom: 2rem;
@@ -2516,6 +2532,22 @@ body.tmpl-home .intro {
 .topic-card--candidate {
   border-color: color-mix(in srgb, var(--accent) 55%, var(--rule));
 }
+/* Crust bar: post count mapped to the ember scale (thresholds follow the
+   contribution calendar's level logic). Candidates keep the accent frame —
+   red = editorial nomination, ember = data heat; the left edge stays ember
+   on both. Hovering "bakes" the flavor one stage darker. */
+.topic-card--bake-1 { --bake: var(--bake-1); }
+.topic-card--bake-2 { --bake: var(--bake-2); }
+.topic-card--bake-3 { --bake: var(--bake-3); }
+.topic-card--bake-4 { --bake: var(--bake-4); }
+.topic-card--bake-1:hover { --bake: var(--bake-2); }
+.topic-card--bake-2:hover { --bake: var(--bake-3); }
+.topic-card--bake-3:hover,
+.topic-card--bake-4:hover { --bake: var(--bake-4); }
+.topic-card,
+.topic-card--candidate {
+  border-left: 4px solid var(--bake, var(--rule));
+}
 .topic-card__link {
   display: flex;
   min-height: 100%;
@@ -2536,6 +2568,7 @@ body.tmpl-home .intro {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
+  gap: 0.28rem;
   padding: 0.15rem 0.45rem;
   border-radius: 999px;
   background: color-mix(in srgb, var(--accent) 12%, transparent);
@@ -2543,6 +2576,11 @@ body.tmpl-home .intro {
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.02em;
+}
+.topic-card__toque {
+  width: 0.95em;
+  height: 0.95em;
+  fill: currentColor;
 }
 .topic-card__stats,
 .topic-card__authors {

--- a/css/main.css
+++ b/css/main.css
@@ -77,51 +77,6 @@ header nav {
 }
 /*! purgecss end ignore */
 
-share-widget {
-  position: fixed;
-  right: 20px;
-  bottom: 20px;
-  opacity: 0.9;
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-  overflow: hidden;
-  box-shadow: 2px 3px 5px 2px rgba(0, 0, 0, 0.2);
-}
-
-@media screen and (max-width: 376px) {
-  share-widget {
-    display: none;
-  }
-}
-
-share-widget div {
-  margin-left: 50%;
-  transform: translateX(-50%);
-  width: 20px;
-  height: 20px;
-  background-image: url("/img/share.svg");
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
-}
-
-.apple share-widget div {
-  background-image: url("/img/share-apple.svg");
-}
-
-share-widget button {
-  margin: 0;
-  padding: 0;
-  width: 100%;
-  height: 100%;
-  transition: 0.3s;
-}
-
-share-widget button:active {
-  transform: scale(1.2);
-}
-
 dialog {
   background-color: var(--primary);
   position: fixed;
@@ -1207,6 +1162,12 @@ body {
   /* Shared motion tokens for micro-interactions. */
   --ease: cubic-bezier(0.2, 0.6, 0.2, 1);
   --dur: 0.25s;
+  /* Shared radius scale: raised surfaces (cards, dialogs), inner controls
+     (forms, result rows), small chips (shortcut hints, tooltips). Pills stay
+     999px and true circles 50% by convention. */
+  --radius-surface: 12px;
+  --radius-control: 8px;
+  --radius-chip: 4px;
 }
 body.dark {
   --paper: #1a1816;
@@ -1444,11 +1405,6 @@ main {
   padding: 0.25rem;
   cursor: pointer;
   line-height: 0;
-}
-#color-scheme-toggle img {
-  width: 24px;
-  display: block;
-  pointer-events: none;
 }
 /* ── Post cards: robust clamp + gentle hover ────────────────────────────*/
 .summary {
@@ -1808,43 +1764,6 @@ dialog#message[open] {
   }
 }
 
-/* Back-to-top: revealed by src/main.js after ~1.5 screens of scrolling.
-   `button.` prefix outranks the global button:not([disabled]) rules. */
-button.back-to-top {
-  position: fixed;
-  right: clamp(1rem, 3vw, 2rem);
-  bottom: clamp(1rem, 3vw, 2rem);
-  width: 44px;
-  height: 44px;
-  padding: 0;
-  border: 0;
-  border-radius: 999px;
-  background: var(--accent);
-  color: #fff;
-  font-size: 1.15rem;
-  line-height: 1;
-  cursor: pointer;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
-  z-index: 10;
-}
-button.back-to-top:hover {
-  background: var(--accent-hover);
-  color: #fff;
-  transform: translateY(-2px);
-}
-button.back-to-top {
-  transition: opacity var(--dur) var(--ease), transform var(--dur) var(--ease),
-    background 0.15s;
-}
-/* Fade/rise in when the hidden attribute is removed (2024 CSS; browsers
-   without @starting-style just show the button instantly). */
-@starting-style {
-  button.back-to-top {
-    opacity: 0;
-    transform: translateY(10px) scale(0.9);
-  }
-}
-
 /* "Freshly baked" chip on posts younger than 30 days (see isFresh filter). */
 .post-fresh {
   display: inline-block;
@@ -1920,6 +1839,10 @@ body.tmpl-post article {
   width: 30px;
   height: 30px;
   margin: 0;
+}
+.byline-role {
+  color: var(--ink-faint);
+  font-weight: 500;
 }
 .byline-tags {
   width: 100%;
@@ -2185,20 +2108,6 @@ h6:hover > .direct-link {
    REFINEMENTS round 2 — nav, language dropdown, back-to-top, author card,
    home masthead rhythm, modern pagination (design-craft review)
    ════════════════════════════════════════════════════════════════════════ */
-
-/* Theme-toggle icon: the SVGs are white (#fafafa); invert them on the light
-   "paper" nav so the icon is visible, keep them white on the dark nav. */
-#color-scheme-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-#color-scheme-toggle img {
-  filter: invert(1) brightness(0.2);
-}
-body.dark #color-scheme-toggle img {
-  filter: none;
-}
 
 /* ── Language switcher: compact globe dropdown (native <details>) ─────────*/
 .lang-switch {
@@ -2558,3 +2467,118 @@ body.tmpl-home .intro {
 /* The intro is prose, not a headline: `balance` halves short paragraphs at
    commas ("lyrics look", worst in en/ja). `pretty` (set in the shared rule)
    keeps natural fills while still avoiding orphans. */
+
+/* ── Topic map: taxonomy first, articles one level deeper ─────────────── */
+.topic-map__intro {
+  max-width: 44rem;
+  margin-bottom: 2rem;
+}
+.topic-map__intro h2 {
+  margin-bottom: 0.5rem;
+}
+.topic-map__intro p {
+  color: var(--ink-soft);
+}
+.topic-map__candidate-note {
+  display: flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  font-size: 0.9rem;
+}
+.topic-map__candidate-dot {
+  flex: 0 0 auto;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: var(--accent);
+}
+.topic-map__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+  gap: 0.9rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.topic-card {
+  min-width: 0;
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-surface);
+  background: var(--paper-raised);
+  transition: border-color var(--dur) var(--ease),
+    transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease);
+}
+.topic-card:hover {
+  border-color: var(--rule-strong);
+  transform: translateY(-2px);
+  box-shadow: 0 0.5rem 1.25rem rgba(31, 29, 27, 0.08);
+}
+.topic-card--candidate {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--rule));
+}
+.topic-card__link {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+.topic-card__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.65rem;
+  font-size: 1.08rem;
+}
+.topic-card__badge {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.topic-card__stats,
+.topic-card__authors {
+  color: var(--ink-faint);
+  font-size: 0.84rem;
+}
+.topic-card__authors {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.topic-breadcrumb {
+  margin-bottom: 1.25rem;
+  font-size: 0.9rem;
+}
+.topic-breadcrumb a {
+  color: var(--ink-soft);
+  text-decoration: none;
+}
+.topic-breadcrumb a:hover {
+  color: var(--accent);
+}
+.topic-detail__stats {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  color: var(--ink-faint);
+  font-size: 0.9rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .topic-card {
+    transition: none;
+  }
+  .topic-card:hover {
+    transform: none;
+  }
+}

--- a/index.njk
+++ b/index.njk
@@ -1,7 +1,7 @@
 ---
 title: ErrorBaker 技術共筆部落格
 layout: layouts/home.njk
-description: 錯誤烘焙師的技術共筆——把踩過的坑，烤成熱騰騰的文章
+description: 錯誤烘焙師的技術共筆——把踩過的坑，烘成熱騰騰的技術麵包
 image: /img/ogimage.png
 date: Last Modified
 lang: zh-TW
@@ -11,10 +11,10 @@ translationKey: home
 
 <section class="intro">
 <p>
-  Hi，這裡是 ErrorBaker —— 我們以共筆互相督促，把踩過的坑，烘成熱騰騰的文章。
+  {{ i18n['zh-TW'].intro }}
 </p>
 <p>
-  口味以 Web 前後端居多，只要跟技術有關，都可能在這裡出爐。
+  {{ i18n['zh-TW'].intro2 }}
 </p>
 </section>
 <section class="posts">

--- a/llms.txt.njk
+++ b/llms.txt.njk
@@ -11,8 +11,8 @@ eleventyExcludeFromCollections: true
 - [{{ post.data.title }}]({{ metadata.url }}{{ post.url }}){% if post.data.description %}: {{ post.data.description }}{% endif %}
 {% endfor %}
 ## Pages
-- [Archive]({{ metadata.url }}/archive/): 全部文章的時間軸索引
-- [About]({{ metadata.url }}/about/): 關於 ErrorBaker 與作者列表（依文章數排序）
+- [麵包櫃]({{ metadata.url }}/archive/): 全部技術麵包的時間軸索引
+- [烘焙師]({{ metadata.url }}/about/): 關於 ErrorBaker 與烘焙師列表（依出爐數排序）
 - [Tags]({{ metadata.url }}/tags/): 依主題標籤瀏覽
 
 ## Feeds

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,13 +23,21 @@
   status = 301
   force = true
 
-# Serve the localized 404 for any unmatched path under a language prefix
-# (e.g. /ja/posts/bad-slug/ → /ja/404.html). `force` defaults to false, so
-# real pages win and only genuinely-missing paths get the localized 404.
-# The zh-TW root /404.html covers no-prefix and /posts/* paths.
+# Existing localized files shadow these fallbacks. A missing locale-prefixed
+# URL receives the matching translated document while preserving HTTP 404.
 [[redirects]]
-  from = "/:lang/*"
-  to = "/:lang/404.html"
+  from = "/en/*"
+  to = "/en/404.html"
+  status = 404
+
+[[redirects]]
+  from = "/ja/*"
+  to = "/ja/404.html"
+  status = 404
+
+[[redirects]]
+  from = "/zh-CN/*"
+  to = "/zh-CN/404.html"
   status = 404
 
 [[headers]]

--- a/src/main.js
+++ b/src/main.js
@@ -40,29 +40,56 @@ if (location.search) {
   }, 1000)
 }
 
-function tweet_(url) {
-  open(
-    "https://twitter.com/intent/tweet?url=" + encodeURIComponent(url),
-    "_blank"
+function legacyCopyShareUrl(url) {
+  var field = document.createElement("textarea");
+  field.value = url;
+  field.setAttribute("readonly", "");
+  field.style.position = "fixed";
+  field.style.opacity = "0";
+  document.body.appendChild(field);
+  field.select();
+  var copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch (error) {}
+  field.remove();
+  if (copied) {
+    message(ui("linkCopied", "麵包連結已複製"));
+  } else {
+    window.prompt(ui("copyPrompt", "Copy this link"), url);
+  }
+}
+
+function copyShareUrl(url) {
+  if (!navigator.clipboard) {
+    legacyCopyShareUrl(url);
+    return;
+  }
+  navigator.clipboard.writeText(url).then(
+    function () {
+      message(ui("linkCopied", "麵包連結已複製"));
+    },
+    function () {
+      legacyCopyShareUrl(url);
+    }
   );
 }
-function tweet(anchor) {
-  tweet_(anchor.getAttribute("href"));
-}
-expose("tweet", tweet);
 
 function share(anchor) {
-  var url = anchor.getAttribute("href");
-  event.preventDefault();
+  var url = anchor.getAttribute("data-share-url");
   if (navigator.share) {
     navigator.share({
+      title: document.title,
       url: url,
+    }).catch(function (error) {
+      // Closing the native share sheet is an intentional no-op. For actual
+      // platform failures, preserve a useful copy fallback.
+      if (!error || error.name !== "AbortError") {
+        copyShareUrl(url);
+      }
     });
-  } else if (navigator.clipboard) {
-    navigator.clipboard.writeText(url);
-    message(ui("linkCopied", "文章連結已複製"));
   } else {
-    tweet_(url);
+    copyShareUrl(url);
   }
 }
 expose("share", share);
@@ -213,6 +240,7 @@ addEventListener(
 if (window.ResizeObserver && document.querySelector("header nav #nav")) {
   var progress = document.getElementById("reading-progress");
   var backToTopButton = document.getElementById("back-to-top");
+  var readerTools = document.querySelector(".reader-tools");
   var readDoneShown = false;
 
   var timeOfLastScroll = 0;
@@ -224,7 +252,7 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
     }
     timeOfLastScroll = Date.now();
   }
-  addEventListener("scroll", scroll);
+  addEventListener("scroll", scroll, { passive: true });
 
   // The progress bar "bakes" from pale dough to deep ember with reading
   // progress, like watching a loaf brown in the oven (values mirror
@@ -255,8 +283,12 @@ if (window.ResizeObserver && document.querySelector("header nav #nav")) {
     progress.style.transform = `translate(-${100 - percent}vw, 0)`;
     progress.style.backgroundColor = bakeColor(percent);
     if (backToTopButton) {
-      backToTopButton.hidden =
+      var hideBackToTop =
         document.scrollingElement.scrollTop < winHeight * 1.5;
+      backToTopButton.hidden = hideBackToTop;
+      if (readerTools) {
+        readerTools.hidden = hideBackToTop;
+      }
     }
     if (
       percent >= 100 &&
@@ -292,6 +324,10 @@ expose("backToTop", function () {
   // css `scroll-behavior: smooth` animates this (and turns it off under
   // prefers-reduced-motion).
   window.scrollTo(0, 0);
+  var homeLink = document.querySelector(".site-title a");
+  if (homeLink) {
+    homeLink.focus({ preventScroll: true });
+  }
 });
 
 // Clicking a heading's "#" anchor copies the section link. Default hash

--- a/tags-list-i18n.njk
+++ b/tags-list-i18n.njk
@@ -1,0 +1,17 @@
+---
+# Per-language topic maps. Only languages with a visible translated post are
+# present in localizedTopicMaps, so these shells can never be empty or orphaned.
+layout: layouts/home.njk
+pagination:
+  data: collections.localizedTopicMaps
+  size: 1
+  alias: localizedTopicMap
+permalink: "/{{ localizedTopicMap.lang }}/tags/"
+eleventyComputed:
+  lang: "{{ localizedTopicMap.lang }}"
+  title: "{{ i18n[localizedTopicMap.lang].tags.title }}"
+  translationKey: tags
+---
+{% set topicMap = localizedTopicMap.topics %}
+{% set tt = i18n[localizedTopicMap.lang].tags %}
+{% include "topic-map.njk" %}

--- a/tags-list.njk
+++ b/tags-list.njk
@@ -1,15 +1,13 @@
 ---
 permalink: /tags/
 layout: layouts/home.njk
-title: 口味｜文章標籤
+title: 口味地圖
+translationKey: tags
 eleventyNavigation:
   key: Tags
   order: 2
 ---
 
-{% for tag in collections.tagList %}
-  {% set tagUrl %}/tags/{{ tag | slug }}/{% endset %}
-  <h2><a href="{{ tagUrl | url }}" class="post-tag">{{ tag }}</a></h2>
-  {% set postslist = collections[tag] | filterByLang('zh-TW') | reverse %}
-  {% include "postslist.njk" %}
-{% endfor %}
+{% set topicMap = collections.topicMap %}
+{% set tt = i18n['zh-TW'].tags %}
+{% include "topic-map.njk" %}

--- a/tags.njk
+++ b/tags.njk
@@ -1,28 +1,28 @@
 ---
 pagination:
-  data: collections
+  data: collections.topicPages
   size: 1
-  alias: tag
-  filter:
-    - all
-    - nav
-    - post
-    - posts
-    - postsZhTW
-    - siteLangsWithPublishedPosts
-    - translations
-    - authorsByPostCount
-    - authorLangPages
-    - aiCrawlRules
-    - tagList
-  addAllPagesToCollections: true
+  alias: topicPage
 layout: layouts/home.njk
 eleventyComputed:
-  title: Tagged “{{ tag }}”
-permalink: /tags/{{ tag | slug }}/
+  lang: "{{ topicPage.lang }}"
+  title: "{{ i18n[topicPage.lang].tags.detailPrefix }}{{ topicPage.canonical }}"
+  topicId: "{{ topicPage.id }}"
+permalink: "{{ topicPage.url }}"
 ---
 
-{% set postslist = collections[ tag ] | filterByLang('zh-TW') | reverse %}
+{% set tt = i18n[topicPage.lang].tags %}
+{% set mapUrl = '/tags/' if topicPage.lang == 'zh-TW' else '/' + topicPage.lang + '/tags/' %}
+<nav class="topic-breadcrumb" aria-label="{{ tt.breadcrumbLabel }}">
+  <a href="{{ mapUrl | url }}">← {{ tt.backToMap }}</a>
+</nav>
+<p class="topic-detail__stats">
+  {{ topicPage.postCount }} {{ tt.postOne if topicPage.postCount == 1 else tt.postMany }}
+  <span aria-hidden="true">·</span>
+  {{ topicPage.authorCount }} {{ tt.authorOne if topicPage.authorCount == 1 else tt.authorMany }}
+  {%- if topicPage.isCategoryCandidate %}
+  <span class="topic-card__badge">{{ tt.candidateLabel }}</span>
+  {%- endif %}
+</p>
+{% set postslist = topicPage.posts | reverse %}
 {% include "postslist.njk" %}
-
-<p>See <a href="{{ '/tags/' | url }}">all tags</a>.</p>

--- a/test/test-comment-threads.js
+++ b/test/test-comment-threads.js
@@ -14,7 +14,10 @@
 const assert = require("assert").strict;
 const fs = require("fs");
 const path = require("path");
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
 const { threadPath } = require("../_11ty/discussions");
 
 const SITE = path.resolve(__dirname, "..", "_site");
@@ -34,7 +37,7 @@ function utterancesPages() {
     .map((file) => {
       const html = fs.readFileSync(file, "utf8");
       if (!html.includes("utteranc.es/client.js")) return null;
-      const doc = new JSDOM(html).window.document;
+      const doc = new JSDOM(html, { virtualConsole: quietConsole }).window.document;
       const embeds = [...doc.querySelectorAll('script[src*="utteranc.es"]')];
       const pagePath =
         "/" + path.relative(SITE, path.dirname(file)).split(path.sep).join("/") + "/";
@@ -46,7 +49,7 @@ function utterancesPages() {
 function embedFor(pagePath) {
   const file = path.join(SITE, ...pagePath.split("/").filter(Boolean), "index.html");
   assert.ok(fs.existsSync(file), `Missing build output: ${file}`);
-  const doc = new JSDOM(fs.readFileSync(file, "utf8")).window.document;
+  const doc = new JSDOM(fs.readFileSync(file, "utf8"), { virtualConsole: quietConsole }).window.document;
   const embeds = doc.querySelectorAll('script[src*="utteranc.es"]');
   assert.equal(embeds.length, 1, `${pagePath} must have exactly one utterances embed`);
   return embeds[0];

--- a/test/test-css-output.js
+++ b/test/test-css-output.js
@@ -3,7 +3,10 @@
 const assert = require("assert").strict;
 const fs = require("fs");
 const path = require("path");
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
 const { CSS_FILES, readCssBundle } = require("../_11ty/css-bundle.js");
 
 const PROJECT_ROOT = path.resolve(__dirname, "..");
@@ -12,7 +15,7 @@ const activeLanguages = require("../_11ty/activeLanguages.js");
 function inlinedCss(relativeOutputPath) {
   const filename = path.join(PROJECT_ROOT, "_site", relativeOutputPath);
   assert.ok(fs.existsSync(filename), `Missing build output: ${filename}`);
-  const doc = new JSDOM(fs.readFileSync(filename, "utf8")).window.document;
+  const doc = new JSDOM(fs.readFileSync(filename, "utf8"), { virtualConsole: quietConsole }).window.document;
   const style = doc.querySelector("style");
   assert.ok(style, `Missing inlined CSS: ${filename}`);
   return style.textContent;
@@ -61,21 +64,32 @@ describe("purged CSS output", () => {
       "css/main.css",
       "css/components/lang-suggest.css",
       "css/components/header-nav.css",
+      "css/components/reader-tools.css",
+      "css/components/not-found.css",
     ]);
 
     const css = readCssBundle();
     const bannerStart = css.indexOf("Locale-suggestion banner");
     const headerStart = css.indexOf("HEADER — quiet editorial top bar");
+    const readerToolsStart = css.indexOf("READER TOOLS — quiet");
+    const notFoundStart = css.indexOf(".not-found {");
     assert.ok(bannerStart > -1, "Expected the locale suggestion component");
     assert.ok(headerStart > bannerStart, "Expected header styles after banner styles");
+    assert.ok(readerToolsStart > headerStart, "Expected reader tools after header styles");
+    assert.ok(notFoundStart > readerToolsStart, "Expected not-found styles after reader tools");
 
     const main = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[0]), "utf8");
     const banner = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[1]), "utf8");
     const header = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[2]), "utf8");
+    const readerTools = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[3]), "utf8");
+    const notFound = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[4]), "utf8");
     assert.doesNotMatch(main, /\.lang-suggest/);
     assert.match(banner, /body\.dark \.lang-suggest/);
     assert.match(header, /html\.js \.nav__links/);
     assert.match(header, /html:not\(\.js\) #nav-toggle/);
+    assert.match(readerTools, /\.reader-tools > button\.reader-tool/);
+    assert.match(readerTools, /border-radius:\s*50%/);
+    assert.match(notFound, /\.not-found__mark/);
   });
 
   it("publishes only CSS that pages load directly", () => {

--- a/test/test-feeds.js
+++ b/test/test-feeds.js
@@ -4,7 +4,10 @@ const assert = require("assert").strict;
 const fs = require("fs");
 const path = require("path");
 const nunjucks = require("nunjucks");
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
 const rssPlugin = require("@11ty/eleventy-plugin-rss");
 const metadata = require("../_data/metadata.json");
 const i18n = require("../_data/i18n.json");
@@ -36,7 +39,7 @@ function assertRfc3339(value, label) {
 }
 
 function assertAbsoluteContentUrls(html, label) {
-  const doc = new JSDOM(`<body>${html}</body>`).window.document;
+  const doc = new JSDOM(`<body>${html}</body>`, { virtualConsole: quietConsole }).window.document;
   for (const element of doc.querySelectorAll("[href],[src],[poster],[srcset]")) {
     for (const attribute of ["href", "src", "poster"]) {
       if (!element.hasAttribute(attribute)) continue;
@@ -215,7 +218,7 @@ describe("syndication feed output", () => {
     for (const lang of langs) {
       const files = pathsForLang(lang);
       if (!fs.existsSync(files.home)) continue;
-      const doc = new JSDOM(fs.readFileSync(files.home, "utf8")).window.document;
+      const doc = new JSDOM(fs.readFileSync(files.home, "utf8"), { virtualConsole: quietConsole }).window.document;
       const atom = doc.querySelectorAll(
         "link[rel='alternate'][type='application/atom+xml']"
       );

--- a/test/test-functional-regression.js
+++ b/test/test-functional-regression.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
+const metadata = require("../_data/metadata.json");
+
+const SITE_ROOT = path.resolve(__dirname, "..", "_site");
+
+function documentFor(relative) {
+  const filename = path.join(SITE_ROOT, relative);
+  assert.ok(fs.existsSync(filename), `Missing build output: ${filename}`);
+  return new JSDOM(fs.readFileSync(filename, "utf8"), { virtualConsole: quietConsole }).window.document;
+}
+
+describe("archive page", () => {
+  // Only the zh-TW archive exists today; localized archives are open issue
+  // #229 and must not be asserted here until that ships.
+  let doc;
+
+  before(() => {
+    doc = documentFor("archive/index.html");
+  });
+
+  it("lists dated posts", () => {
+    const dates = [...doc.querySelectorAll(".archive-date")].map((node) =>
+      node.textContent.trim()
+    );
+    assert.ok(dates.length >= 80, `only ${dates.length} archive rows`);
+    for (const date of dates) {
+      assert.match(date, /^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  it("orders posts newest first", () => {
+    const dates = [...doc.querySelectorAll(".archive-date")].map((node) =>
+      node.textContent.trim()
+    );
+    const sorted = [...dates].sort().reverse();
+    assert.deepEqual(dates, sorted);
+  });
+});
+
+describe("llms.txt", () => {
+  it("describes the site for AI crawlers", () => {
+    const filename = path.join(SITE_ROOT, "llms.txt");
+    assert.ok(fs.existsSync(filename));
+    const body = fs.readFileSync(filename, "utf8");
+    assert.ok(body.trim().length > 0);
+    assert.ok(body.includes(metadata.url));
+  });
+});
+
+describe("status dialog", () => {
+  it("ships the localized toast dialog on every page type", () => {
+    for (const page of ["index.html", "posts/tian/git-flow/index.html"]) {
+      const dialog = documentFor(page).getElementById("message");
+      assert.ok(dialog, `${page}: missing #message dialog`);
+      assert.equal(dialog.getAttribute("role"), "status");
+      assert.equal(dialog.getAttribute("aria-live"), "polite");
+      assert.ok(dialog.getAttribute("data-ui").length > 0);
+    }
+  });
+});

--- a/test/test-gamification.js
+++ b/test/test-gamification.js
@@ -3,7 +3,10 @@
 const assert = require("assert").strict;
 const fs = require("fs");
 const path = require("path");
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
 const { buildAuthorStats } = require("../_11ty/authorStats.js");
 
 const ABOUT_FILENAME = path.resolve(__dirname, "..", "_site", "about", "index.html");
@@ -128,7 +131,7 @@ describe("gamification build output", () => {
 
   before(() => {
     assert.ok(fs.existsSync(ABOUT_FILENAME), `Missing build output: ${ABOUT_FILENAME}`);
-    about = new JSDOM(fs.readFileSync(ABOUT_FILENAME, "utf8")).window.document;
+    about = new JSDOM(fs.readFileSync(ABOUT_FILENAME, "utf8"), { virtualConsole: quietConsole }).window.document;
   });
 
   it("renders the leaderboard with rank, level badge, and proportional bars", () => {
@@ -149,12 +152,12 @@ describe("gamification build output", () => {
   });
 
   it("renders the localized leaderboard on translated about pages", () => {
-    const enAbout = new JSDOM(fs.readFileSync(EN_ABOUT_FILENAME, "utf8")).window.document;
+    const enAbout = new JSDOM(fs.readFileSync(EN_ABOUT_FILENAME, "utf8"), { virtualConsole: quietConsole }).window.document;
     assert.ok(enAbout.querySelector("ul.gx-leaderboard li.gx-row"));
   });
 
   it("renders the quarterly contribution calendar on author pages", () => {
-    const author = new JSDOM(fs.readFileSync(AUTHOR_FILENAME, "utf8")).window.document;
+    const author = new JSDOM(fs.readFileSync(AUTHOR_FILENAME, "utf8"), { virtualConsole: quietConsole }).window.document;
     const cells = [...author.querySelectorAll(".gx-cal .gx-cell[data-level]")];
     assert.ok(cells.length > 0, "Expected contribution calendar cells");
     for (const cell of cells) {
@@ -164,11 +167,11 @@ describe("gamification build output", () => {
 
   it("loads gamification.css only on about and author-listing pages", () => {
     const selector = "link[href^='/css/gamification.css']";
-    const authorDoc = new JSDOM(fs.readFileSync(AUTHOR_FILENAME, "utf8")).window.document;
+    const authorDoc = new JSDOM(fs.readFileSync(AUTHOR_FILENAME, "utf8"), { virtualConsole: quietConsole }).window.document;
     assert.ok(about.querySelector(selector));
     assert.ok(authorDoc.querySelector(selector));
     for (const file of [HOME_FILENAME, POST_FILENAME]) {
-      const doc = new JSDOM(fs.readFileSync(file, "utf8")).window.document;
+      const doc = new JSDOM(fs.readFileSync(file, "utf8"), { virtualConsole: quietConsole }).window.document;
       assert.equal(doc.querySelector(selector), null, `Unexpected gamification.css in ${file}`);
     }
   });

--- a/test/test-generic-post.js
+++ b/test/test-generic-post.js
@@ -3,8 +3,12 @@
 const assert = require("assert").strict;
 const fs = require("fs");
 const path = require("path");
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
 const metadata = require("../_data/metadata.json");
+const i18n = require("../_data/i18n.json");
 
 const POST_PATH = "/posts/tian/git-flow/";
 const POST_URL = metadata.url + POST_PATH;
@@ -32,7 +36,7 @@ describe("representative post build output", () => {
 
   before(() => {
     assert.ok(fs.existsSync(POST_FILENAME), `Missing build output: ${POST_FILENAME}`);
-    doc = new JSDOM(fs.readFileSync(POST_FILENAME, "utf8")).window.document;
+    doc = new JSDOM(fs.readFileSync(POST_FILENAME, "utf8"), { virtualConsole: quietConsole }).window.document;
   });
 
   it("has correct title, language, canonical, and social metadata", () => {
@@ -57,10 +61,17 @@ describe("representative post build output", () => {
   });
 
   it("has an accessible share control and correct publication date", () => {
-    const share = doc.querySelector("share-widget button");
-    assert.ok(share);
-    assert.ok(share.getAttribute("aria-label"));
-    assert.equal(share.getAttribute("href"), POST_URL);
+    const shares = [...doc.querySelectorAll("[on-click='share']")];
+    assert.equal(shares.length, 1, "Expected one article sharing action");
+
+    const share = shares[0];
+    assert.ok(share.matches("main article .post-share > button.post-share__button"));
+    assert.equal(share.tagName, "BUTTON");
+    assert.equal(share.type, "button");
+    assert.equal(share.hasAttribute("href"), false, "A button must not have href");
+    assert.equal(share.dataset.shareUrl, POST_URL);
+    assert.equal(share.getAttribute("aria-label"), i18n["zh-TW"].shareArticle);
+    assert.match(share.textContent, new RegExp(i18n["zh-TW"].shareArticle));
 
     const published = doc.querySelector("time.byline-date");
     assert.equal(published.getAttribute("datetime"), "2021-10-28");
@@ -93,8 +104,9 @@ describe("representative post build output", () => {
       fs.existsSync(IMAGE_POST_FILENAME),
       `Missing build output: ${IMAGE_POST_FILENAME}`
     );
-    const imagePost = new JSDOM(fs.readFileSync(IMAGE_POST_FILENAME, "utf8"))
-      .window.document;
+    const imagePost = new JSDOM(fs.readFileSync(IMAGE_POST_FILENAME, "utf8"), {
+      virtualConsole: quietConsole,
+    }).window.document;
     const article = JSON.parse(
       imagePost.querySelector("script[type='application/ld+json']").textContent
     );
@@ -108,9 +120,9 @@ describe("representative post build output", () => {
       fs.existsSync(IMAGE_POST_FILENAME),
       `Missing build output: ${IMAGE_POST_FILENAME}`
     );
-    const imageDoc = new JSDOM(
-      fs.readFileSync(IMAGE_POST_FILENAME, "utf8")
-    ).window.document;
+    const imageDoc = new JSDOM(fs.readFileSync(IMAGE_POST_FILENAME, "utf8"), {
+      virtualConsole: quietConsole,
+    }).window.document;
     const image = imageDoc.querySelector("picture img[src^='/img/']:not(.avatar)");
     assert.ok(image, "Expected at least one optimized local image");
     assert.match(image.getAttribute("width"), /^\d+$/);

--- a/test/test-homepage.js
+++ b/test/test-homepage.js
@@ -3,8 +3,12 @@
 const assert = require("assert").strict;
 const fs = require("fs");
 const path = require("path");
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
 const metadata = require("../_data/metadata.json");
+const i18n = require("../_data/i18n.json");
 
 const SITE_ROOT = path.resolve(__dirname, "..", "_site");
 const FILENAME = path.join(SITE_ROOT, "index.html");
@@ -14,7 +18,7 @@ describe("homepage build output", () => {
 
   before(() => {
     assert.ok(fs.existsSync(FILENAME), `Missing build output: ${FILENAME}`);
-    doc = new JSDOM(fs.readFileSync(FILENAME, "utf8")).window.document;
+    doc = new JSDOM(fs.readFileSync(FILENAME, "utf8"), { virtualConsole: quietConsole }).window.document;
   });
 
   it("has localized document metadata and a self canonical", () => {
@@ -33,6 +37,66 @@ describe("homepage build output", () => {
     assert.ok(hrefs.includes("/archive/"));
     assert.ok(hrefs.includes("/tags/"));
     assert.ok(hrefs.includes("/about/"));
+  });
+
+  it("keeps mobile header actions in theme, menu order", () => {
+    const nav = doc.getElementById("nav");
+    const actionIds = [...nav.children]
+      .map((element) => element.id)
+      .filter((id) => [
+        "color-scheme-toggle",
+        "nav-toggle",
+      ].includes(id));
+
+    assert.deepEqual(actionIds, [
+      "color-scheme-toggle",
+      "nav-toggle",
+    ]);
+    assert.equal(
+      doc.getElementById("color-scheme-toggle").nextElementSibling.id,
+      "nav-toggle"
+    );
+  });
+
+  it("localizes the theme and menu action names", () => {
+    const strings = i18n["zh-TW"];
+    const primaryNav = doc.querySelector("header nav");
+    const theme = doc.getElementById("color-scheme-toggle");
+    const menu = doc.getElementById("nav-toggle");
+
+    assert.equal(primaryNav.getAttribute("aria-label"), strings.primaryNavigation);
+    assert.equal(theme.getAttribute("aria-label"), strings.switchToDarkTheme);
+    assert.equal(theme.dataset.labelToDark, strings.switchToDarkTheme);
+    assert.equal(theme.dataset.labelToLight, strings.switchToLightTheme);
+    assert.equal(menu.getAttribute("aria-label"), strings.openMenu);
+    assert.equal(menu.dataset.labelOpen, strings.openMenu);
+    assert.equal(menu.dataset.labelClose, strings.closeMenu);
+  });
+
+  it("uses each emitted page locale for the theme and menu labels", () => {
+    for (const [lang, strings] of Object.entries(i18n)) {
+      if (lang === "zh-TW") continue;
+      const filename = path.join(SITE_ROOT, lang, "index.html");
+      if (!fs.existsSync(filename)) continue;
+
+      const html = fs
+        .readFileSync(filename, "utf8")
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
+      const localized = new JSDOM(html, { virtualConsole: quietConsole }).window.document;
+      assert.equal(localized.documentElement.lang, lang);
+      assert.equal(
+        localized.getElementById("color-scheme-toggle").getAttribute("aria-label"),
+        strings.switchToDarkTheme
+      );
+      assert.equal(
+        localized.getElementById("nav-toggle").getAttribute("aria-label"),
+        strings.openMenu
+      );
+      assert.equal(
+        localized.getElementById("nav-toggle").dataset.labelClose,
+        strings.closeMenu
+      );
+    }
   });
 
   it("lists real posts whose generated pages exist", () => {

--- a/test/test-image-pipeline.js
+++ b/test/test-image-pipeline.js
@@ -1,7 +1,10 @@
 "use strict";
 
 const assert = require("assert").strict;
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
 const imagePlugin = require("../_11ty/img-dim.js");
 
 function getTransform() {
@@ -40,7 +43,7 @@ describe("image build pipeline", () => {
       '<!doctype html><img class="avatar avatar-large" alt="" src="/img/authors/tian.jpg">',
       "_site/avatar-test/index.html"
     );
-    const doc = new JSDOM(output).window.document;
+    const doc = new JSDOM(output, { virtualConsole: quietConsole }).window.document;
     const image = doc.querySelector("picture > img.avatar");
     assert.ok(image, "Expected the local avatar to be wrapped in a picture");
     assert.match(image.getAttribute("width"), /^\d+$/);
@@ -62,7 +65,7 @@ describe("image build pipeline", () => {
       '<!doctype html><img class="avatar avatar-small" alt="" src="/img/authors/tian.jpg">',
       "_site/small-avatar-test/index.html"
     );
-    const doc = new JSDOM(output).window.document;
+    const doc = new JSDOM(output, { virtualConsole: quietConsole }).window.document;
     const image = doc.querySelector("picture > img.avatar-small");
     assert.ok(image, "Expected the small avatar to be wrapped in a picture");
     assert.equal(image.getAttribute("src"), "/img/authors/tian-96w.jpg");

--- a/test/test-locale-suggestion.js
+++ b/test/test-locale-suggestion.js
@@ -3,7 +3,10 @@
 const assert = require("assert").strict;
 const fs = require("fs");
 const path = require("path");
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
 
 const clientSource = fs.readFileSync(
   path.resolve(__dirname, "..", "src", "main.js"),

--- a/test/test-not-found.js
+++ b/test/test-not-found.js
@@ -1,0 +1,98 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
+const activeLanguages = require("../_11ty/activeLanguages.js");
+const i18n = require("../_data/i18n.json");
+const languages = require("../_data/langs.json");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const SITE_ROOT = path.join(PROJECT_ROOT, "_site");
+
+function outputForLanguage(lang) {
+  return lang === languages[0]
+    ? path.join(SITE_ROOT, "404.html")
+    : path.join(SITE_ROOT, lang, "404.html");
+}
+
+function parseHtmlWithoutStyles(filename) {
+  const html = fs
+    .readFileSync(filename, "utf8")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
+  return new JSDOM(html, { virtualConsole: quietConsole }).window.document;
+}
+
+function redirectField(block, field) {
+  const match = block.match(
+    new RegExp(`^\\s*${field}\\s*=\\s*(?:"([^"]*)"|(\\d+)|(true|false))\\s*$`, "m")
+  );
+  if (!match) return undefined;
+  if (match[1] !== undefined) return match[1];
+  if (match[2] !== undefined) return Number(match[2]);
+  return match[3] === "true";
+}
+
+function netlifyRedirects(source) {
+  return source
+    .split(/^\[\[redirects\]\]\s*$/m)
+    .slice(1)
+    .map((part) => part.split(/^\[\[/m)[0])
+    .map((block) => ({
+      from: redirectField(block, "from"),
+      to: redirectField(block, "to"),
+      status: redirectField(block, "status"),
+      force: redirectField(block, "force"),
+    }));
+}
+
+describe("localized not-found documents", () => {
+  it("renders root and active-locale 404 outputs with matching i18n copy", () => {
+    const active = activeLanguages(false);
+    for (const lang of active) {
+      const filename = outputForLanguage(lang);
+      assert.ok(fs.existsSync(filename), `Missing ${lang} 404 output: ${filename}`);
+
+      const doc = parseHtmlWithoutStyles(filename);
+      const strings = i18n[lang];
+      const notFound = doc.querySelector(".not-found");
+      assert.ok(notFound, `${lang} 404 must render the localized not-found body`);
+      const body = [...notFound.children].find(
+        (element) => element.tagName === "P" && !element.classList.contains("not-found__mark")
+      );
+      const home = notFound.querySelector("a");
+
+      assert.equal(doc.documentElement.lang, lang);
+      assert.equal(doc.title, strings.notFoundTitle);
+      assert.equal(body.textContent.trim(), strings.notFoundBody);
+      assert.equal(home.textContent.trim(), strings.notFoundHome);
+      assert.equal(
+        home.getAttribute("href"),
+        lang === languages[0] ? "/" : `/${lang}/`
+      );
+    }
+  });
+
+  it("keeps every locale fallback on a real HTTP 404 response", () => {
+    const source = fs.readFileSync(path.join(PROJECT_ROOT, "netlify.toml"), "utf8");
+    const redirects = netlifyRedirects(source);
+
+    for (const lang of languages.slice(1)) {
+      const fallback = redirects.find((redirect) => redirect.from === `/${lang}/*`);
+      assert.ok(fallback, `Missing Netlify fallback for ${lang}`);
+      assert.equal(fallback.to, `/${lang}/404.html`);
+      assert.equal(fallback.status, 404, `${lang} fallback must preserve not-found status`);
+    }
+  });
+
+  it("excludes every not-found document from the sitemap", () => {
+    const filename = path.join(SITE_ROOT, "sitemap.xml");
+    assert.ok(fs.existsSync(filename), `Missing build output: ${filename}`);
+    const sitemap = fs.readFileSync(filename, "utf8");
+    assert.doesNotMatch(sitemap, /<loc>[^<]*\/404\.html<\/loc>/);
+  });
+});

--- a/test/test-production-output.js
+++ b/test/test-production-output.js
@@ -3,7 +3,10 @@
 const assert = require("assert").strict;
 const fs = require("fs");
 const path = require("path");
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
 const metadata = require("../_data/metadata.json");
 const computedData = require("../_data/eleventyComputed.js");
 

--- a/test/test-readability.js
+++ b/test/test-readability.js
@@ -3,7 +3,11 @@
 const assert = require("assert").strict;
 const fs = require("fs");
 const path = require("path");
-const { JSDOM } = require("jsdom");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
+const i18n = require("../_data/i18n.json");
 
 const POST_FILENAME = path.resolve(
   __dirname,
@@ -41,7 +45,7 @@ describe("article readability build output", () => {
 
   before(() => {
     assert.ok(fs.existsSync(POST_FILENAME), `Missing build output: ${POST_FILENAME}`);
-    doc = new JSDOM(fs.readFileSync(POST_FILENAME, "utf8")).window.document;
+    doc = new JSDOM(fs.readFileSync(POST_FILENAME, "utf8"), { virtualConsole: quietConsole }).window.document;
     inlineCss = doc.querySelector("style").textContent;
   });
 
@@ -68,10 +72,29 @@ describe("article readability build output", () => {
     assert.ok(doc.getElementById("reading-progress"));
   });
 
+  it("renders one initially-hidden, localized back-to-top component", () => {
+    const tools = doc.querySelector("body > .reader-tools");
+    const controls = [...doc.querySelectorAll("#back-to-top")];
+
+    assert.ok(tools, "Expected the fixed reader-tools shell");
+    assert.equal(tools.hidden, true, "Client-side scrolling reveals the shell");
+    assert.equal(controls.length, 1);
+
+    const control = controls[0];
+    assert.ok(control.matches(".reader-tools > button.reader-tool.back-to-top"));
+    assert.equal(control.type, "button");
+    assert.equal(control.hidden, true, "Client-side scrolling reveals the control");
+    assert.equal(control.getAttribute("aria-label"), i18n["zh-TW"].backToTop);
+    assert.ok(control.querySelector("svg[aria-hidden='true']"));
+    assert.doesNotMatch(control.textContent, /↑/, "Use an icon, not a raw arrow glyph");
+  });
+
   it("keeps JS-toggled reading UI selectors through the CSS purge", () => {
     assert.match(inlineCss, /#reading-progress/);
     assert.match(inlineCss, /\.toc-ready/);
     assert.match(inlineCss, /\.direct-link/);
+    assert.match(inlineCss, /\.reader-tools/);
+    assert.match(inlineCss, /\.back-to-top/);
   });
 
   it("keeps language-aware article typography through the CSS purge", () => {
@@ -82,8 +105,8 @@ describe("article readability build output", () => {
   });
 
   it("applies the matching document language on translated pages", () => {
-    const ja = new JSDOM(fs.readFileSync(JA_POST_FILENAME, "utf8")).window.document;
-    const en = new JSDOM(fs.readFileSync(EN_POST_FILENAME, "utf8")).window.document;
+    const ja = new JSDOM(fs.readFileSync(JA_POST_FILENAME, "utf8"), { virtualConsole: quietConsole }).window.document;
+    const en = new JSDOM(fs.readFileSync(EN_POST_FILENAME, "utf8"), { virtualConsole: quietConsole }).window.document;
     assert.equal(ja.documentElement.lang, "ja");
     assert.equal(en.documentElement.lang, "en");
     assert.match(ja.querySelector("style").textContent, /line-height:1\.85/);

--- a/test/test-seo.js
+++ b/test/test-seo.js
@@ -1,0 +1,107 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
+const metadata = require("../_data/metadata.json");
+const activeLanguages = require("../_11ty/activeLanguages.js");
+const languages = require("../_data/langs.json");
+
+const SITE_ROOT = path.resolve(__dirname, "..", "_site");
+
+function documentFor(relative) {
+  const filename = path.join(SITE_ROOT, relative);
+  assert.ok(fs.existsSync(filename), `Missing build output: ${filename}`);
+  return new JSDOM(fs.readFileSync(filename, "utf8"), { virtualConsole: quietConsole }).window.document;
+}
+
+// Head-emission SEO contract for the layouts in base.njk. Canonical,
+// description, og:url and hreflang sets are already pinned elsewhere
+// (test-homepage, test-generic-post, test-production-output); this suite
+// covers the tags no other test asserts.
+describe("SEO head emissions", () => {
+  const samples = [
+    "index.html",
+    "posts/tian/git-flow/index.html",
+    "tags/index.html",
+    "about/index.html",
+    "en/about/index.html",
+  ];
+
+  for (const relative of samples) {
+    describe(relative, () => {
+      let doc;
+
+      before(() => {
+        doc = documentFor(relative);
+      });
+
+      it("stays indexable with exactly one canonical", () => {
+        assert.equal(
+          doc.querySelector("meta[name='robots']").content,
+          "index, follow"
+        );
+        assert.equal(doc.querySelectorAll("link[rel='canonical']").length, 1);
+      });
+
+      it("emits the Open Graph and Twitter card set", () => {
+        for (const property of [
+          "og:title",
+          "og:description",
+          "og:image",
+          "og:type",
+          "og:site_name",
+          "og:url",
+        ]) {
+          const tag = doc.querySelector(`meta[property='${property}']`);
+          assert.ok(tag, `missing ${property}`);
+          assert.ok(tag.content.length > 0, `empty ${property}`);
+        }
+        assert.equal(
+          doc.querySelector("meta[name='twitter:card']").content,
+          "summary"
+        );
+      });
+
+      it("has a non-empty page title", () => {
+        assert.ok(doc.querySelector("title").textContent.trim().length > 0);
+      });
+    });
+  }
+
+  it("links the localized Atom and JSON feeds from every language home", () => {
+    for (const lang of activeLanguages(false)) {
+      const home = lang === languages[0] ? "index.html" : `${lang}/index.html`;
+      const doc = documentFor(home);
+      const prefix = lang === languages[0] ? "" : `/${lang}`;
+      const atom = doc.querySelector("link[type='application/atom+xml']");
+      const json = doc.querySelector("link[type='application/feed+json']");
+      assert.ok(atom, `${lang}: missing Atom feed link`);
+      assert.equal(atom.getAttribute("href"), `${prefix}${metadata.feed.path}`);
+      assert.ok(json, `${lang}: missing JSON feed link`);
+      assert.equal(
+        json.getAttribute("href"),
+        `${prefix}${metadata.jsonfeed.path}`
+      );
+    }
+  });
+});
+
+describe("SEO deployment artifacts", () => {
+  it("advertises the sitemap from robots.txt", () => {
+    const robots = fs.readFileSync(path.join(SITE_ROOT, "robots.txt"), "utf8");
+    assert.ok(robots.includes(`Sitemap: ${metadata.url}/sitemap.xml`));
+  });
+
+  it("lists the topic map in the sitemap", () => {
+    const sitemap = fs.readFileSync(
+      path.join(SITE_ROOT, "sitemap.xml"),
+      "utf8"
+    );
+    assert.ok(sitemap.includes(`<loc>${metadata.url}/tags/</loc>`));
+  });
+});

--- a/test/test-tags.js
+++ b/test/test-tags.js
@@ -2,6 +2,7 @@
 
 const assert = require("assert").strict;
 const fs = require("fs");
+const { JSDOM, VirtualConsole } = require("jsdom");
 const taxonomy = require("../_data/tagTaxonomy.json");
 const { auditPosts } = require("../scripts/check-tags");
 const {
@@ -128,6 +129,14 @@ describe("tag taxonomy", () => {
 });
 
 describe("built topic pages", () => {
+  function documentFor(file) {
+    return new JSDOM(fs.readFileSync(file, "utf8"), {
+      // jsdom 15 reports modern CSS syntax (for example color-mix()) as a
+      // stylesheet parse warning even though the HTML DOM is valid.
+      virtualConsole: new VirtualConsole(),
+    }).window.document;
+  }
+
   it("publishes permanent redirects for the verified legacy tag URLs", () => {
     const lines = fs
       .readFileSync("_site/_redirects", "utf8")
@@ -141,4 +150,36 @@ describe("built topic pages", () => {
     assert.equal(lines.some((line) => /^\/(?:en|ja|zh-CN)\//.test(line)), false);
   });
 
+  it("renders the source topic map without expanding article lists", () => {
+    const document = documentFor("_site/tags/index.html");
+    assert.equal(document.querySelectorAll(".topic-card").length, 92);
+    assert.equal(document.querySelectorAll(".topic-card--candidate").length, 3);
+    assert.equal(document.querySelector("#post-list"), null);
+    assert.equal(document.querySelector(".archive-row"), null);
+    assert.ok(document.querySelector('a[href="/tags/frontend/"]'));
+  });
+
+  it("uses canonical detail slugs and preserves source article lists", () => {
+    const document = documentFor("_site/tags/frontend/index.html");
+    assert.equal(document.querySelectorAll(".archive-row").length, 23);
+    assert.ok(document.querySelector('a[href="/tags/"]'));
+    assert.ok(fs.existsSync("_site/tags/node-js/index.html"));
+  });
+
+  it("localizes topic chrome while keeping labels canonical and posts locale-only", () => {
+    for (const lang of ["en", "ja", "zh-CN"]) {
+      const map = documentFor(`_site/${lang}/tags/index.html`);
+      assert.equal(map.documentElement.lang, lang);
+      assert.equal(map.querySelectorAll(".topic-card").length, 24);
+      assert.ok(map.querySelector('a[href="/' + lang + '/tags/git/"]'));
+      assert.ok(map.querySelector('nav a[href="/' + lang + '/tags/"]'));
+
+      const detail = documentFor(`_site/${lang}/tags/git/index.html`);
+      const articleLinks = [...detail.querySelectorAll(".archive-title")].map(
+        (link) => link.getAttribute("href")
+      );
+      assert.deepEqual(articleLinks, [`/${lang}/posts/tian/git-flow/`]);
+      assert.equal(detail.querySelector("h1").textContent.includes("Git"), true);
+    }
+  });
 });

--- a/test/test-tags.js
+++ b/test/test-tags.js
@@ -154,6 +154,9 @@ describe("built topic pages", () => {
     const document = documentFor("_site/tags/index.html");
     assert.equal(document.querySelectorAll(".topic-card").length, 92);
     assert.equal(document.querySelectorAll(".topic-card--candidate").length, 3);
+    // Every card carries an ember bake stage; the busiest topics reach 4.
+    assert.equal(document.querySelectorAll("[class*='topic-card--bake-']").length, 92);
+    assert.ok(document.querySelectorAll(".topic-card--bake-4").length >= 3);
     assert.equal(document.querySelector("#post-list"), null);
     assert.equal(document.querySelector(".archive-row"), null);
     assert.ok(document.querySelector('a[href="/tags/frontend/"]'));

--- a/test/test-ui-regression.js
+++ b/test/test-ui-regression.js
@@ -1,0 +1,103 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM, VirtualConsole } = require("jsdom");
+// jsdom 15 reports modern CSS syntax (for example color-mix()) as parse
+// warnings; route them into a muted VirtualConsole to keep test output clean.
+const quietConsole = new VirtualConsole();
+const metadata = require("../_data/metadata.json");
+const activeLanguages = require("../_11ty/activeLanguages.js");
+const languages = require("../_data/langs.json");
+
+const SITE_ROOT = path.resolve(__dirname, "..", "_site");
+
+function readPage(relative) {
+  const filename = path.join(SITE_ROOT, relative);
+  assert.ok(fs.existsSync(filename), `Missing build output: ${filename}`);
+  return fs.readFileSync(filename, "utf8");
+}
+
+function documentFor(relative) {
+  return new JSDOM(readPage(relative), { virtualConsole: quietConsole }).window.document;
+}
+
+function inlineStyle(relative) {
+  const match = readPage(relative).match(/<style>([\s\S]*?)<\/style>/);
+  assert.ok(match, `${relative}: no inlined <style> block`);
+  return match[1];
+}
+
+describe("language switcher markup", () => {
+  it("links available languages with hreflang and marks the current one", () => {
+    const doc = documentFor("index.html");
+    const switcher = doc.querySelector("details.lang-switch");
+    assert.ok(switcher, "missing language switcher");
+    const current = switcher.querySelector(".lang-switch__item.is-current");
+    assert.ok(current, "missing current-language marker");
+    for (const link of switcher.querySelectorAll("a.lang-switch__item")) {
+      assert.ok(link.getAttribute("hreflang"), "switcher link missing hreflang");
+      assert.equal(link.getAttribute("hreflang"), link.getAttribute("lang"));
+    }
+  });
+});
+
+describe("footer feed link", () => {
+  it("points at the current language's feed on every home page", () => {
+    for (const lang of activeLanguages(false)) {
+      const home = lang === languages[0] ? "index.html" : `${lang}/index.html`;
+      const prefix = lang === languages[0] ? "" : `/${lang}`;
+      const rss = documentFor(home).getElementById("rss");
+      assert.ok(rss, `${lang}: missing footer feed link`);
+      assert.equal(rss.getAttribute("href"), `${prefix}${metadata.feed.path}`);
+    }
+  });
+});
+
+// Pins the brand design-token decisions so later edits cannot silently
+// reintroduce the divergences the design audit removed.
+describe("brand token regression", () => {
+  it("defines the shared radius tokens on sampled pages", () => {
+    for (const page of ["index.html", "posts/tian/git-flow/index.html"]) {
+      const css = inlineStyle(page);
+      // --radius-control ships with the search layer (its only consumer).
+      for (const token of ["--radius-surface", "--radius-chip"]) {
+        assert.ok(css.includes(token), `${page}: missing ${token}`);
+      }
+    }
+  });
+
+  it("uses the ink-based shadow tint everywhere, never the off-brand one", () => {
+    for (const page of ["index.html", "posts/tian/git-flow/index.html"]) {
+      assert.ok(
+        !inlineStyle(page).includes("rgba(20,16,13"),
+        `${page}: off-brand shadow tint rgba(20,16,13,…) present`
+      );
+    }
+  });
+
+  it("keeps font weights on the 400/600/700 scale", () => {
+    for (const page of ["index.html", "posts/tian/git-flow/index.html"]) {
+      assert.ok(
+        !/font-weight:\s*650/.test(inlineStyle(page)),
+        `${page}: off-scale font-weight 650 present`
+      );
+    }
+  });
+
+  it("keeps the conditional topic-card candidate chrome through PurgeCSS", () => {
+    const css = inlineStyle("tags/index.html");
+    assert.ok(css.includes(".topic-card--candidate"));
+    assert.ok(css.includes(".topic-card__badge"));
+  });
+
+  it("keeps the global focus-visible ring on sampled pages", () => {
+    for (const page of ["index.html", "tags/index.html"]) {
+      assert.ok(
+        inlineStyle(page).includes(":focus-visible"),
+        `${page}: global :focus-visible ring purged`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## 概述

視覺與互動層：手機 header 重排、theme toggle 回歸原版品牌 icon、分享／回頂改為安靜的閱讀工具、`/tags/` 改為主題地圖、404 四語在地化。解 #230 與 #232。本層 header 暫為兩顆按鈕（Theme→Menu），搜尋鈕在 Stack 4。

## 變更內容

**Header 與閱讀工具**
- Theme toggle 使用原版月亮／太陽 icon（`img/dark.svg`／`light.svg` inline 為 currentColor），修正置中排版；光學等重調整：實心 icon 20px、線條 icon 統一 2px 筆畫
- 分享改為文章流內 44px pill：優先 `navigator.share`，fallback 站內複製（不再誤導向 Twitter）；回頂改小型圓形工具，修正舊 CSS specificity 造成的方形紅鈕
- footer 底部保留浮動工具高度，修正回頂鈕壓住 RSS icon
- Theme/Menu 的 aria-label、狀態同步、Escape、focus 行為改善

**主題地圖（解 #230）**
- `/tags/` 不再全文傾印：92 topic 卡片、文章數／烘焙師數統計、分類候選徽章；topic detail 顯示麵包清單；`/en|ja|zh-CN/tags/` 與 detail 在地化
- topic URL 由 taxonomy 固定 slug 決定，改顯示名稱不會移動已建立的頁面

**404 在地化（解 #232）**
- 404 四語輸出＋Netlify per-locale fallback（`/en/*` → `/en/404.html` 等，維持 HTTP 404）

**品牌一致性與工具鏈**
- radius tokens（`--radius-surface/control/chip`）；陰影統一 ink 基底；字重回 400/600/700 尺度；focus offset 統一 2px
- PurgeCSS whitelistPatterns 加 `/^topic-/`（purgecss@2 防剪）
- jsdom VirtualConsole 降噪（4 個 _11ty transforms＋全部測試檔）：build/test log 的 CSS parse warning 182→**0**
- about 頁補 meta description（SEO 測試抓到的真缺口）

## 驗證

- `npm run build` exit 0，**138 tests passing、0 CSS warning**
- 新增 `test-seo.js`（robots/OG/Twitter/feed links/sitemap）、`test-ui-regression.js`（品牌 token 防回歸、語言切換器、footer feed）、`test-functional-regression.js`（archive／llms.txt／#message）
- Playwright 截圖驗證：320/375/520px 零橫向溢出；光暗 × 首頁/主題地圖/404 無破版；三顆 icon（本層兩顆）視覺等重

## 缺口審計（有意保留）

- #229（非 zh-TW archive 入口）、#231（作者頁 hreflang）：未處理，不在本 stack 範圍
- `#reading-progress` 的 `#eac7a2`/`#5c3423` 字面值：餘燼色階 JS 漸層 fallback，註解已標明，非偏差
- 陰影在 dark mode 不反轉：全站既有慣例
- i18n 文案為待校對稿（見 Stack 2/4）

## 合併順序

Stack：1/4 → 2/4 → **3/4（本 PR，base: i18n/unified-copy）** → 4/4。前層合併後請 re-target 至 main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)