### PR TITLE
test: 媒體體積預算守門（img/ 單檔 1MB 上限）

### DIFF
--- a/test/test-media-budget.js
+++ b/test/test-media-budget.js
@@ -1,0 +1,95 @@
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+
+// 單一媒體檔案的體積預算：1MB。
+// 超過這條線的圖片會直接拖垮讀者的載入體驗（尤其是行動網路）。
+const BUDGET_BYTES = 1024 * 1024;
+
+// 現存超標檔案的豁免清單（相對於 repo 根目錄、使用 / 分隔）。
+// 這些是歷史遺留的肥檔，正由並行 PR 重新壓縮處理中。
+// 請「不要」把新檔案加進來——新圖片請先壓縮到 1MB 以下再提交。
+const ALLOWLIST = new Set([
+  "img/authors/simon198-avatar.jpg",
+  "img/posts/benben/15-raycast-101/15-wrapped.gif",
+  "img/posts/clay/next-seo/5.png",
+  "img/posts/ruofan/animation-2.gif",
+  "img/posts/ruofan/event.gif",
+  "img/posts/ruofan/next-login.gif",
+  "img/posts/ruofan/observe.gif",
+  "img/posts/ruofan/postgres.png",
+  "img/posts/ruofan/quill-1.png",
+]);
+
+const ROOT = path.join(__dirname, "..");
+const IMG_DIR = path.join(ROOT, "img");
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath, files);
+    } else if (entry.isFile()) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function toRelative(fullPath) {
+  return path.relative(ROOT, fullPath).split(path.sep).join("/");
+}
+
+function formatMB(bytes) {
+  return `${(bytes / (1024 * 1024)).toFixed(2)}MB`;
+}
+
+describe("媒體體積預算（img/）", () => {
+  const oversized = walk(IMG_DIR)
+    .map((fullPath) => ({
+      relPath: toRelative(fullPath),
+      size: fs.statSync(fullPath).size,
+    }))
+    .filter((file) => file.size > BUDGET_BYTES);
+
+  it(`未豁免的檔案不得超過 ${formatMB(BUDGET_BYTES)}`, () => {
+    const offenders = oversized.filter((file) => !ALLOWLIST.has(file.relPath));
+
+    const message = [
+      `發現 ${offenders.length} 個超過 ${formatMB(BUDGET_BYTES)} 的媒體檔案：`,
+      ...offenders.map((file) => `  - ${file.relPath}（${formatMB(file.size)}）`),
+      "",
+      "請先壓縮再提交，建議工具：",
+      "  - GIF：轉成 MP4/WebM，或用 gifsicle -O3 --lossy 壓縮",
+      "  - PNG/JPG：用 squoosh.app、ImageOptim 或轉成 WebP",
+      "若確有不可壓縮的例外，請在 test/test-media-budget.js 的 ALLOWLIST 說明並豁免。",
+    ].join("\n");
+
+    assert.equal(offenders.length, 0, message);
+  });
+
+  it("豁免清單中已瘦身的檔案不會造成失敗（僅提示清理）", () => {
+    const oversizedPaths = new Set(oversized.map((file) => file.relPath));
+    const slimmed = [...ALLOWLIST].filter(
+      (relPath) =>
+        !oversizedPaths.has(relPath) && fs.existsSync(path.join(ROOT, relPath))
+    );
+    const removed = [...ALLOWLIST].filter(
+      (relPath) => !fs.existsSync(path.join(ROOT, relPath))
+    );
+
+    for (const relPath of slimmed) {
+      console.log(
+        `      提示：${relPath} 已低於預算，可從 ALLOWLIST 移除（不影響測試結果）。`
+      );
+    }
+    for (const relPath of removed) {
+      console.log(
+        `      提示：${relPath} 已不存在，可從 ALLOWLIST 移除（不影響測試結果）。`
+      );
+    }
+    // 刻意不 assert：豁免檔案被並行 PR 壓縮或移除時，這裡只提醒、不擋人。
+  });
+});


### PR DESCRIPTION
## 背景與目的

近期原始碼 `img/` 中已累積多支 3–6MB 的 GIF/PNG（最肥的 `observe.gif` 達 6MB），
在行動網路上會嚴重拖垮讀者的首屏與載入體驗。目前沒有任何自動化守門，
下一支肥檔（例如又一個 6MB GIF）可以毫無阻力地被合進 main。

本測試建立一條體積紅線，讓「新肥檔」在 CI 就被擋下，把體積問題留在提交當下解決。

## 改動內容

- 新增 `test/test-media-budget.js`（純測試，CommonJS，沿用既有 `assert.strict` 風格）。
- 遞迴掃描「原始碼」`img/` 目錄（非 `_site`），任何 > 1,048,576 bytes（1MB）的媒體檔案視為超標。
- 以 `ALLOWLIST` 豁免目前 9 個歷史遺留肥檔；不在清單內的超標檔會讓測試失敗。
- 失敗訊息為繁體中文，列出違規檔名與大小，並建議壓縮方式（GIF→MP4/WebM、PNG/JPG→WebP/ImageOptim）。
- 豁免檔案一旦被壓到 1MB 以下（或移除），僅 `console.log` 提示「可從 ALLOWLIST 移除」，不會讓測試失敗——避免與並行重壓 PR 打架。
- 由既有 `mocha test/test*.js` glob 自動納入，無須額外設定。

## 爆炸半徑

純新增測試檔，不動任何產品程式碼、建置流程或線上資產，爆炸半徑僅限測試套件本身。

## 驗證證據

現行 allowlist 下綠燈：

```
  媒體體積預算（img/）
    ✓ 未豁免的檔案不得超過 1.00MB
    ✓ 豁免清單中已瘦身的檔案不會造成失敗（僅提示清理）

  2 passing (2ms)
```

放入臨時 2MB 假檔 `img/_c3-dummy/huge-test.gif` 後紅燈（訊息正確、事後已刪除）：

```
  1) 媒體體積預算（img/）
       未豁免的檔案不得超過 1.00MB:
      AssertionError: 發現 1 個超過 1.00MB 的媒體檔案：
  - img/_c3-dummy/huge-test.gif（2.00MB）
請先壓縮再提交，建議工具：
  - GIF：轉成 MP4/WebM，或用 gifsicle -O3 --lossy 壓縮
  - PNG/JPG：用 squoosh.app、ImageOptim 或轉成 WebP
```

## 有意不做

- 不在本 PR 壓縮任何現存肥檔——9 個歷史檔由並行 PR D1 專責重壓，本 PR 只負責「守門」，避免衝突。
- 不改動建置流程或 `_site` 產物檢查。

## 後續

- 待 D1 重壓完成後，逐一從 ALLOWLIST 移除已瘦身檔（測試會主動提示哪些可移除）。
- 未來可視需要調整紅線或加入圖片格式（WebP/AVIF）建議的更嚴格規則。

🤖 Generated with [Claude Code](https://claude.com/claude-code)