### PR TITLE
修正列表頁作者連結：改用 authorUrlForLang 統一產生

### DIFF
--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -6,7 +6,7 @@
     <a class="archive-title" href="{{ post.url | url }}">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
     <span class="archive-by">
       <img class="avatar avatar-small" src="{{ author.avatarUrl }}" alt="" loading="lazy" />
-      <a href="/posts/{{ post.data.author }}">{{ author.name }}</a>
+      <a href="{{ collections.authorLangPages | authorUrlForLang(lang, post.data.author) | url }}">{{ author.name }}</a>
     </span>
   </li>
 {% endfor %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "eleventy-high-performance-blog",
       "version": "5.0.2",
       "license": "MIT",
-      "engines": {
-        "node": "24.x"
-      },
       "dependencies": {
         "@ampproject/toolbox-optimizer": "^2.7.5",
         "any-shell-escape": "^0.1.1",
@@ -51,6 +48,9 @@
         "pre-push": "^0.1.1",
         "rollup-plugin-terser": "^6.1.0",
         "shorthash": "0.0.2"
+      },
+      "engines": {
+        "node": "24.x"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/test/test-listing-author-links.js
+++ b/test/test-listing-author-links.js
@@ -1,0 +1,72 @@
+// The shared `postslist.njk` partial (used by the archive and tag listing
+// pages) must build author links through the `authorUrlForLang` filter, the
+// same way `home-postslist.njk` does, rather than hardcoding
+// `/posts/{author}`. On the default (zh-TW) listings the filter yields the
+// canonical trailing-slash form `/posts/{author}/`; hardcoding dropped the
+// slash and — more importantly — would point future localized listings at the
+// zh-TW author page. This guards both the trailing-slash form and the "links
+// resolve to a real author page" invariant.
+"use strict";
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+const metadata = require("../_data/metadata.json");
+
+const SITE_ROOT = path.resolve(__dirname, "..", "_site");
+const ARCHIVE = path.join(SITE_ROOT, "archive", "index.html");
+
+function authorLinks(doc) {
+  return [...doc.querySelectorAll(".archive-by a")].map((link) =>
+    link.getAttribute("href")
+  );
+}
+
+describe("listing-page author links (postslist.njk)", () => {
+  let doc;
+
+  before(() => {
+    assert.ok(fs.existsSync(ARCHIVE), `Missing build output: ${ARCHIVE}`);
+    doc = new JSDOM(fs.readFileSync(ARCHIVE, "utf8")).window.document;
+  });
+
+  it("emits at least one author link", () => {
+    assert.ok(
+      authorLinks(doc).length > 0,
+      "Expected the archive listing to render author links"
+    );
+  });
+
+  it("links each author with the localized (trailing-slash) URL form", () => {
+    for (const href of authorLinks(doc)) {
+      // zh-TW archive → filter returns `/posts/{author}/`.
+      assert.match(
+        href,
+        /^\/posts\/[^/]+\/$/,
+        `Author link is not the localized /posts/{author}/ form: ${href}`
+      );
+    }
+  });
+
+  it("never emits the hardcoded slash-less /posts/{author} link", () => {
+    for (const href of authorLinks(doc)) {
+      assert.doesNotMatch(
+        href,
+        /^\/posts\/[^/]+$/,
+        `Author link uses the old hardcoded form (missing trailing slash): ${href}`
+      );
+    }
+  });
+
+  it("points every author link at a real generated author page", () => {
+    for (const href of authorLinks(doc)) {
+      const pathname = decodeURIComponent(new URL(href, metadata.url).pathname);
+      const output = path.join(SITE_ROOT, pathname, "index.html");
+      assert.ok(
+        fs.existsSync(output),
+        `Author link points to missing output: ${pathname}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## 背景與目的

archive、tags 列表頁共用的 `_includes/postslist.njk` 在作者署名處硬寫 `href="/posts/{{ post.data.author }}"`，與首頁 `home-postslist.njk`、feeds、about 頁一致使用的 `authorUrlForLang` filter 脫節。這造成兩個問題：

1. **現行問題**：輸出的作者連結缺結尾斜線（`/posts/benben`），與站內其他地方的 canonical 形式（`/posts/benben/`）不一致，點擊需靠伺服器 redirect 才到頁。
2. **未來問題**：列表頁一旦 i18n 化，硬寫的連結會把所有語言的讀者都導向 zh-TW 作者頁，而不是對應語言的作者頁。

## 改動內容

- `_includes/postslist.njk`：作者連結改為 `{{ collections.authorLangPages | authorUrlForLang(lang, post.data.author) | url }}`，與 `home-postslist.njk` 完全相同的寫法。filter 行為：目標語言有生成作者頁才給語言化 URL，否則回退 zh-TW `/posts/{author}/`。
- `test/test-listing-author-links.js`（新增）：對建置後的 `/archive/` 輸出做防回歸驗證（見下方驗證證據）。

## 爆炸半徑

以未修正 main 的完整建置與修正後建置做逐檔比對（`diff -rq`），實測結果：

- **會變的輸出**（僅限 `postslist.njk` 的三個使用者）：
  - `/archive/`：82 個作者連結 `/posts/{author}` → `/posts/{author}/`（13 位作者）
  - `/tags/`（總表）：177 個作者連結同樣補上結尾斜線
  - 各 `/tags/{tag}/` 頁：作者連結同樣補上結尾斜線
  - 變動內容**只有結尾斜線**——作者、數量、順序完全不變。
- **不變的輸出**：其餘全站頁面逐檔比對相同（sitemap 差異僅為建置時間戳、兩篇文章頁差異為 Prism 標記非決定性，連結集合逐一比對完全相同，皆與本修正無關）。
- **語言化部分是防未來**：目前 `en/`、`ja/`、`zh-CN/` 僅有 about/feed/posts/首頁，沒有 archive 或 tags 列表頁，所以 `authorUrlForLang` 的語言判斷在現行輸出不會產生任何語言化 URL；等列表頁 i18n 化時才會生效。

## 驗證證據

- 完整建置 + 測試全綠：mocha **76 passing**（含本 PR 新增 4 條），translation checks **40 passed**（push 時 pre-push hook 又跑了一次，同樣全綠）。
- 新增測試 4 條皆通過：
  - emits at least one author link
  - links each author with the localized (trailing-slash) URL form
  - never emits the hardcoded slash-less /posts/{author} link
  - points every author link at a real generated author page
- 實證比對：未修正建置的 `/archive/` 作者連結為 `/posts/benben`（無斜線）等 82 條；修正後同頁為 `/posts/benben/` 等 82 條，作者分布逐一相同。

## 有意不做

- 不動 `authorUrlForLang` filter 本身——行為已被 feeds/首頁測試覆蓋，本 PR 只是讓列表頁「加入」既有慣例。
- 不為 `/tags/` 每一頁各寫一條測試——三個模板共用同一個 partial，archive 一頁的防回歸即覆蓋模板層級的回歸。
- 不新增 redirect 規則——修正後連結直接是 canonical 形式，不需要。

## 後續

- 列表頁（archive/tags）i18n 化時，本 partial 已可直接輸出語言化作者連結，屆時可把本測試擴充到各語言列表頁。

🤖 Generated with [Claude Code](https://claude.com/claude-code)