### PR TITLE
[Stack 4/4] feat(search): 全站搜尋「找麵包」——lazy 索引、四語 fallback、效能預算

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -60,6 +60,7 @@ const isDraftFrontmatter = require("./_11ty/draftFlag");
 const { buildAiCrawlRules } = require("./_11ty/aiCrawlPolicy");
 const { commentCountsByPath } = require("./_11ty/discussions");
 const { CSS_FILES } = require("./_11ty/css-bundle");
+const { buildSearchIndexJson } = require("./_11ty/search-index");
 const TAG_TAXONOMY = require("./_data/tagTaxonomy.json");
 const {
   buildTopicMap,
@@ -163,6 +164,12 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addFilter("cssmin", function (code) {
     return new CleanCSS({}).minify(code).styles;
+  });
+
+  // Build a static, published-only index. The browser fetches it lazily when
+  // the search dialog first opens, so ordinary page loads pay no index cost.
+  eleventyConfig.addFilter("searchIndex", function (posts, metadata, langs) {
+    return buildSearchIndexJson(posts, metadata, langs);
   });
 
   // Canonical topic URLs never depend on Eleventy's slug filter: changing a

--- a/_11ty/css-bundle.js
+++ b/_11ty/css-bundle.js
@@ -12,6 +12,7 @@ const CSS_FILES = Object.freeze([
   "css/components/lang-suggest.css",
   "css/components/header-nav.css",
   "css/components/reader-tools.css",
+  "css/components/search.css",
   "css/components/not-found.css",
 ]);
 

--- a/_11ty/search-index.js
+++ b/_11ty/search-index.js
@@ -1,0 +1,287 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const isDraftFrontmatter = require("./draftFlag");
+const { postPublishedDate } = require("./publication-dates");
+const DEFAULT_TAG_TAXONOMY = require("../_data/tagTaxonomy.json");
+
+const DEFAULT_LANG = "zh-TW";
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+function decodeEntities(value) {
+  const named = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: '"',
+  };
+  return String(value || "")
+    .replace(/&#x([0-9a-f]+);/gi, (_, code) =>
+      String.fromCodePoint(parseInt(code, 16))
+    )
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replace(/&([a-z]+);/gi, (match, name) => named[name.toLowerCase()] || match);
+}
+
+function normalizeWhitespace(value) {
+  return decodeEntities(value)
+    .replace(/\u00a0/g, " ")
+    .replace(/[\t\r\n ]+/g, " ")
+    .trim();
+}
+
+// Keep this normalization aligned with src/search-core.mjs. Aliases are
+// search-only data, so storing their normalized form once makes the shared
+// catalogue smaller and avoids shipping case/punctuation duplicates.
+function normalizeSearchValue(value) {
+  return String(value || "")
+    .normalize("NFKC")
+    .toLocaleLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\p{L}\p{N}+#.]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+/**
+ * Build one compact canonical → aliases catalogue for the whole index.
+ *
+ * Aliases are deliberately not copied onto every article: result rendering
+ * continues to receive canonical `tags`, while the scorer can consult this
+ * shared lookup. Only topics present in published indexed articles are sent.
+ */
+function buildTagAliases(articles, taxonomy = DEFAULT_TAG_TAXONOMY) {
+  const usedTags = new Set(
+    (articles || []).flatMap((article) =>
+      Array.isArray(article.tags) ? article.tags : []
+    )
+  );
+  const entries = [];
+  for (const [canonical, definition] of Object.entries(
+    (taxonomy && taxonomy.topics) || {}
+  )) {
+    if (!usedTags.has(canonical)) continue;
+    const seen = new Set([normalizeSearchValue(canonical)]);
+    const aliases = [];
+    for (const alias of (definition && definition.aliases) || []) {
+      const normalized = normalizeSearchValue(alias);
+      if (!normalized || seen.has(normalized)) continue;
+      seen.add(normalized);
+      aliases.push(normalized);
+    }
+    if (aliases.length) entries.push([canonical, aliases.join(" ")]);
+  }
+  return Object.fromEntries(entries);
+}
+
+function cleanInlineMarkdown(value) {
+  return normalizeWhitespace(
+    String(value || "")
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+      .replace(/<https?:\/\/[^>]+>/g, " ")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/`{1,3}([^`]+)`{1,3}/g, "$1")
+      .replace(/[*_~]/g, "")
+      .replace(/^\s*>+\s?/gm, "")
+  );
+}
+
+function markdownToSearchText(markdown) {
+  return normalizeWhitespace(
+    String(markdown || "")
+      .replace(FRONTMATTER_RE, "")
+      .replace(/<!--[\s\S]*?-->/g, " ")
+      .replace(/\{[%{][\s\S]*?[%}]\}/g, " ")
+      .replace(/^\s*```[^\n]*$/gm, " ")
+      .replace(/^\s*~~~[^\n]*$/gm, " ")
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+      .replace(/<https?:\/\/[^>]+>/g, " ")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+      .replace(/^\s*>+\s?/gm, "")
+      .replace(/^\s*[-+*]\s+/gm, "")
+      .replace(/^\s*\d+[.)]\s+/gm, "")
+      .replace(/`{1,3}([^`]+)`{1,3}/g, "$1")
+      .replace(/[*_~]/g, "")
+  );
+}
+
+function markdownHeadings(markdown) {
+  const headings = [];
+  const body = String(markdown || "").replace(FRONTMATTER_RE, "");
+  for (const match of body.matchAll(/^\s{0,3}#{2,6}\s+(.+?)\s*#*\s*$/gm)) {
+    const heading = cleanInlineMarkdown(match[1]);
+    if (heading && !headings.includes(heading)) headings.push(heading);
+  }
+  for (const match of body.matchAll(/<h[2-6][^>]*>([\s\S]*?)<\/h[2-6]>/gi)) {
+    const heading = cleanInlineMarkdown(match[1]);
+    if (heading && !headings.includes(heading)) headings.push(heading);
+  }
+  return headings;
+}
+
+function readSource(item) {
+  if (typeof item.rawInput === "string") return item.rawInput;
+  if (!item.inputPath) return "";
+  return fs.readFileSync(item.inputPath, "utf8");
+}
+
+function translationKey(item, langs) {
+  if (item.data && item.data.translationKey) return item.data.translationKey;
+  const known = (langs || [DEFAULT_LANG]).join("|");
+  const normalized = String(item.inputPath || "").replace(/\\/g, "/");
+  const match = normalized.match(
+    new RegExp(`posts/(.+?)(?:\\.(?:${known}))?\\.md$`)
+  );
+  return match ? match[1] : normalized;
+}
+
+function articleRecord(item, metadata, langs) {
+  const data = item.data || {};
+  const raw = readSource(item);
+  const frontmatter = (raw.match(FRONTMATTER_RE) || [])[1] || "";
+  if (
+    data.draft === true ||
+    data.draft === "true" ||
+    isDraftFrontmatter(frontmatter) ||
+    !item.url
+  ) {
+    return null;
+  }
+
+  const lang = data.lang || DEFAULT_LANG;
+  const authorKey = data.author || "";
+  const author = (metadata.authors && metadata.authors[authorKey]) || {};
+  const body = markdownToSearchText(raw);
+  const tags = [...new Set((data.tags || []).filter((tag) => tag !== "posts"))];
+  let published;
+  try {
+    published = postPublishedDate(item).toISOString().slice(0, 10);
+  } catch (error) {
+    published = "";
+  }
+  const key = translationKey(item, langs);
+  const description = normalizeWhitespace(data.description || body.slice(0, 240));
+
+  return {
+    id: `${key}|${lang}`,
+    translationKey: key,
+    title: normalizeWhitespace(data.title || path.basename(key)),
+    url: item.url,
+    lang,
+    author: {
+      key: authorKey,
+      name: normalizeWhitespace(author.name || authorKey),
+    },
+    tags,
+    published,
+    year: published ? published.slice(0, 4) : "",
+    slug: normalizeWhitespace(path.basename(key).replace(/[-_]+/g, " ")),
+    description,
+    headings: markdownHeadings(raw),
+    body,
+  };
+}
+
+function localizedBio(author, lang) {
+  return normalizeWhitespace(author[`intro_${lang}`] || author.intro || "");
+}
+
+function authorRecords(articles, metadata, langs) {
+  const grouped = new Map();
+  for (const article of articles) {
+    const key = article.author.key;
+    if (!key) continue;
+    if (!grouped.has(key)) {
+      grouped.set(key, {
+        versions: new Map(),
+        works: new Set(),
+        tagCounts: new Map(),
+      });
+    }
+    const group = grouped.get(key);
+    group.versions.set(
+      article.lang,
+      article.lang === DEFAULT_LANG
+        ? `/posts/${key}/`
+        : `/${article.lang}/posts/${key}/`
+    );
+    // Translations are editions of the same loaf, not extra contributions.
+    // Count each logical work once when deriving a baker's top topics.
+    if (!group.works.has(article.translationKey)) {
+      group.works.add(article.translationKey);
+      article.tags.forEach((tag) =>
+        group.tagCounts.set(tag, (group.tagCounts.get(tag) || 0) + 1)
+      );
+    }
+  }
+
+  return [...grouped.entries()]
+    .map(([key, group]) => {
+      const author = (metadata.authors && metadata.authors[key]) || {};
+      const bios = {};
+      for (const lang of langs || [DEFAULT_LANG]) {
+        const bio = localizedBio(author, lang);
+        if (bio) bios[lang] = bio;
+      }
+      return {
+        id: key,
+        name: normalizeWhitespace(author.name || key),
+        avatar: author.avatarUrl || "",
+        bios,
+        urls: Object.fromEntries(group.versions),
+        postCount: group.works.size,
+        topics: [...group.tagCounts]
+          .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0]))
+          .slice(0, 6)
+          .map(([tag]) => tag),
+      };
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function buildSearchIndex(
+  posts,
+  metadata,
+  langs,
+  taxonomy = DEFAULT_TAG_TAXONOMY
+) {
+  const articles = (posts || [])
+    .map((item) => articleRecord(item, metadata || {}, langs))
+    .filter(Boolean)
+    .sort((left, right) =>
+      right.published.localeCompare(left.published) || left.url.localeCompare(right.url)
+    );
+
+  return {
+    version: 1,
+    languages: langs || [DEFAULT_LANG],
+    tagAliases: buildTagAliases(articles, taxonomy),
+    articles,
+    authors: authorRecords(articles, metadata || {}, langs),
+  };
+}
+
+function buildSearchIndexJson(posts, metadata, langs, taxonomy) {
+  return JSON.stringify(buildSearchIndex(posts, metadata, langs, taxonomy))
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+}
+
+module.exports = {
+  buildSearchIndex,
+  buildSearchIndexJson,
+  buildTagAliases,
+  cleanInlineMarkdown,
+  markdownHeadings,
+  markdownToSearchText,
+  normalizeSearchValue,
+  normalizeWhitespace,
+};

--- a/_headers
+++ b/_headers
@@ -22,3 +22,8 @@
   Content-Type: application/feed+json; charset=utf-8
 /:lang/feed/feed.json
   Content-Type: application/feed+json; charset=utf-8
+
+/search-index.json
+  Content-Type: application/json; charset=utf-8
+  cache-control: public,max-age=300,must-revalidate
+  X-Robots-Tag: noindex, nofollow

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -223,6 +223,8 @@
 
         document.addEventListener("keydown", (e) => {
           if (e.key !== "Escape") return;
+          const searchDialog = document.getElementById("site-search");
+          if (searchDialog && searchDialog.open) return;
           if (langSwitch && langSwitch.open) {
             langSwitch.removeAttribute("open");
             langSwitch.querySelector("summary").focus();
@@ -240,7 +242,8 @@
         <div id="nav">
           <p class="site-title">
             <a href="{{ homeUrl | url }}" title="{{ t.homeLabel }}" aria-label="{{ t.siteName or metadata.title }}">
-              {{ t.siteName or metadata.title }}
+              <span class="site-title__full">{{ t.siteName or metadata.title }}</span>
+              <span class="site-title__compact" aria-hidden="true">ErrorBaker</span>
             </a>
           </p>
           {#- Read more about `eleventy-navigation` at https://www.11ty.dev/docs/plugins/navigation/ #}
@@ -280,6 +283,14 @@
             </ul>
           </details>
           </div>
+          <button id="search-toggle" class="search-toggle" type="button"
+            aria-haspopup="dialog" aria-controls="site-search" aria-expanded="false"
+            aria-label="{{ t.search.open }}">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <circle cx="10.75" cy="10.75" r="6.25"/>
+              <path d="m15.5 15.5 4 4"/>
+            </svg>
+          </button>
           <button id="color-scheme-toggle" type="button" aria-pressed="false"
             aria-label="{{ t.switchToDarkTheme }}"
             data-label-to-dark="{{ t.switchToDarkTheme }}"
@@ -323,6 +334,115 @@
       </noscript>
       {% endif %}
     </header>
+
+    <dialog id="site-search" class="search-dialog" aria-labelledby="search-title"
+      data-lang="{{ pageLang }}" data-index-url="{{ '/search-index.json' | url }}"
+      data-i18n="{{ t.search | dump }}">
+      <div class="search-dialog__shell">
+        <div class="search-dialog__heading">
+          <div>
+            <p class="search-dialog__eyebrow">ErrorBaker</p>
+            <h2 id="search-title">{{ t.search.title }}</h2>
+          </div>
+          <button class="search-dialog__close" type="button" aria-label="{{ t.search.close }}">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M6 6l12 12M18 6 6 18"/>
+            </svg>
+          </button>
+        </div>
+
+        <form class="search-form" role="search">
+          <label class="visually-hidden" for="search-input">{{ t.search.label }}</label>
+          <svg class="search-form__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="10.75" cy="10.75" r="6.25"/>
+            <path d="m15.5 15.5 4 4"/>
+          </svg>
+          <input id="search-input" class="search-form__input" type="search"
+            autocomplete="off" spellcheck="false" enterkeyhint="search"
+            placeholder="{{ t.search.placeholder }}" aria-describedby="search-help"
+            aria-controls="search-results">
+          <button class="search-form__clear" type="button" hidden aria-label="{{ t.search.clear }}">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M7 7l10 10M17 7 7 17"/>
+            </svg>
+          </button>
+          <kbd class="search-form__shortcut" aria-hidden="true">⌘K</kbd>
+        </form>
+        <p id="search-help" class="visually-hidden">{{ t.search.label }}</p>
+
+        <div class="search-dialog__body" aria-busy="false">
+          <p id="search-status" class="visually-hidden" role="status"
+            aria-live="polite" aria-atomic="true"></p>
+
+          <div class="search-state search-state--idle">
+            <svg class="search-state__icon" viewBox="0 0 64 64" aria-hidden="true" focusable="false">
+              <path d="M12 28h40v24H12zM18 28c0-9 6-16 14-16s14 7 14 16M22 20c3 2 6 3 10 3s7-1 10-3"/>
+            </svg>
+            <h3>{{ t.search.idleTitle }}</h3>
+            <p>{{ t.search.idleBody }}</p>
+          </div>
+
+          <div class="search-state search-state--loading" hidden>
+            <span class="search-spinner" aria-hidden="true"></span>
+            <p>{{ t.search.loading }}</p>
+          </div>
+
+          <div class="search-state search-state--empty" hidden>
+            <h3 class="search-empty__title"></h3>
+            <p class="search-empty__body">{{ t.search.noResultsBody }}</p>
+          </div>
+
+          <div class="search-state search-state--error" hidden>
+            <h3>{{ t.search.errorTitle }}</h3>
+            <p>{{ t.search.errorBody }}</p>
+            <button class="search-retry" type="button">{{ t.search.retry }}</button>
+          </div>
+
+          <div id="search-results" class="search-results" hidden>
+            <p class="search-fallback" hidden>{{ t.search.fallbackNotice }}</p>
+            <div class="search-group search-group--articles" hidden>
+              <h3>{{ t.search.articlesHeading }}</h3>
+              <ul class="search-result-list search-result-list--articles"></ul>
+            </div>
+            <div class="search-group search-group--authors" hidden>
+              <h3>{{ t.search.authorsHeading }}</h3>
+              <ul class="search-result-list search-result-list--authors"></ul>
+            </div>
+            <div class="search-group search-group--other" hidden>
+              <h3>{{ t.search.otherLanguagesHeading }}</h3>
+              <ul class="search-result-list search-result-list--other"></ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <template id="search-article-template">
+        <li class="search-result search-result--article">
+          <a class="search-result__link">
+            <span class="search-result__topline">
+              <strong class="search-result__title"></strong>
+              <span class="search-result__lang"></span>
+            </span>
+            <span class="search-result__meta"></span>
+            <span class="search-result__snippet"></span>
+            <span class="search-result__reason"></span>
+          </a>
+        </li>
+      </template>
+
+      <template id="search-author-template">
+        <li class="search-result search-result--author">
+          <a class="search-result__link search-result__link--author">
+            <img class="search-result__avatar" alt="" loading="lazy">
+            <span class="search-result__author-body">
+              <strong class="search-result__title"></strong>
+              <span class="search-result__meta"></span>
+              <span class="search-result__snippet"></span>
+            </span>
+          </a>
+        </li>
+      </template>
+    </dialog>
 
     <main id="main">
       <article>

--- a/css/components/search.css
+++ b/css/components/search.css
@@ -1,0 +1,426 @@
+/* ════════════════════════════════════════════════════════════════════════
+   FIND A LOAF — site-wide command palette
+   The index is fetched only when this dialog first opens. All selectors are
+   component-scoped to out-rank the starter stylesheet's form/dialog defaults.
+   ════════════════════════════════════════════════════════════════════════ */
+.site-title__compact {
+  display: none;
+}
+
+#nav > button.search-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 44px;
+  width: 44px;
+  height: 44px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+}
+
+#nav > button.search-toggle:hover {
+  background: color-mix(in srgb, var(--ink) 6%, transparent);
+  color: var(--accent);
+}
+
+.search-toggle svg,
+.search-dialog button svg,
+.search-form__icon {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: currentColor;
+  /* Match the hamburger's 2px bars so all header line icons share one
+     stroke weight. */
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+
+dialog.search-dialog {
+  position: fixed;
+  inset: 0;
+  width: min(calc(100% - 2rem), 46rem);
+  height: min(42rem, calc(100dvh - 3rem));
+  max-width: none;
+  max-height: none;
+  margin: auto;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--rule-strong);
+  border-radius: var(--radius-surface);
+  background: var(--paper);
+  color: var(--ink);
+  font-size: 1rem;
+  line-height: 1.5;
+  opacity: 1;
+  box-shadow: 0 24px 80px rgba(31, 29, 27, 0.28);
+}
+
+dialog.search-dialog::backdrop {
+  background: rgba(31, 29, 27, 0.52);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+}
+
+.search-dialog__shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.search-dialog__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.2rem 1.25rem 0.75rem;
+}
+
+.search-dialog__eyebrow {
+  margin: 0 0 0.1rem;
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.search-dialog__heading h2 {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-serif);
+  font-size: 1.45rem;
+  line-height: 1.2;
+}
+
+.search-dialog button.search-dialog__close,
+.search-dialog button.search-form__clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 44px;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  min-height: 44px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--ink-soft);
+}
+
+.search-dialog button.search-dialog__close:hover,
+.search-dialog button.search-form__clear:hover {
+  background: var(--rule);
+  color: var(--ink);
+}
+
+.search-form {
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin: 0 1.25rem;
+  padding: 0;
+  border: 1px solid var(--rule-strong);
+  border-radius: var(--radius-control);
+  background: var(--paper-raised);
+  box-shadow: 0 5px 20px rgba(31, 29, 27, 0.06);
+}
+
+.search-form:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.search-form__icon {
+  flex: 0 0 22px;
+  margin-left: 0.9rem;
+  color: var(--ink-faint);
+}
+
+.search-form input.search-form__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 52px;
+  margin: 0;
+  padding: 0.7rem 0.75rem;
+  border: 0;
+  border-radius: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--ink);
+  font-size: 1rem;
+  line-height: 1.4;
+}
+
+.search-form__input::placeholder {
+  color: var(--ink-faint);
+  opacity: 1;
+}
+
+.search-form__input::-webkit-search-cancel-button,
+.search-form__input::-webkit-search-decoration {
+  display: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.search-form__shortcut {
+  margin-right: 0.65rem;
+  padding: 0.16rem 0.38rem;
+  border: 1px solid var(--rule);
+  border-bottom-color: var(--rule-strong);
+  border-radius: var(--radius-chip);
+  background: var(--paper);
+  color: var(--ink-faint);
+  font-family: inherit;
+  font-size: 0.68rem;
+  line-height: 1.4;
+}
+
+.search-dialog__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0.9rem 1.25rem 1.3rem;
+}
+
+.search-state {
+  display: grid;
+  place-items: center;
+  min-height: 15rem;
+  padding: 2rem;
+  text-align: center;
+  color: var(--ink-soft);
+}
+
+.search-state[hidden] {
+  display: none;
+}
+
+.search-state h3 {
+  margin: 0.8rem 0 0.3rem;
+  color: var(--ink);
+  font-family: var(--font-serif);
+  font-size: 1.2rem;
+}
+
+.search-state p {
+  max-width: 28rem;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.search-state__icon {
+  width: 64px;
+  height: 64px;
+  fill: none;
+  stroke: var(--rule-strong);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.search-spinner {
+  width: 32px;
+  height: 32px;
+  border: 2px solid var(--rule-strong);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: search-spin 0.75s linear infinite;
+}
+
+@keyframes search-spin {
+  to { transform: rotate(360deg); }
+}
+
+.search-dialog button.search-retry {
+  min-height: 44px;
+  margin: 1rem 0 0;
+  padding: 0.55rem 0.9rem;
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--accent);
+}
+
+.search-fallback {
+  margin: 0 0 1rem;
+  padding: 0.7rem 0.85rem;
+  border-left: 3px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+  color: var(--ink-soft);
+  font-size: 0.83rem;
+}
+
+.search-group[hidden],
+.search-results[hidden],
+.search-fallback[hidden] {
+  display: none;
+}
+
+.search-group + .search-group {
+  margin-top: 1.25rem;
+}
+
+.search-group h3 {
+  margin: 0 0 0.45rem;
+  color: var(--ink-faint);
+  font-family: inherit;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.search-result-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.search-result {
+  margin: 0;
+  border-top: 1px solid var(--rule);
+}
+
+.search-result:first-child {
+  border-top: 0;
+}
+
+.search-result__link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.24rem;
+  margin: 0;
+  padding: 0.75rem 0.65rem;
+  border-radius: var(--radius-control);
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.search-result__link:hover,
+.search-result__link:focus-visible {
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+  color: var(--ink);
+}
+
+.search-result__topline {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.search-result__title {
+  color: var(--ink);
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+.search-result__lang,
+.search-result__reason {
+  flex: 0 0 auto;
+  color: var(--accent);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.search-result__meta {
+  color: var(--ink-faint);
+  font-size: 0.75rem;
+}
+
+.search-result__snippet {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.search-result__link--author {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr);
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.search-result__avatar {
+  width: 48px;
+  height: 48px;
+  margin: 0;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.search-result__author-body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.18rem;
+}
+
+@media (max-width: 840px) {
+  #nav {
+    gap: 0.35rem;
+  }
+}
+
+/* Three 44px actions need more room than the old two-action header. Switch to
+   the compact wordmark before the menu can be pushed outside the viewport. */
+@media (max-width: 520px) {
+  .site-title__full {
+    display: none;
+  }
+  .site-title__compact {
+    display: inline;
+  }
+}
+
+@media (max-width: 600px) {
+  dialog.search-dialog {
+    width: 100%;
+    height: 100dvh;
+    border: 0;
+    border-radius: 0;
+  }
+  .search-dialog__heading {
+    padding-top: max(0.85rem, env(safe-area-inset-top));
+  }
+  .search-dialog__heading,
+  .search-dialog__body {
+    padding-right: max(1rem, env(safe-area-inset-right));
+    padding-left: max(1rem, env(safe-area-inset-left));
+  }
+  .search-form {
+    margin-right: max(1rem, env(safe-area-inset-right));
+    margin-left: max(1rem, env(safe-area-inset-left));
+  }
+  .search-form__shortcut {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-spinner {
+    animation: none;
+  }
+}

--- a/robots.njk
+++ b/robots.njk
@@ -26,6 +26,10 @@ Allow: /
 
 User-agent: {{ bot }}
 Allow: /
+{#- The site-wide search index centralizes full article text, including work by
+    authors who have not opted in to AI crawling. Keep that aggregate endpoint
+    outside every generative crawler's allowed surface. #}
+Disallow: /search-index.json
 {%- for path in rules.disallowPaths %}
 Disallow: {{ path }}
 {%- endfor %}

--- a/search-index.json.njk
+++ b/search-index.json.njk
@@ -1,0 +1,6 @@
+---
+permalink: /search-index.json
+eleventyExcludeFromCollections: true
+sitemapExclude: true
+---
+{{ collections.posts | searchIndex(metadata, langs) | safe }}

--- a/src/main.js
+++ b/src/main.js
@@ -18,7 +18,15 @@
  * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+import { initSiteSearch } from "./search-ui.mjs";
+
 const exposed = {};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initSiteSearch, { once: true });
+} else {
+  initSiteSearch();
+}
 
 // Page-language UI strings, injected by base.njk on <dialog id="message">
 // (same pattern as the lang-suggest banner's data-strings).

--- a/src/search-core.mjs
+++ b/src/search-core.mjs
@@ -1,0 +1,258 @@
+const CJK_RE = /[\u3040-\u30ff\u3400-\u9fff\uf900-\ufaff]/;
+const WORD_RE = /[\p{L}\p{N}+#.]+/gu;
+const articleFieldsCache = new WeakMap();
+const authorFieldsCache = new WeakMap();
+
+export function normalizeText(value) {
+  return String(value || "")
+    .normalize("NFKC")
+    .toLocaleLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^\p{L}\p{N}+#.]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function words(value) {
+  return normalizeText(value).match(WORD_RE) || [];
+}
+
+function bigrams(value) {
+  const compact = normalizeText(value).replace(/\s+/g, "");
+  if (compact.length < 2) return compact ? [compact] : [];
+  const out = [];
+  for (let index = 0; index < compact.length - 1; index += 1) {
+    out.push(compact.slice(index, index + 2));
+  }
+  return out;
+}
+
+function diceCoefficient(left, right) {
+  const a = bigrams(left);
+  const b = bigrams(right);
+  if (!a.length || !b.length) return 0;
+  const remaining = [...b];
+  let overlap = 0;
+  for (const pair of a) {
+    const index = remaining.indexOf(pair);
+    if (index === -1) continue;
+    overlap += 1;
+    remaining.splice(index, 1);
+  }
+  return (2 * overlap) / (a.length + b.length);
+}
+
+export function damerauLevenshtein(left, right, maxDistance = Infinity) {
+  const a = normalizeText(left);
+  const b = normalizeText(right);
+  if (Math.abs(a.length - b.length) > maxDistance) return maxDistance + 1;
+  if (!a) return b.length;
+  if (!b) return a.length;
+
+  let previousPrevious = null;
+  let previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  for (let row = 1; row <= a.length; row += 1) {
+    const current = [row];
+    let rowMinimum = current[0];
+    for (let column = 1; column <= b.length; column += 1) {
+      const substitution = previous[column - 1] +
+        (a[row - 1] === b[column - 1] ? 0 : 1);
+      let distance = Math.min(
+        previous[column] + 1,
+        current[column - 1] + 1,
+        substitution
+      );
+      if (
+        previousPrevious &&
+        row > 1 &&
+        column > 1 &&
+        a[row - 1] === b[column - 2] &&
+        a[row - 2] === b[column - 1]
+      ) {
+        distance = Math.min(distance, previousPrevious[column - 2] + 1);
+      }
+      current[column] = distance;
+      rowMinimum = Math.min(rowMinimum, distance);
+    }
+    if (rowMinimum > maxDistance) return maxDistance + 1;
+    previousPrevious = previous;
+    previous = current;
+  }
+  return previous[b.length];
+}
+
+function tokenQuality(field, token, fuzzy) {
+  if (!field || !token) return 0;
+  if (field === token) return 1;
+  if (field.startsWith(token)) return 0.94;
+  if (field.includes(token)) return 0.86;
+  if (!fuzzy) return 0;
+
+  if (CJK_RE.test(token)) {
+    const dice = diceCoefficient(field, token);
+    return dice >= 0.5 ? Math.min(0.78, 0.42 + dice * 0.36) : 0;
+  }
+
+  if (token.length < 4) return 0;
+  const maxDistance = token.length >= 8 ? 2 : 1;
+  let best = 0;
+  for (const candidate of words(field)) {
+    if (Math.abs(candidate.length - token.length) > maxDistance) continue;
+    const distance = damerauLevenshtein(candidate, token, maxDistance);
+    if (distance <= maxDistance) {
+      best = Math.max(best, 0.78 - distance * 0.1);
+    }
+  }
+  return best;
+}
+
+function fieldQuality(field, normalizedQuery, fuzzy = true) {
+  if (!field || !normalizedQuery) return 0;
+  if (field === normalizedQuery) return 1;
+  if (field.startsWith(normalizedQuery)) return 0.96;
+  if (field.includes(normalizedQuery)) return 0.9;
+
+  const queryTokens = words(normalizedQuery);
+  if (!queryTokens.length) return 0;
+  const qualities = queryTokens.map((token) => tokenQuality(field, token, fuzzy));
+  if (qualities.some((quality) => quality < 0.58)) return 0;
+  return qualities.reduce((sum, quality) => sum + quality, 0) / qualities.length;
+}
+
+function weightedScore(fields, query) {
+  const normalizedQuery = normalizeText(query);
+  const matches = fields
+    .map((field) => ({
+      name: field.name,
+      score: field.weight * fieldQuality(field.value, normalizedQuery, field.fuzzy),
+    }))
+    .filter((match) => match.score > 0)
+    .sort((left, right) => right.score - left.score);
+  if (!matches.length) return { score: 0, matchedField: "" };
+  const score = matches[0].score +
+    matches.slice(1, 4).reduce((sum, match) => sum + match.score * 0.08, 0);
+  return { score, matchedField: matches[0].name };
+}
+
+function normalizedValue(value) {
+  return normalizeText(Array.isArray(value) ? value.join(" ") : value);
+}
+
+function articleFields(article, tagAliases) {
+  let fields = articleFieldsCache.get(article);
+  if (fields) return fields;
+  const aliasText = (article.tags || [])
+    .map((tag) => (tagAliases || {})[tag])
+    .filter(Boolean)
+    .join(" ");
+  fields = [
+    { name: "title", value: normalizedValue(article.title), weight: 120, fuzzy: true },
+    { name: "tag", value: normalizedValue([...(article.tags || []), aliasText]), weight: 96, fuzzy: true },
+    { name: "heading", value: normalizedValue(article.headings), weight: 78, fuzzy: true },
+    { name: "author", value: normalizedValue([article.author.name, article.author.key]), weight: 70, fuzzy: true },
+    { name: "description", value: normalizedValue(article.description), weight: 55, fuzzy: true },
+    { name: "slug", value: normalizedValue(article.slug), weight: 42, fuzzy: true },
+    { name: "year", value: normalizedValue(article.year), weight: 30, fuzzy: false },
+    { name: "content", value: normalizedValue(article.body), weight: 18, fuzzy: false },
+  ];
+  articleFieldsCache.set(article, fields);
+  return fields;
+}
+
+function authorFields(author, currentLang) {
+  let byLanguage = authorFieldsCache.get(author);
+  if (!byLanguage) {
+    byLanguage = new Map();
+    authorFieldsCache.set(author, byLanguage);
+  }
+  if (byLanguage.has(currentLang)) return byLanguage.get(currentLang);
+  const currentBio = author.bios[currentLang] || author.bios["zh-TW"] || "";
+  const fields = [
+    { name: "author", value: normalizedValue(author.name), weight: 116, fuzzy: true },
+    { name: "author", value: normalizedValue(author.id), weight: 100, fuzzy: true },
+    { name: "tag", value: normalizedValue(author.topics), weight: 68, fuzzy: true },
+    { name: "description", value: normalizedValue(currentBio), weight: 58, fuzzy: true },
+    { name: "description", value: normalizedValue(Object.values(author.bios).join(" ")), weight: 40, fuzzy: true },
+  ];
+  byLanguage.set(currentLang, fields);
+  return fields;
+}
+
+export function scoreArticle(article, query, currentLang, tagAliases) {
+  const match = weightedScore(articleFields(article, tagAliases), query);
+  if (match.score > 0 && article.lang === currentLang) match.score += 12;
+  return match;
+}
+
+export function scoreAuthor(author, query, currentLang) {
+  return weightedScore(authorFields(author, currentLang), query);
+}
+
+function articleOrder(left, right, currentLang) {
+  return right.score - left.score ||
+    Number(right.item.lang === currentLang) - Number(left.item.lang === currentLang) ||
+    right.item.published.localeCompare(left.item.published) ||
+    left.item.id.localeCompare(right.item.id);
+}
+
+export function searchIndex(index, query, options = {}) {
+  const currentLang = options.lang || "zh-TW";
+  const limit = options.limit || 12;
+  const normalizedQuery = normalizeText(query);
+  if (!normalizedQuery) {
+    return { articles: [], otherArticles: [], authors: [], total: 0 };
+  }
+
+  const byWork = new Map();
+  for (const article of index.articles || []) {
+    const match = scoreArticle(article, normalizedQuery, currentLang, index.tagAliases);
+    if (match.score < 12) continue;
+    const result = { item: article, ...match };
+    const previous = byWork.get(article.translationKey);
+    if (!previous || articleOrder(result, previous, currentLang) < 0) {
+      byWork.set(article.translationKey, result);
+    }
+  }
+  const rankedArticles = [...byWork.values()]
+    .sort((left, right) => articleOrder(left, right, currentLang));
+  const articles = rankedArticles
+    .filter((result) => result.item.lang === currentLang)
+    .slice(0, limit);
+  const otherArticles = rankedArticles
+    .filter((result) => result.item.lang !== currentLang)
+    .slice(0, Math.max(4, Math.floor(limit / 2)));
+
+  const authors = (index.authors || [])
+    .map((author) => ({ item: author, ...scoreAuthor(author, normalizedQuery, currentLang) }))
+    .filter((result) => result.score >= 20)
+    .sort((left, right) => right.score - left.score || left.item.name.localeCompare(right.item.name))
+    .slice(0, 5);
+
+  return {
+    articles,
+    otherArticles,
+    authors,
+    total: articles.length + otherArticles.length + authors.length,
+  };
+}
+
+export function makeSnippet(article, query, maxLength = 170) {
+  const candidates = [article.description, ...(article.headings || []), article.body]
+    .filter(Boolean);
+  const normalizedQuery = normalizeText(query);
+  let source = candidates[0] || "";
+  let index = -1;
+  for (const candidate of candidates) {
+    const candidateIndex = normalizeText(candidate).indexOf(normalizedQuery);
+    if (candidateIndex >= 0) {
+      source = candidate;
+      index = candidateIndex;
+      break;
+    }
+  }
+  if (source.length <= maxLength) return source;
+  const start = Math.max(0, index < 0 ? 0 : index - Math.floor(maxLength * 0.35));
+  const end = Math.min(source.length, start + maxLength);
+  return `${start > 0 ? "…" : ""}${source.slice(start, end).trim()}${end < source.length ? "…" : ""}`;
+}

--- a/src/search-ui.mjs
+++ b/src/search-ui.mjs
@@ -1,0 +1,398 @@
+import { makeSnippet, normalizeText, searchIndex } from "./search-core.mjs";
+
+const MIN_QUERY_LENGTH = 2;
+const SEARCH_DELAY_MS = 140;
+
+function replaceToken(value, token, replacement) {
+  return String(value || "").split(`{${token}}`).join(String(replacement));
+}
+
+function internalUrl(value) {
+  try {
+    const url = new URL(value, window.location.origin);
+    if (url.origin !== window.location.origin) return "";
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch (error) {
+    return "";
+  }
+}
+
+function imageUrl(value) {
+  try {
+    const url = new URL(value, window.location.origin);
+    return url.protocol === "https:" || url.origin === window.location.origin
+      ? url.href
+      : "";
+  } catch (error) {
+    return "";
+  }
+}
+
+function languageName(code, displayLocale) {
+  try {
+    return new Intl.DisplayNames([displayLocale], { type: "language" }).of(code) || code;
+  } catch (error) {
+    return code;
+  }
+}
+
+function formattedDate(value, locale) {
+  if (!value) return "";
+  try {
+    return new Intl.DateTimeFormat(locale, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      timeZone: "UTC",
+    }).format(new Date(`${value}T00:00:00Z`));
+  } catch (error) {
+    return value;
+  }
+}
+
+export function initSiteSearch() {
+  const dialog = document.getElementById("site-search");
+  const toggle = document.getElementById("search-toggle");
+  if (!dialog || !toggle) return;
+
+  const input = dialog.querySelector("#search-input");
+  const form = dialog.querySelector(".search-form");
+  const closeButton = dialog.querySelector(".search-dialog__close");
+  const clearButton = dialog.querySelector(".search-form__clear");
+  const retryButton = dialog.querySelector(".search-retry");
+  const body = dialog.querySelector(".search-dialog__body");
+  const status = dialog.querySelector("#search-status");
+  const resultsRoot = dialog.querySelector("#search-results");
+  const fallback = dialog.querySelector(".search-fallback");
+  const emptyTitle = dialog.querySelector(".search-empty__title");
+  const emptyBody = dialog.querySelector(".search-empty__body");
+  const articleTemplate = dialog.querySelector("#search-article-template");
+  const authorTemplate = dialog.querySelector("#search-author-template");
+  const shortcut = dialog.querySelector(".search-form__shortcut");
+  const groups = {
+    articles: dialog.querySelector(".search-group--articles"),
+    authors: dialog.querySelector(".search-group--authors"),
+    other: dialog.querySelector(".search-group--other"),
+  };
+  const lists = {
+    articles: dialog.querySelector(".search-result-list--articles"),
+    authors: dialog.querySelector(".search-result-list--authors"),
+    other: dialog.querySelector(".search-result-list--other"),
+  };
+  const states = {
+    idle: dialog.querySelector(".search-state--idle"),
+    loading: dialog.querySelector(".search-state--loading"),
+    empty: dialog.querySelector(".search-state--empty"),
+    error: dialog.querySelector(".search-state--error"),
+  };
+
+  if (!input || !form || !articleTemplate || !authorTemplate) return;
+
+  let strings = {};
+  try {
+    strings = JSON.parse(dialog.getAttribute("data-i18n") || "{}");
+  } catch (error) {}
+
+  const locale = dialog.getAttribute("data-lang") || "zh-TW";
+  const indexUrl = dialog.getAttribute("data-index-url") || "/search-index.json";
+  let indexPromise = null;
+  let searchTimer = 0;
+  let searchSequence = 0;
+  let restoreFocus = toggle;
+
+  if (shortcut) {
+    shortcut.textContent = /Mac|iPhone|iPad/.test(navigator.platform || "")
+      ? "⌘K"
+      : "Ctrl K";
+  }
+
+  function setState(name) {
+    Object.keys(states).forEach((key) => {
+      if (states[key]) states[key].hidden = key !== name;
+    });
+    resultsRoot.hidden = name !== "results";
+    body.setAttribute("aria-busy", String(name === "loading"));
+  }
+
+  function clearResults() {
+    Object.values(lists).forEach((list) => list.replaceChildren());
+    Object.values(groups).forEach((group) => {
+      group.hidden = true;
+    });
+    fallback.hidden = true;
+  }
+
+  function loadIndex(force) {
+    if (force) indexPromise = null;
+    if (!indexPromise) {
+      indexPromise = fetch(indexUrl, {
+        credentials: "same-origin",
+        headers: { Accept: "application/json" },
+      }).then((response) => {
+        if (!response.ok) throw new Error(`Search index: ${response.status}`);
+        return response.json();
+      });
+    }
+    return indexPromise;
+  }
+
+  async function retryIndex() {
+    const sequence = ++searchSequence;
+    setState("loading");
+    status.textContent = strings.loading || "";
+    try {
+      await loadIndex(true);
+      if (sequence !== searchSequence) return;
+      if (input.value.trim()) runSearch(false);
+      else {
+        status.textContent = "";
+        setState("idle");
+      }
+    } catch (error) {
+      if (sequence !== searchSequence) return;
+      indexPromise = null;
+      status.textContent = strings.errorTitle || "";
+      setState("error");
+    }
+  }
+
+  function matchReason(field) {
+    const key = {
+      title: "matchTitle",
+      tag: "matchTag",
+      author: "matchAuthor",
+      heading: "matchHeading",
+      description: "matchDescription",
+      content: "matchContent",
+      slug: "matchSlug",
+      year: "matchYear",
+    }[field];
+    return key ? strings[key] || "" : "";
+  }
+
+  function renderArticle(result, list) {
+    const article = result.item;
+    const href = internalUrl(article.url);
+    if (!href) return;
+    const fragment = articleTemplate.content.cloneNode(true);
+    const link = fragment.querySelector("a");
+    const lang = fragment.querySelector(".search-result__lang");
+    link.href = href;
+    fragment.querySelector(".search-result__title").textContent = article.title;
+    lang.textContent = article.lang === locale
+      ? ""
+      : languageName(article.lang, locale);
+    lang.hidden = article.lang === locale;
+
+    const meta = [
+      article.author && article.author.name,
+      formattedDate(article.published, locale),
+      (article.tags || []).slice(0, 3).join(" · "),
+    ].filter(Boolean);
+    fragment.querySelector(".search-result__meta").textContent = meta.join("  ·  ");
+    fragment.querySelector(".search-result__snippet").textContent =
+      makeSnippet(article, input.value, 170);
+    fragment.querySelector(".search-result__reason").textContent =
+      matchReason(result.matchedField);
+    list.appendChild(fragment);
+  }
+
+  function authorUrl(author) {
+    return internalUrl(
+      (author.urls && author.urls[locale]) ||
+      (author.urls && author.urls["zh-TW"]) ||
+      Object.values(author.urls || {})[0] ||
+      ""
+    );
+  }
+
+  function renderAuthor(result) {
+    const author = result.item;
+    const href = authorUrl(author);
+    if (!href) return;
+    const fragment = authorTemplate.content.cloneNode(true);
+    const link = fragment.querySelector("a");
+    const avatar = fragment.querySelector("img");
+    const avatarSource = imageUrl(author.avatar);
+    link.href = href;
+    fragment.querySelector(".search-result__title").textContent = author.name;
+    if (avatarSource) {
+      avatar.src = avatarSource;
+    } else {
+      avatar.remove();
+    }
+    const count = replaceToken(strings.authorPostCount, "count", author.postCount);
+    const topics = (author.topics || []).slice(0, 3).join(" · ");
+    fragment.querySelector(".search-result__meta").textContent =
+      [count, topics].filter(Boolean).join("  ·  ");
+    fragment.querySelector(".search-result__snippet").textContent =
+      (author.bios && (author.bios[locale] || author.bios["zh-TW"])) || "";
+    lists.authors.appendChild(fragment);
+  }
+
+  function renderResults(found, query) {
+    clearResults();
+    found.articles.forEach((result) => renderArticle(result, lists.articles));
+    found.authors.forEach(renderAuthor);
+    found.otherArticles.forEach((result) => renderArticle(result, lists.other));
+
+    groups.articles.hidden = !lists.articles.children.length;
+    groups.authors.hidden = !lists.authors.children.length;
+    groups.other.hidden = !lists.other.children.length;
+    fallback.hidden = Boolean(lists.articles.children.length) ||
+      !lists.other.children.length;
+
+    const renderedCount = dialog.querySelectorAll(".search-result__link").length;
+    if (!renderedCount) {
+      emptyTitle.textContent = replaceToken(strings.noResultsTitle, "query", query);
+      emptyBody.textContent = strings.noResultsBody || "";
+      status.textContent = emptyTitle.textContent;
+      setState("empty");
+      return;
+    }
+    status.textContent = replaceToken(strings.resultCount, "count", renderedCount);
+    setState("results");
+  }
+
+  async function runSearch(forceReload) {
+    const sequence = ++searchSequence;
+    const query = input.value.trim();
+    clearButton.hidden = !query;
+    clearResults();
+
+    if (!query) {
+      status.textContent = "";
+      setState("idle");
+      return;
+    }
+    if (normalizeText(query).replace(/\s/g, "").length < MIN_QUERY_LENGTH) {
+      status.textContent = strings.minChars || "";
+      emptyTitle.textContent = strings.minChars || "";
+      emptyBody.textContent = "";
+      setState("empty");
+      return;
+    }
+
+    setState("loading");
+    status.textContent = strings.loading || "";
+    try {
+      const index = await loadIndex(forceReload);
+      if (sequence !== searchSequence) return;
+      renderResults(searchIndex(index, query, { lang: locale, limit: 12 }), query);
+    } catch (error) {
+      if (sequence !== searchSequence) return;
+      indexPromise = null;
+      status.textContent = strings.errorTitle || "";
+      setState("error");
+    }
+  }
+
+  function scheduleSearch() {
+    window.clearTimeout(searchTimer);
+    searchTimer = window.setTimeout(() => runSearch(false), SEARCH_DELAY_MS);
+  }
+
+  function openSearch(trigger) {
+    restoreFocus = trigger || toggle;
+    const nav = document.getElementById("nav");
+    const navToggle = document.getElementById("nav-toggle");
+    const langSwitch = document.querySelector(".lang-switch[open]");
+    if (nav) nav.classList.remove("nav-open");
+    if (navToggle) {
+      navToggle.setAttribute("aria-expanded", "false");
+      navToggle.setAttribute("aria-label", navToggle.dataset.labelOpen || "");
+    }
+    if (langSwitch) langSwitch.removeAttribute("open");
+
+    if (!dialog.open) {
+      if (typeof dialog.showModal === "function") dialog.showModal();
+      else dialog.setAttribute("open", "");
+    }
+    toggle.setAttribute("aria-expanded", "true");
+    requestAnimationFrame(() => input.focus());
+
+    if (!indexPromise) {
+      setState("loading");
+      status.textContent = strings.loading || "";
+      loadIndex(false).then(
+        () => {
+          if (!dialog.open) return;
+          if (input.value.trim()) runSearch(false);
+          else {
+            status.textContent = "";
+            setState("idle");
+          }
+        },
+        () => {
+          if (!dialog.open) return;
+          indexPromise = null;
+          status.textContent = strings.errorTitle || "";
+          setState("error");
+        }
+      );
+    } else if (input.value.trim()) {
+      runSearch(false);
+    }
+  }
+
+  function closeSearch() {
+    if (typeof dialog.close === "function") dialog.close();
+    else {
+      dialog.removeAttribute("open");
+      toggle.setAttribute("aria-expanded", "false");
+      restoreFocus.focus();
+    }
+  }
+
+  toggle.addEventListener("click", () => openSearch(toggle));
+  closeButton.addEventListener("click", closeSearch);
+  clearButton.addEventListener("click", () => {
+    input.value = "";
+    clearButton.hidden = true;
+    runSearch(false);
+    input.focus();
+  });
+  retryButton.addEventListener("click", retryIndex);
+  input.addEventListener("input", scheduleSearch);
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const first = dialog.querySelector(".search-result__link");
+    if (first) first.click();
+  });
+
+  input.addEventListener("keydown", (event) => {
+    if (event.key !== "ArrowDown") return;
+    const first = dialog.querySelector(".search-result__link");
+    if (first) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+
+  dialog.addEventListener("keydown", (event) => {
+    if (event.key !== "ArrowUp") return;
+    const first = dialog.querySelector(".search-result__link");
+    if (first && document.activeElement === first) {
+      event.preventDefault();
+      input.focus();
+    }
+  });
+
+  dialog.addEventListener("cancel", () => {
+    toggle.setAttribute("aria-expanded", "false");
+  });
+  dialog.addEventListener("close", () => {
+    toggle.setAttribute("aria-expanded", "false");
+    if (restoreFocus && typeof restoreFocus.focus === "function") restoreFocus.focus();
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (!(event.metaKey || event.ctrlKey) || event.altKey || event.key.toLowerCase() !== "k") {
+      return;
+    }
+    event.preventDefault();
+    if (dialog.open) input.focus();
+    else openSearch(toggle);
+  });
+}

--- a/test/test-css-output.js
+++ b/test/test-css-output.js
@@ -65,6 +65,7 @@ describe("purged CSS output", () => {
       "css/components/lang-suggest.css",
       "css/components/header-nav.css",
       "css/components/reader-tools.css",
+      "css/components/search.css",
       "css/components/not-found.css",
     ]);
 
@@ -72,23 +73,28 @@ describe("purged CSS output", () => {
     const bannerStart = css.indexOf("Locale-suggestion banner");
     const headerStart = css.indexOf("HEADER — quiet editorial top bar");
     const readerToolsStart = css.indexOf("READER TOOLS — quiet");
+    const searchStart = css.indexOf("FIND A LOAF — site-wide");
     const notFoundStart = css.indexOf(".not-found {");
     assert.ok(bannerStart > -1, "Expected the locale suggestion component");
     assert.ok(headerStart > bannerStart, "Expected header styles after banner styles");
     assert.ok(readerToolsStart > headerStart, "Expected reader tools after header styles");
-    assert.ok(notFoundStart > readerToolsStart, "Expected not-found styles after reader tools");
+    assert.ok(searchStart > readerToolsStart, "Expected search styles after reader tools");
+    assert.ok(notFoundStart > searchStart, "Expected not-found styles after search styles");
 
     const main = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[0]), "utf8");
     const banner = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[1]), "utf8");
     const header = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[2]), "utf8");
     const readerTools = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[3]), "utf8");
-    const notFound = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[4]), "utf8");
+    const search = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[4]), "utf8");
+    const notFound = fs.readFileSync(path.join(PROJECT_ROOT, CSS_FILES[5]), "utf8");
     assert.doesNotMatch(main, /\.lang-suggest/);
     assert.match(banner, /body\.dark \.lang-suggest/);
     assert.match(header, /html\.js \.nav__links/);
     assert.match(header, /html:not\(\.js\) #nav-toggle/);
     assert.match(readerTools, /\.reader-tools > button\.reader-tool/);
     assert.match(readerTools, /border-radius:\s*50%/);
+    assert.match(search, /dialog\.search-dialog/);
+    assert.match(search, /#nav > button\.search-toggle/);
     assert.match(notFound, /\.not-found__mark/);
   });
 

--- a/test/test-homepage.js
+++ b/test/test-homepage.js
@@ -39,32 +39,42 @@ describe("homepage build output", () => {
     assert.ok(hrefs.includes("/about/"));
   });
 
-  it("keeps mobile header actions in theme, menu order", () => {
+  it("keeps mobile header actions in search, theme, menu order", () => {
     const nav = doc.getElementById("nav");
     const actionIds = [...nav.children]
       .map((element) => element.id)
       .filter((id) => [
+        "search-toggle",
         "color-scheme-toggle",
         "nav-toggle",
       ].includes(id));
 
     assert.deepEqual(actionIds, [
+      "search-toggle",
       "color-scheme-toggle",
       "nav-toggle",
     ]);
+    assert.equal(
+      doc.getElementById("search-toggle").nextElementSibling.id,
+      "color-scheme-toggle"
+    );
     assert.equal(
       doc.getElementById("color-scheme-toggle").nextElementSibling.id,
       "nav-toggle"
     );
   });
 
-  it("localizes the theme and menu action names", () => {
+  it("localizes the search, theme, and menu action names", () => {
     const strings = i18n["zh-TW"];
     const primaryNav = doc.querySelector("header nav");
+    const search = doc.getElementById("search-toggle");
     const theme = doc.getElementById("color-scheme-toggle");
     const menu = doc.getElementById("nav-toggle");
 
     assert.equal(primaryNav.getAttribute("aria-label"), strings.primaryNavigation);
+    assert.equal(search.getAttribute("aria-label"), strings.search.open);
+    assert.equal(search.getAttribute("aria-controls"), "site-search");
+    assert.equal(search.getAttribute("aria-haspopup"), "dialog");
     assert.equal(theme.getAttribute("aria-label"), strings.switchToDarkTheme);
     assert.equal(theme.dataset.labelToDark, strings.switchToDarkTheme);
     assert.equal(theme.dataset.labelToLight, strings.switchToLightTheme);

--- a/test/test-performance.js
+++ b/test/test-performance.js
@@ -1,0 +1,62 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+
+const SITE_ROOT = path.resolve(__dirname, "..", "_site");
+
+function sizesOf(relative) {
+  const filename = path.join(SITE_ROOT, relative);
+  assert.ok(fs.existsSync(filename), `Missing build output: ${filename}`);
+  const raw = fs.readFileSync(filename);
+  return { raw: raw.length, gzip: zlib.gzipSync(raw, { level: 9 }).length };
+}
+
+// First byte budgets for the artifacts readers actually download.
+// Baselines measured 2026-07-19 (133 indexed articles, 349 pages);
+// budgets sit ~15-20% above baseline so organic growth passes but a
+// regression (accidentally indexing drafts, unminified bundle, purge
+// failure) fails loudly. When the search index outgrows its budget,
+// revisit the sharded-index decision (Pagefind) recorded in the PR notes.
+describe("performance budgets", () => {
+  it("keeps the search index within its lazy-download budget", () => {
+    const { raw, gzip } = sizesOf("search-index.json");
+    assert.ok(raw <= 1_750_000, `search-index.json raw ${raw} > 1750000`);
+    assert.ok(gzip <= 640_000, `search-index.json gzip ${gzip} > 640000`);
+  });
+
+  it("keeps the JS bundle small", () => {
+    const { raw, gzip } = sizesOf("js/min.js");
+    assert.ok(raw <= 25_000, `js/min.js raw ${raw} > 25000`);
+    assert.ok(gzip <= 9_000, `js/min.js gzip ${gzip} > 9000`);
+  });
+
+  it("keeps per-page inlined CSS lean", () => {
+    for (const page of ["index.html", "posts/tian/git-flow/index.html"]) {
+      const html = fs.readFileSync(path.join(SITE_ROOT, page), "utf8");
+      const match = html.match(/<style>([\s\S]*?)<\/style>/);
+      assert.ok(match, `${page}: no inlined <style>`);
+      assert.ok(
+        match[1].length <= 40_000,
+        `${page}: inlined CSS ${match[1].length} > 40000`
+      );
+    }
+  });
+
+  it("never preloads the search index with the page", () => {
+    for (const page of [
+      "index.html",
+      "posts/tian/git-flow/index.html",
+      "tags/index.html",
+    ]) {
+      const html = fs.readFileSync(path.join(SITE_ROOT, page), "utf8");
+      const head = html.slice(0, html.indexOf("</head>"));
+      assert.ok(
+        !/<link[^>]+search-index\.json/.test(head),
+        `${page}: search index referenced from <head> — it must stay lazy`
+      );
+    }
+  });
+});

--- a/test/test-search-core.js
+++ b/test/test-search-core.js
@@ -1,0 +1,148 @@
+"use strict";
+
+const assert = require("assert").strict;
+
+function article(overrides = {}) {
+  return {
+    id: "work|zh-TW",
+    translationKey: "work",
+    title: "JavaScript patterns",
+    url: "/posts/baker/work/",
+    lang: "zh-TW",
+    author: { key: "baker", name: "Baker Chen" },
+    tags: ["Frontend"],
+    published: "2026-07-19",
+    year: "2026",
+    slug: "javascript patterns",
+    description: "A practical guide",
+    headings: ["Module design"],
+    body: "Long-form article content",
+    ...overrides,
+  };
+}
+
+describe("client search ranking", () => {
+  let searchIndex;
+  let damerauLevenshtein;
+
+  before(async () => {
+    ({ searchIndex, damerauLevenshtein } = await import("../src/search-core.mjs"));
+  });
+
+  it("handles a Latin transposition as one fuzzy edit", () => {
+    assert.equal(damerauLevenshtein("javascript", "javascrpit", 2), 1);
+    const result = searchIndex(
+      { articles: [article()], authors: [] },
+      "javascrpit",
+      { lang: "zh-TW" }
+    );
+    assert.equal(result.articles.length, 1);
+    assert.equal(result.articles[0].matchedField, "title");
+  });
+
+  it("handles a missing CJK character through bigram similarity", () => {
+    const result = searchIndex(
+      {
+        articles: [article({ title: "反應式程式設計" })],
+        authors: [],
+      },
+      "反應程式設計",
+      { lang: "zh-TW" }
+    );
+    assert.equal(result.articles.length, 1);
+    assert.equal(result.articles[0].matchedField, "title");
+  });
+
+  it("prioritizes the current locale and deduplicates translated works", () => {
+    const zh = article();
+    const en = article({
+      id: "work|en",
+      lang: "en",
+      url: "/en/posts/baker/work/",
+    });
+    const result = searchIndex(
+      { articles: [en, zh], authors: [] },
+      "JavaScript",
+      { lang: "zh-TW" }
+    );
+
+    assert.equal(result.articles.length, 1);
+    assert.equal(result.articles[0].item.lang, "zh-TW");
+    assert.equal(result.otherArticles.length, 0);
+    assert.equal(result.total, 1);
+  });
+
+  it("still returns another-language version when only it matches", () => {
+    const zh = article({ title: "模組設計", slug: "module design" });
+    const en = article({
+      id: "work|en",
+      lang: "en",
+      title: "JavaScript patterns",
+      url: "/en/posts/baker/work/",
+    });
+    const result = searchIndex(
+      { articles: [zh, en], authors: [] },
+      "JavaScript",
+      { lang: "zh-TW" }
+    );
+
+    assert.equal(result.articles.length, 0);
+    assert.equal(result.otherArticles.length, 1);
+    assert.equal(result.otherArticles[0].item.lang, "en");
+  });
+
+  it("matches taxonomy aliases against canonical tags", () => {
+    const go = article({
+      title: "併發模式",
+      slug: "concurrency patterns",
+      tags: ["Go"],
+      description: "",
+      headings: [],
+      body: "",
+    });
+    const js = article({
+      id: "work-js|zh-TW",
+      translationKey: "work-js",
+      title: "模組設計",
+      slug: "module design",
+      tags: ["JavaScript"],
+      description: "",
+      headings: [],
+      body: "",
+    });
+    const index = {
+      articles: [go, js],
+      authors: [],
+      tagAliases: { Go: "golang", JavaScript: "js" },
+    };
+
+    const byGolang = searchIndex(index, "golang", { lang: "zh-TW" });
+    assert.equal(byGolang.articles.length, 1);
+    assert.equal(byGolang.articles[0].item.tags[0], "Go");
+    assert.equal(byGolang.articles[0].matchedField, "tag");
+
+    const byJs = searchIndex(index, "js", { lang: "zh-TW" });
+    assert.equal(byJs.articles.length, 1);
+    assert.equal(byJs.articles[0].item.tags[0], "JavaScript");
+    assert.equal(byJs.articles[0].matchedField, "tag");
+  });
+
+  it("searches authors by name and topic", () => {
+    const index = {
+      articles: [],
+      authors: [{
+        id: "baker",
+        name: "Baker Chen",
+        bios: { "zh-TW": "烘焙技術文章" },
+        topics: ["Frontend", "JavaScript"],
+      }],
+    };
+
+    const byName = searchIndex(index, "Bkaer", { lang: "zh-TW" });
+    const byTopic = searchIndex(index, "Frontend", { lang: "zh-TW" });
+    assert.equal(byName.authors[0].item.id, "baker");
+    assert.equal(byName.authors[0].matchedField, "author");
+    assert.equal(byTopic.authors[0].item.id, "baker");
+    assert.equal(byTopic.authors[0].matchedField, "tag");
+  });
+});

--- a/test/test-search-index.js
+++ b/test/test-search-index.js
@@ -1,0 +1,159 @@
+"use strict";
+
+const assert = require("assert").strict;
+const {
+  buildSearchIndex,
+  buildSearchIndexJson,
+} = require("../_11ty/search-index.js");
+
+const metadata = {
+  authors: {
+    baker: {
+      name: "Baker Chen",
+      avatarUrl: "/img/baker.png",
+      intro: "烘焙前端技術麵包。",
+      intro_en: "Bakes frontend loaves.",
+    },
+    hidden: { name: "Hidden Baker" },
+  },
+};
+const languages = ["zh-TW", "en"];
+
+function post({
+  inputPath,
+  url,
+  lang = "zh-TW",
+  draft,
+  rawDraft,
+  title,
+  tags = ["Frontend"],
+  date = "2026-07-19",
+}) {
+  const draftLine = rawDraft === undefined ? "" : `draft: ${rawDraft}\n`;
+  return {
+    inputPath,
+    url,
+    date: new Date(`${date}T00:00:00.000Z`),
+    rawInput: `---\ntitle: ${title}\n${draftLine}---\n## Search heading\nBody with \`SearchToken\` and [a link](https://example.com).\n`,
+    data: {
+      author: inputPath.includes("hidden") ? "hidden" : "baker",
+      draft,
+      lang,
+      tags: ["posts", ...tags],
+      title,
+    },
+  };
+}
+
+describe("site search index", () => {
+  const visibleZh = post({
+    inputPath: "./posts/baker/frontend.md",
+    url: "/posts/baker/frontend/",
+    title: "前端麵包",
+  });
+  const visibleEn = post({
+    inputPath: "./posts/baker/frontend.en.md",
+    url: "/en/posts/baker/frontend/",
+    lang: "en",
+    title: "Frontend loaf",
+  });
+
+  it("hard-excludes parsed, raw-frontmatter, and non-emitted drafts", () => {
+    const posts = [
+      visibleZh,
+      post({
+        inputPath: "./posts/hidden/parsed.md",
+        url: "/posts/hidden/parsed/",
+        draft: true,
+        title: "Parsed draft",
+      }),
+      post({
+        inputPath: "./posts/hidden/string-draft.md",
+        url: "/posts/hidden/string-draft/",
+        draft: "true",
+        title: "String draft",
+      }),
+      post({
+        inputPath: "./posts/hidden/commented.md",
+        url: "/posts/hidden/commented/",
+        rawDraft: "true # awaiting review",
+        title: "Raw draft",
+      }),
+      post({
+        inputPath: "./posts/hidden/no-output.md",
+        url: false,
+        title: "No output",
+      }),
+    ];
+
+    const index = buildSearchIndex(posts, metadata, languages);
+    assert.deepEqual(index.articles.map((article) => article.title), ["前端麵包"]);
+    assert.deepEqual(index.authors.map((author) => author.id), ["baker"]);
+  });
+
+  it("emits a versioned article/author schema with searchable Markdown fields", () => {
+    const index = buildSearchIndex([visibleZh, visibleEn], metadata, languages);
+    assert.equal(index.version, 1);
+    assert.deepEqual(index.languages, languages);
+    assert.equal(index.articles.length, 2);
+
+    const article = index.articles.find((item) => item.lang === "zh-TW");
+    const articleFields = [
+      "author",
+      "body",
+      "description",
+      "headings",
+      "id",
+      "lang",
+      "published",
+      "slug",
+      "tags",
+      "title",
+      "translationKey",
+      "url",
+      "year",
+    ];
+    articleFields.forEach((field) => {
+      assert.ok(Object.hasOwn(article, field), `Missing article field: ${field}`);
+    });
+    assert.equal(article.translationKey, "baker/frontend");
+    assert.equal(article.id, "baker/frontend|zh-TW");
+    assert.deepEqual(article.tags, ["Frontend"]);
+    assert.deepEqual(article.headings, ["Search heading"]);
+    assert.match(article.body, /SearchToken/);
+    assert.doesNotMatch(article.body, /https:\/\/example\.com/);
+    assert.equal(article.published, "2026-07-19");
+    assert.equal(article.year, "2026");
+
+    assert.equal(index.authors.length, 1);
+    const author = index.authors[0];
+    const authorFields = [
+      "avatar",
+      "bios",
+      "id",
+      "name",
+      "postCount",
+      "topics",
+      "urls",
+    ];
+    authorFields.forEach((field) => {
+      assert.ok(Object.hasOwn(author, field), `Missing author field: ${field}`);
+    });
+    assert.equal(author.postCount, 1, "Translations count as one logical loaf");
+    assert.deepEqual(author.urls, {
+      "zh-TW": "/posts/baker/",
+      en: "/en/posts/baker/",
+    });
+  });
+
+  it("serializes markup-significant text safely for a JSON response", () => {
+    const hostile = post({
+      inputPath: "./posts/baker/safe.md",
+      url: "/posts/baker/safe/",
+      title: "Safe <script> & search",
+    });
+    const json = buildSearchIndexJson([hostile], metadata, languages);
+    assert.doesNotMatch(json, /[<>&]/);
+    assert.equal(JSON.parse(json).articles[0].title, "Safe <script> & search");
+  });
+});

--- a/test/test-seo.js
+++ b/test/test-seo.js
@@ -92,6 +92,15 @@ describe("SEO head emissions", () => {
 });
 
 describe("SEO deployment artifacts", () => {
+  it("keeps the search index out of search engines via _headers", () => {
+    const headers = fs.readFileSync(path.join(SITE_ROOT, "_headers"), "utf8");
+    const block = headers.split("/search-index.json")[1] || "";
+    assert.ok(
+      /X-Robots-Tag:\s*noindex/.test(block),
+      "search-index.json must carry X-Robots-Tag: noindex"
+    );
+  });
+
   it("advertises the sitemap from robots.txt", () => {
     const robots = fs.readFileSync(path.join(SITE_ROOT, "robots.txt"), "utf8");
     assert.ok(robots.includes(`Sitemap: ${metadata.url}/sitemap.xml`));

--- a/test/test-ui-regression.js
+++ b/test/test-ui-regression.js
@@ -29,6 +29,47 @@ function inlineStyle(relative) {
   return match[1];
 }
 
+describe("search dialog markup", () => {
+  let dialog;
+
+  before(() => {
+    dialog = documentFor("index.html").getElementById("site-search");
+  });
+
+  it("is an accessible dialog wired for lazy index loading", () => {
+    assert.ok(dialog, "missing #site-search");
+    assert.equal(dialog.tagName, "DIALOG");
+    assert.equal(dialog.getAttribute("aria-labelledby"), "search-title");
+    assert.ok(dialog.querySelector("h2#search-title"));
+    assert.equal(dialog.getAttribute("data-index-url"), "/search-index.json");
+    assert.equal(dialog.getAttribute("data-lang"), "zh-TW");
+    assert.ok(dialog.getAttribute("data-i18n").includes("{query}"));
+  });
+
+  it("keeps the close button and search form scoped and labelled", () => {
+    const close = dialog.querySelector("button.search-dialog__close");
+    assert.ok(close);
+    assert.ok(close.getAttribute("aria-label").length > 0);
+    const form = dialog.querySelector("form.search-form");
+    assert.equal(form.getAttribute("role"), "search");
+    const input = dialog.querySelector("input#search-input");
+    assert.equal(input.getAttribute("type"), "search");
+    assert.equal(input.getAttribute("aria-controls"), "search-results");
+    assert.ok(dialog.querySelector("label[for='search-input']"));
+  });
+
+  it("announces result updates through a live region", () => {
+    assert.ok(dialog.querySelector("[aria-live]"));
+  });
+
+  it("is opened by a toggle that declares its popup contract", () => {
+    const toggle = documentFor("index.html").getElementById("search-toggle");
+    assert.equal(toggle.getAttribute("aria-controls"), "site-search");
+    assert.equal(toggle.getAttribute("aria-haspopup"), "dialog");
+    assert.equal(toggle.getAttribute("aria-expanded"), "false");
+  });
+});
+
 describe("language switcher markup", () => {
   it("links available languages with hreflang and marks the current one", () => {
     const doc = documentFor("index.html");
@@ -61,8 +102,11 @@ describe("brand token regression", () => {
   it("defines the shared radius tokens on sampled pages", () => {
     for (const page of ["index.html", "posts/tian/git-flow/index.html"]) {
       const css = inlineStyle(page);
-      // --radius-control ships with the search layer (its only consumer).
-      for (const token of ["--radius-surface", "--radius-chip"]) {
+      for (const token of [
+        "--radius-surface",
+        "--radius-control",
+        "--radius-chip",
+      ]) {
         assert.ok(css.includes(token), `${page}: missing ${token}`);
       }
     }


### PR DESCRIPTION
## 概述

零依賴的全站搜尋：build-time 索引＋client scorer，涵蓋四語內容、translationKey 去重、當前語言優先。索引只在第一次開啟搜尋才下載，一般頁面載入零成本。Stack 最上層，合併後即為完整功能。

## 變更內容

- `_11ty/search-index.js`＋`search-index.json.njk`：published-only 索引（標題／章節／摘要／全文／canonical tags／作者名與簡介／年份／slug），輸出 taxonomy aliases
- `src/search-core.mjs`：exact/prefix/substring＋CJK bigram Dice＋Damerau-Levenshtein fuzzy；**aliases 接進 tag 欄位**（`js`／`front-end`／`golang` 可命中 JavaScript／Frontend／Go）
- `src/search-ui.mjs`：⌘/Ctrl+K、鍵盤導覽、焦點還原、載入／失敗／空結果／外語 fallback 狀態
- header 第三顆搜尋鈕（DOM 順序 搜尋→Theme→Menu）＋ ≤520px 短版 wordmark
- `search-index.json`：`X-Robots-Tag: noindex`＋robots.txt 對 AI bot disallow（索引彙整了未 opt-in AI 爬取作者的全文，集中端點不開放）

## 效能實測與預算（test-performance.js，zlib gzip）

| 項目 | 實測 | 預算 |
|---|---|---|
| search-index.json | 1.48MB raw／**543KB gzip** | ≤1.75MB／≤640KB |
| js/min.js | 18.7KB raw／6.7KB gzip | ≤25KB／≤9KB |
| 每頁 inline CSS | ~29–31KB | ≤40KB |

scorer：cold query ~45ms；正規化快取後 p50 ~5.1ms／p95 ~6.7ms。另有「索引不得隨頁面預載」不變量測試。

## ⚠️ 套件決策揭露：Pagefind 觸發線已越過

先前決策「索引超過 **400KB gzip** 或 300 篇時評估 Pagefind 分片索引」——benben 01–16 譯文合併後索引已達 **543KB gzip**（133 篇索引文）。本 PR 維持零依賴 scorer（Fuse.js +8.6KB gzip 仍需自行處理 CJK／fallback／去重，不降總成本），但**建議近期立案評估 Pagefind**；若需 typo tolerance 則評估 build-time MiniSearch。

## 驗證

- `npm run build` exit 0，**156 tests passing、0 CSS warning**（本層新增 search-core×6、search-index、performance、search dialog a11y 測試）
- 本層 tree 與拆分前的完整工作樹 **diff 為空**（4 層疊加零遺失）
- 手動驗證：`js`／`golang`／`front-end` 查詢命中對應主題文章

## 合併順序

Stack：1/4 → 2/4 → 3/4 → **4/4（本 PR，base: feat/editorial-reader-ui）**。前層合併後請 re-target 至 main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)