### PR TITLE
ci: SEO 黃金輸出比對——PR 上自動 diff head 與 merge-base 的 SEO 輸出

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,70 @@ jobs:
           # discussions.js degrades to no comment stats when the GitHub API
           # rate-limits; authenticate so leaderboard data stays deterministic.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  seo-diff:
+    name: SEO golden-output diff
+    # 黃金輸出比對：建置 PR head 與 merge-base 兩份 _site，
+    # 比對 SEO 敏感輸出（title/meta/canonical/hreflang/og/twitter/
+    # robots/JSON-LD/sitemap/feed），把差異寫進 job summary。
+    # 僅供 review 參考，不阻擋合併（continue-on-error）。
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository (full history for merge-base)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build PR head
+        run: |
+          npm run clean
+          npm run js-build
+          npx eleventy
+          cp -R _site /tmp/site-head
+          # diff-site 腳本只存在於 head，先存起來供 base 比對用
+          cp scripts/diff-site.js /tmp/diff-site.js
+        env:
+          ELEVENTY_ENV: production
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build merge-base
+        run: |
+          BASE_SHA="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+          echo "merge-base: $BASE_SHA"
+          git checkout --force "$BASE_SHA"
+          npm ci
+          npm run clean
+          npm run js-build
+          npx eleventy
+          cp -R _site /tmp/site-base
+        env:
+          ELEVENTY_ENV: production
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Diff SEO output into job summary
+        run: |
+          set +e
+          node /tmp/diff-site.js /tmp/site-base /tmp/site-head > /tmp/seo-diff.md
+          status=$?
+          set -e
+          {
+            echo "## SEO 黃金輸出比對（merge-base → PR head）"
+            echo ""
+            cat /tmp/seo-diff.md
+          } >> "$GITHUB_STEP_SUMMARY"
+          # 離開碼 1 = 有差異、2 = 腳本執行錯誤。讓非零碼傳出去，
+          # step 會標記為失敗以吸引 review 目光，但 job 設了
+          # continue-on-error，不會擋 PR。
+          exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
       - name: Build merge-base
         run: |
           BASE_SHA="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+          if [ -z "$BASE_SHA" ]; then
+            echo "無法取得 merge-base，中止比對" >&2
+            exit 2
+          fi
           echo "merge-base: $BASE_SHA"
           git checkout --force "$BASE_SHA"
           npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,6 @@ jobs:
           npm run js-build
           npx eleventy
           cp -R _site /tmp/site-head
-          # diff-site 腳本只存在於 head，先存起來供 base 比對用
-          cp scripts/diff-site.js /tmp/diff-site.js
         env:
           ELEVENTY_ENV: production
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,8 +84,11 @@ jobs:
 
       - name: Diff SEO output into job summary
         run: |
+          # 工作區目前在 merge-base；從 PR head 還原 diff 腳本後於
+          # 工作區內執行，讓 require() 能解析到 node_modules（jsdom）。
+          git checkout --force "${{ github.sha }}" -- scripts/diff-site.js
           set +e
-          node /tmp/diff-site.js /tmp/site-base /tmp/site-head > /tmp/seo-diff.md
+          node scripts/diff-site.js /tmp/site-base /tmp/site-head > /tmp/seo-diff.md
           status=$?
           set -e
           {

--- a/_11ty/getTagList.js
+++ b/_11ty/getTagList.js
@@ -24,5 +24,8 @@ module.exports = function(collection) {
   });
 
   // returning an array in addCollection works in Eleventy 0.5.3
-  return [...tagSet];
+  // 排序讓 tag 順序在不同次建置間保持一致：collection.getAll() 的順序
+  // 取決於檔案系統掃描，並不穩定，會讓 /tags/ 頁的區塊順序（連帶自動
+  // 產生的 meta description）每次建置都不同。
+  return [...tagSet].sort();
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "npm run test:site && npm run test:translations && npm run check-tags",
     "test:site": "node scripts/assert-site-built.js && mocha test/test*.js",
     "test-watch": "mocha test/test*.js --watch",
+    "diff-site": "node scripts/diff-site.js",
     "check-translations": "node scripts/check-translations.js",
     "check-translations:all": "node scripts/check-translations.js --all",
     "check-tags": "node scripts/check-tags.js",

--- a/scripts/diff-site.js
+++ b/scripts/diff-site.js
@@ -440,7 +440,7 @@ function main(argv) {
   if (asJson) {
     process.stdout.write(JSON.stringify({ ...report, hasDifferences: differ }, null, 2) + "\n");
   } else {
-    process.stdout.write(renderReport(report) + "\n");
+    process.stdout.write(renderReport(report));
   }
 
   return differ ? 1 : 0;

--- a/scripts/diff-site.js
+++ b/scripts/diff-site.js
@@ -1,0 +1,462 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * diff-site.js — 黃金輸出比對（golden-output diff）
+ *
+ * 比對兩個已建置的 `_site` 目錄，回答「這次改動是否影響 SEO」。
+ *
+ * 用法：
+ *   node scripts/diff-site.js <dirA> <dirB> [--json]
+ *
+ * 比對內容：
+ *   1. 所有 .html 檔的 URL 集合 → 新增／消失頁面
+ *   2. sitemap.xml 的 <loc> 集合、feed/feed.xml 的 <id> 集合
+ *   3. 每個共同頁面的 SEO 敏感節點：
+ *      <title>、meta[name=description]、link[rel=canonical]、
+ *      link[rel=alternate][hreflang]、meta[property^=og:]、
+ *      meta[name^=twitter:]、meta[name=robots]、JSON-LD、<html lang>
+ *
+ * 離開碼：0 = 完全相同，1 = 有差異。
+ *
+ * 設計備註：一次只在記憶體中處理一個頁面的 DOM（8GB RAM、平行 agent），
+ * 解析後只保留輕量的「簽章」物件，DOM 立即釋放。
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { JSDOM, VirtualConsole } = require("jsdom");
+
+// 靜音的 virtual console：站台 CSS 用了 jsdom 解析不了的新語法時，
+// 預設會對每一頁噴出 "Could not parse CSS stylesheet" 到 stderr
+// （300+ 頁 × 多段 style 會灌出數十 MB）。我們只讀 SEO 節點，不需要
+// CSSOM，直接丟棄所有 jsdom 內部錯誤輸出。
+const silentConsole = new VirtualConsole();
+silentConsole.on("jsdomError", () => {});
+
+// ---------------------------------------------------------------------------
+// 正規化（normalizer）
+//
+// 目的：把「同一份內容、不同次建置」造成的非語意雜訊消掉，只保留真正的
+// SEO 語意差異。雜訊來源以「main 連建兩次再 diff」的方式實證發現：
+//
+//   - 資產快取破壞參數 `?hash=xxxxxxxx`（rollup/eleventy 對 min.js、favicon
+//     等加的內容雜湊；同內容 → 同雜湊，但為了穩健仍一律剝除）。
+//   - 空白差異（模板換行／縮排在不同建置間可能微幅不同）。
+//   - 時間戳：sitemap 的 <lastmod>、feed 的 <updated>/<published> 採
+//     RFC3339 / W3C datetime；本專案的日期多為內容衍生（文章 frontmatter），
+//     但 <lastmod> 會讀檔案 mtime，CI 上 merge-base 與 head 兩次 checkout 的
+//     mtime 不同 → 會製造假差異，因此一律遮蔽為固定佔位符。
+// ---------------------------------------------------------------------------
+
+// `?hash=deadbeef` 或 `?v=deadbeef` 之類的快取破壞查詢字串。
+const HASH_QUERY_RE = /\?(?:hash|v)=[0-9a-f]+/gi;
+
+// ISO-8601 / RFC3339 / W3C datetime 時間戳（sitemap lastmod、feed updated…）。
+// 例：2026-05-16T00:00:00Z、2026-05-16T00:00:00+08:00、2026-05-16
+const TIMESTAMP_RE =
+  /\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?)?/g;
+
+function stripHash(value) {
+  if (value == null) return value;
+  return String(value).replace(HASH_QUERY_RE, "");
+}
+
+function collapseWs(value) {
+  if (value == null) return value;
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function maskTimestamps(value) {
+  if (value == null) return value;
+  return String(value).replace(TIMESTAMP_RE, "<ts>");
+}
+
+// URL 類欄位（href/canonical/og:url…）：剝雜湊 + 收斂空白。
+function normUrl(value) {
+  return collapseWs(stripHash(value));
+}
+
+// 文字類欄位（title/description…）：收斂空白。
+function normText(value) {
+  return collapseWs(value);
+}
+
+// ---------------------------------------------------------------------------
+// 目錄掃描
+// ---------------------------------------------------------------------------
+
+function walk(dir, predicate) {
+  const out = [];
+  const stack = [dir];
+  while (stack.length) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(cur, { withFileTypes: true });
+    } catch (e) {
+      continue;
+    }
+    for (const ent of entries) {
+      const full = path.join(cur, ent.name);
+      if (ent.isDirectory()) {
+        stack.push(full);
+      } else if (ent.isFile() && predicate(full)) {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+// 把檔案路徑轉成站台 URL（index.html → 目錄斜線）。
+function toUrlKey(root, file) {
+  let rel = path.relative(root, file).split(path.sep).join("/");
+  if (rel.endsWith("/index.html")) {
+    rel = rel.slice(0, -"index.html".length);
+  } else if (rel === "index.html") {
+    rel = "";
+  }
+  return "/" + rel;
+}
+
+function htmlUrlMap(root) {
+  const map = new Map();
+  for (const file of walk(root, (f) => f.endsWith(".html"))) {
+    map.set(toUrlKey(root, file), file);
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// 每頁 SEO 簽章擷取（一次一個 DOM）
+// ---------------------------------------------------------------------------
+
+function extractSignature(file) {
+  const html = fs.readFileSync(file, "utf8");
+  const dom = new JSDOM(html, { virtualConsole: silentConsole });
+  const doc = dom.window.document;
+
+  const sig = {
+    htmlLang: normText(doc.documentElement.getAttribute("lang")),
+    title: normText(doc.querySelector("title") && doc.querySelector("title").textContent),
+    description: null,
+    canonical: null,
+    robots: null,
+    hreflang: [], // "hreflang=xx -> href"
+    og: [], // "og:xxx = yyy"
+    twitter: [], // "twitter:xxx = yyy"
+    jsonld: [], // canonical JSON strings
+  };
+
+  const desc = doc.querySelector('meta[name="description"]');
+  if (desc) sig.description = normText(desc.getAttribute("content"));
+
+  const canonical = doc.querySelector('link[rel="canonical"]');
+  if (canonical) sig.canonical = normUrl(canonical.getAttribute("href"));
+
+  const robots = doc.querySelector('meta[name="robots"]');
+  if (robots) sig.robots = normText(robots.getAttribute("content"));
+
+  doc.querySelectorAll('link[rel="alternate"][hreflang]').forEach((el) => {
+    const hl = normText(el.getAttribute("hreflang"));
+    const href = normUrl(el.getAttribute("href"));
+    sig.hreflang.push(`${hl} -> ${href}`);
+  });
+  sig.hreflang.sort();
+
+  doc.querySelectorAll("meta[property]").forEach((el) => {
+    const prop = el.getAttribute("property") || "";
+    if (prop.startsWith("og:")) {
+      sig.og.push(`${prop} = ${normUrl(el.getAttribute("content"))}`);
+    }
+  });
+  sig.og.sort();
+
+  doc.querySelectorAll("meta[name]").forEach((el) => {
+    const name = el.getAttribute("name") || "";
+    if (name.startsWith("twitter:")) {
+      sig.twitter.push(`${name} = ${normUrl(el.getAttribute("content"))}`);
+    }
+  });
+  sig.twitter.sort();
+
+  doc.querySelectorAll('script[type="application/ld+json"]').forEach((el) => {
+    sig.jsonld.push(canonicalJsonLd(el.textContent));
+  });
+  sig.jsonld.sort();
+
+  // 主動釋放：關閉 window，交由 GC 回收 DOM。
+  dom.window.close();
+  return sig;
+}
+
+// JSON-LD 正規化：解析後遞迴排序鍵值 + 遮蔽時間戳 + 剝雜湊，序列化。
+// 解析失敗時退回純文字正規化。
+function canonicalJsonLd(text) {
+  const cleaned = maskTimestamps(stripHash(text || ""));
+  try {
+    const obj = JSON.parse(cleaned);
+    return JSON.stringify(sortKeys(obj));
+  } catch (e) {
+    return collapseWs(cleaned);
+  }
+}
+
+function sortKeys(value) {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = sortKeys(value[key]);
+    }
+    return out;
+  }
+  if (typeof value === "string") return maskTimestamps(stripHash(value));
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// sitemap / feed 擷取
+// ---------------------------------------------------------------------------
+
+function readTagSet(file, tag) {
+  const set = new Set();
+  let xml;
+  try {
+    xml = fs.readFileSync(file, "utf8");
+  } catch (e) {
+    return null; // 檔案不存在
+  }
+  const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`, "gi");
+  let m;
+  while ((m = re.exec(xml)) !== null) {
+    set.add(normUrl(m[1]));
+  }
+  return set;
+}
+
+function sitemapLocs(root) {
+  return readTagSet(path.join(root, "sitemap.xml"), "loc");
+}
+
+function feedIds(root) {
+  return readTagSet(path.join(root, "feed", "feed.xml"), "id");
+}
+
+// ---------------------------------------------------------------------------
+// 比對
+// ---------------------------------------------------------------------------
+
+function diffSets(a, b) {
+  // a, b: Set | null。回傳 {added, removed} 或 null（雙方皆不存在）。
+  if (!a && !b) return null;
+  const setA = a || new Set();
+  const setB = b || new Set();
+  const added = [...setB].filter((x) => !setA.has(x)).sort();
+  const removed = [...setA].filter((x) => !setB.has(x)).sort();
+  return { added, removed };
+}
+
+function diffArray(a, b) {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  const added = b.filter((x) => !setA.has(x));
+  const removed = a.filter((x) => !setB.has(x));
+  return { added, removed };
+}
+
+const SCALAR_FIELDS = [
+  ["htmlLang", "html lang"],
+  ["title", "<title>"],
+  ["description", "meta description"],
+  ["canonical", "canonical"],
+  ["robots", "meta robots"],
+];
+
+const LIST_FIELDS = [
+  ["hreflang", "hreflang alternates"],
+  ["og", "Open Graph (og:*)"],
+  ["twitter", "Twitter Card (twitter:*)"],
+  ["jsonld", "JSON-LD"],
+];
+
+function diffPage(sigA, sigB) {
+  const changes = [];
+  for (const [key, label] of SCALAR_FIELDS) {
+    if (sigA[key] !== sigB[key]) {
+      changes.push({ field: label, type: "scalar", before: sigA[key], after: sigB[key] });
+    }
+  }
+  for (const [key, label] of LIST_FIELDS) {
+    const { added, removed } = diffArray(sigA[key], sigB[key]);
+    if (added.length || removed.length) {
+      changes.push({ field: label, type: "list", added, removed });
+    }
+  }
+  return changes;
+}
+
+function buildReport(dirA, dirB) {
+  const mapA = htmlUrlMap(dirA);
+  const mapB = htmlUrlMap(dirB);
+
+  const urlsA = new Set(mapA.keys());
+  const urlsB = new Set(mapB.keys());
+  const addedPages = [...urlsB].filter((u) => !urlsA.has(u)).sort();
+  const removedPages = [...urlsA].filter((u) => !urlsB.has(u)).sort();
+  const common = [...urlsA].filter((u) => urlsB.has(u)).sort();
+
+  const pageChanges = [];
+  for (const url of common) {
+    const sigA = extractSignature(mapA.get(url));
+    const sigB = extractSignature(mapB.get(url));
+    const changes = diffPage(sigA, sigB);
+    if (changes.length) pageChanges.push({ url, changes });
+  }
+
+  const sitemap = diffSets(sitemapLocs(dirA), sitemapLocs(dirB));
+  const feed = diffSets(feedIds(dirA), feedIds(dirB));
+
+  return { dirA, dirB, addedPages, removedPages, pageChanges, sitemap, feed };
+}
+
+function hasDifferences(report) {
+  if (report.addedPages.length || report.removedPages.length) return true;
+  if (report.pageChanges.length) return true;
+  if (report.sitemap && (report.sitemap.added.length || report.sitemap.removed.length)) return true;
+  if (report.feed && (report.feed.added.length || report.feed.removed.length)) return true;
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// zh-TW 文字報告
+// ---------------------------------------------------------------------------
+
+function shortVal(v) {
+  if (v === null || v === undefined) return "（無）";
+  const s = String(v);
+  return s.length > 160 ? s.slice(0, 157) + "…" : s;
+}
+
+function renderReport(report) {
+  const lines = [];
+  const push = (s) => lines.push(s);
+
+  if (!hasDifferences(report)) {
+    push("黃金輸出比對：兩份 _site 的 SEO 相關輸出完全相同，無差異。");
+    return lines.join("\n");
+  }
+
+  push("# 黃金輸出比對報告（SEO 影響）");
+  push("");
+
+  // 新增頁面
+  push(`## 新增頁面（${report.addedPages.length}）`);
+  if (report.addedPages.length) {
+    report.addedPages.forEach((u) => push(`- + ${u}`));
+  } else {
+    push("- （無）");
+  }
+  push("");
+
+  // 消失頁面
+  push(`## 消失頁面（${report.removedPages.length}）`);
+  if (report.removedPages.length) {
+    report.removedPages.forEach((u) => push(`- - ${u}`));
+  } else {
+    push("- （無）");
+  }
+  push("");
+
+  // 每頁 SEO 元素變更
+  push(`## 每頁 SEO 元素變更（${report.pageChanges.length} 頁）`);
+  if (!report.pageChanges.length) {
+    push("- （無）");
+  } else {
+    for (const pc of report.pageChanges) {
+      push(`### ${pc.url}`);
+      for (const c of pc.changes) {
+        if (c.type === "scalar") {
+          push(`- **${c.field}**`);
+          push(`  - 前：${shortVal(c.before)}`);
+          push(`  - 後：${shortVal(c.after)}`);
+        } else {
+          push(`- **${c.field}**`);
+          c.removed.forEach((x) => push(`  - − ${shortVal(x)}`));
+          c.added.forEach((x) => push(`  - ＋ ${shortVal(x)}`));
+        }
+      }
+      push("");
+    }
+  }
+
+  // sitemap
+  if (report.sitemap && (report.sitemap.added.length || report.sitemap.removed.length)) {
+    push(`## sitemap.xml 網址變更`);
+    report.sitemap.removed.forEach((u) => push(`- − ${u}`));
+    report.sitemap.added.forEach((u) => push(`- ＋ ${u}`));
+    push("");
+  }
+
+  // feed
+  if (report.feed && (report.feed.added.length || report.feed.removed.length)) {
+    push(`## feed/feed.xml 項目（id）變更`);
+    report.feed.removed.forEach((u) => push(`- − ${u}`));
+    report.feed.added.forEach((u) => push(`- ＋ ${u}`));
+    push("");
+  }
+
+  return lines.join("\n").replace(/\n+$/, "") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+function main(argv) {
+  const args = argv.slice(2);
+  const asJson = args.includes("--json");
+  const positional = args.filter((a) => !a.startsWith("--"));
+
+  if (positional.length !== 2) {
+    process.stderr.write(
+      "用法：node scripts/diff-site.js <dirA> <dirB> [--json]\n"
+    );
+    return 2;
+  }
+
+  const [dirA, dirB] = positional;
+  for (const d of [dirA, dirB]) {
+    if (!fs.existsSync(d) || !fs.statSync(d).isDirectory()) {
+      process.stderr.write(`錯誤：找不到目錄 ${d}\n`);
+      return 2;
+    }
+  }
+
+  const report = buildReport(dirA, dirB);
+  const differ = hasDifferences(report);
+
+  if (asJson) {
+    process.stdout.write(JSON.stringify({ ...report, hasDifferences: differ }, null, 2) + "\n");
+  } else {
+    process.stdout.write(renderReport(report) + "\n");
+  }
+
+  return differ ? 1 : 0;
+}
+
+if (require.main === module) {
+  process.exit(main(process.argv));
+}
+
+module.exports = {
+  buildReport,
+  renderReport,
+  hasDifferences,
+  extractSignature,
+  normUrl,
+  normText,
+  maskTimestamps,
+  canonicalJsonLd,
+};

--- a/test/test-diff-site.js
+++ b/test/test-diff-site.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const assert = require("assert").strict;
+const {
+  normUrl,
+  normText,
+  maskTimestamps,
+  canonicalJsonLd,
+} = require("../scripts/diff-site.js");
+
+describe("diff-site 正規化（SEO 比對的消音合約）", () => {
+  it("normUrl 剝除 ?hash= 與 ?v= 快取參數", () => {
+    assert.equal(
+      normUrl("/js/min.js?hash=deadbeef0123"),
+      "/js/min.js"
+    );
+    assert.equal(normUrl("/css/x.css?v=0a1b2c"), "/css/x.css");
+    assert.equal(
+      normUrl("/page/?q=keep"),
+      "/page/?q=keep",
+      "非快取查詢字串必須保留"
+    );
+  });
+
+  it("normText 收斂空白但保留內容", () => {
+    assert.equal(normText("  a\n  b\t c  "), "a b c");
+  });
+
+  it("maskTimestamps 遮蔽各種 W3C datetime 變體", () => {
+    assert.equal(maskTimestamps("2026-05-16T00:00:00Z"), "<ts>");
+    assert.equal(maskTimestamps("2026-05-16T00:00:00+08:00"), "<ts>");
+    assert.equal(maskTimestamps("2026-05-16"), "<ts>");
+    assert.equal(
+      maskTimestamps("updated 2026-05-16T08:00:00.123Z ok"),
+      "updated <ts> ok"
+    );
+  });
+
+  it("canonicalJsonLd 排序鍵值，使鍵序差異不產生假警報", () => {
+    const a = canonicalJsonLd('{"b":1,"a":{"d":2,"c":3}}');
+    const b = canonicalJsonLd('{"a":{"c":3,"d":2},"b":1}');
+    assert.equal(a, b);
+  });
+
+  it("canonicalJsonLd 對壞掉的 JSON 退回收斂空白的原文", () => {
+    assert.equal(canonicalJsonLd("not { json"), "not { json");
+  });
+});


### PR DESCRIPTION
## 背景與目的

改動模板、i18n、或 SEO 相關程式時，很難在 review 階段看出「這個 PR 到底改了哪些對搜尋引擎可見的輸出」。本 PR 引入「黃金輸出比對」（golden-output diff）：在 CI 上把 PR head 與 merge-base 各建置一份 `_site`，逐頁比對 SEO 敏感輸出，把差異直接寫進 job summary，讓 reviewer 一眼看到這個 PR 對 SEO 的實際影響（或確認沒有影響）。

## 改動內容

1. **`scripts/diff-site.js`（新增）**：比對兩份 `_site` 的工具。
   - 比對範圍：頁面 URL 集合（新增／消失頁）、每頁的 `<title>`、meta description、canonical、hreflang alternates、`og:*`、`twitter:*`、meta robots、JSON-LD、`<html lang>`，以及 `sitemap.xml` 的 `<loc>` 集合與 `feed/feed.xml` 的 `<id>` 集合。
   - 正規化：剝除 `?hash=`／`?v=` 快取破壞參數、收斂空白、JSON-LD 遞迴排序鍵值並遮蔽時間戳（CI 上兩次 checkout 的檔案 mtime 不同，會讓日期欄位產生假差異）。
   - 記憶體安全：一次只解析一頁的 DOM，取出輕量簽章後立即釋放；334 頁全站比對數秒內完成。
   - jsdom 對新 CSS 語法會噴大量 `Could not parse CSS stylesheet` 警告（全站可達數十 MB），已用靜音 VirtualConsole 丟棄——本工具只讀 SEO 節點，不需要 CSSOM。
   - 離開碼：`0` 無差異、`1` 有差異、`2` 使用錯誤。
2. **`package.json`**：新增 `npm run diff-site` 捷徑。
3. **`.github/workflows/ci.yml`**：新增 `seo-diff` job（僅 `pull_request` 觸發）。依序建置 PR head 與 merge-base（同一 runner 循序建置，不吃雙倍資源），跑 diff-site，報告寫入 `$GITHUB_STEP_SUMMARY`。job 設 `continue-on-error: true`：有差異時 step 會標紅提醒 reviewer 去看 summary，但**不會擋 PR**。
4. **`_11ty/getTagList.js`**：修正非決定性排序（見下方驗證證據——這是用本工具實證抓到的真實建置雜訊）。`collection.getAll()` 的順序取決於檔案系統掃描並不穩定，導致 `/tags/` 頁的區塊順序、連帶自動產生的 meta description **每次建置都不同**（線上每次 deploy 也在隨機變動）。改為 `[...tagSet].sort()` 之後輸出穩定。

## 爆炸半徑

- 對建置產物的影響只有一處：`/tags/` 頁（含各語系）改為固定字母序呈現，其餘 333 頁輸出位元不變（見下方 C/D 空 diff 證據；tag 順序原本每次建置就是隨機的，排序是把「隨機」變「穩定」，沒有任何頁面消失或新增）。
- CI：`seo-diff` job 只在 PR 觸發，失敗不擋合併（`continue-on-error`）；push 觸發的主 build job 完全不受影響。
- 讀者端零影響：無任何 runtime JS／CSS 改動。

## 驗證證據

**1. 雜訊實證（修正前）**：同一 commit 連建兩次再 diff，抓到唯一一筆真實雜訊——`/tags/` 的描述隨建置隨機變動：

```
## 每頁 SEO 元素變更（1 頁）
### /tags/
- **meta description**
  - 前：mentor 2022-07-01 RE [前端引路人計劃] - 我也能夠當個 mentor 嗎？ Benben Front-end 2025-01-26 …
  - 後：p5 2022-05-03 來畫個圖吧 - P5.js 入門 Benben JavaScript 2026-05-16 Reduce | 完全手冊 …
- **Open Graph (og:*)** 、 **Twitter Card (twitter:*)** 同步變動
```

**2. 空 diff 驗證（修正後）**：rebase 到最新 main、套用 `getTagList` 排序修正後，同一 commit 連建兩次（各 334 頁）再 diff：

```
黃金輸出比對：兩份 _site 的 SEO 相關輸出完全相同，無差異。
（離開碼 0，stderr 0 bytes）
```

**3. 正向對照（positive control）**：對 `posts/benben/04-cli.md` 加一行 throwaway `description:` 再建置比對，工具精準回報該頁、且只有該頁：

```
## 每頁 SEO 元素變更（1 頁）
### /posts/benben/04-cli/
- **meta description**
  - 前：圖片來源：我的 window terminal (imgur) # 前言 （因為工作太忙，拖稿中） …
  - 後：黃金輸出比對正向對照測試用描述（throwaway）
- **Open Graph (og:*)**、**Twitter Card (twitter:*)**、**JSON-LD** 同步偵測到對應變更
（離開碼 1；throwaway 改動已還原，未進 commit）
```

## 有意不做

- **不比對頁面本文／版面**：留言數、gamification 數字等本文變動與 SEO 無關，納入只會製造噪音；本工具聚焦搜尋引擎讀的節點。
- **不設硬性門檻擋 PR**：SEO 輸出變更常常是「本來就想要的」（如新增翻譯頁）；工具的定位是給 reviewer 的顯微鏡，不是守門員。要升級成硬門檻只需拿掉 `continue-on-error`。
- **不快取 merge-base 建置產物**：循序建置一次約多 3–4 分鐘，先求簡單正確；有需要再加 actions/cache。
- **不修 `/tags/<tag>/` 子頁的同日期併列排序**：`sortByPublishedDate` 對同日期文章的相對順序理論上仍依輸入順序；本次兩輪實證均未觀察到抖動，留待真的出現再處理。

## 後續

- 觀察幾個真實 PR 的 summary 報告品質，必要時調整正規化規則（新的合法雜訊來源出現時，優先修根因、其次才是在 normalizer 遮蔽）。
- 可考慮把報告貼成 PR comment（需要 `pull-requests: write` 權限，另開 PR 討論）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
