### PR TITLE
perf(images): 恢復 gif2mp4，動畫 GIF 轉 <video>（-73.8% 體積）

### DIFF
--- a/_11ty/img-dim.js
+++ b/_11ty/img-dim.js
@@ -75,9 +75,11 @@ const processImage = async (img, outputPath) => {
     return;
   }
   if (dimensions.type == "gif") {
-    // note: disable gif2mp4 by huli
-    return
-    const videoSrc = await gif2mp4(src);
+    // 2021 年 huli 在此停用 gif2mp4（"note: disable gif2mp4 by huli"）：
+    // 當時新增的 react.gif 是 874x615（奇數高），ffmpeg 的 yuv420p 要求
+    // 偶數寬高，轉檔直接失敗。video-gif.js 已加 scale 濾鏡修正根因，
+    // 因此恢復轉檔。
+    const videoSrc = await gif2mp4(localUrlPath(src));
     const video = img.ownerDocument.createElement(
       /AMP/i.test(img.tagName) ? "amp-video" : "video"
     );
@@ -88,10 +90,12 @@ const processImage = async (img, outputPath) => {
     video.setAttribute("autoplay", "");
     video.setAttribute("muted", "");
     video.setAttribute("loop", "");
+    video.setAttribute("playsinline", "");
     if (!video.getAttribute("aria-label")) {
-      video.setAttribute("aria-label", img.getAttribute("alt"));
-      video.removeAttribute("alt");
+      const alt = img.getAttribute("alt");
+      if (alt) video.setAttribute("aria-label", alt);
     }
+    video.removeAttribute("alt");
     img.parentElement.replaceChild(video, img);
     return;
   }

--- a/_11ty/video-gif.js
+++ b/_11ty/video-gif.js
@@ -20,18 +20,53 @@
  */
 
 const { promisify } = require("util");
-const { join } = require("path");
+const { join, dirname } = require("path");
+const fs = require("fs");
 const shell = require("any-shell-escape");
-const exists = promisify(require("fs").exists);
 const exec = promisify(require("child_process").exec);
 const pathToFfmpeg = require("ffmpeg-static");
 
-exports.gif2mp4 = async function (filename) {
+// 內容欄寬 608px，×2（retina）＝ 1216；取 srcset 既有級距 1280 對齊。
+// 全解析度輸出（如 2768px 寬的螢幕錄影）壓不小，縮到版面實際需要的寬度
+// 才能拿到約 80–90% 的體積縮減。
+const MAX_WIDTH = 1280;
+
+// 同一個 GIF 會被多個頁面引用（例如 i18n 的四個語言版本）。Eleventy 的
+// transform 逐頁並行執行，若不去重，同一個輸出檔會有多個 ffmpeg 行程
+// 同時寫入（-y 互相覆蓋）。以輸出路徑為鍵快取 in-flight promise，
+// 讓每個 GIF 每次建置最多轉檔一次。
+const inFlight = new Map();
+
+exports.gif2mp4 = function (filename) {
   const dest = mp4Name(filename);
-  const exists = promisify(require("fs").exists);
-  if (await exists(dest)) {
+  if (!inFlight.has(dest)) {
+    inFlight.set(
+      dest,
+      convert(filename, dest).catch((e) => {
+        // 失敗不留快取，讓下一個引用頁重試並回報一樣的錯誤。
+        inFlight.delete(dest);
+        throw e;
+      })
+    );
+  }
+  return inFlight.get(dest);
+};
+
+async function convert(filename, dest) {
+  const outputFile = join("_site", dest);
+  // 舊碼在這裡檢查的是 `dest`（一個以 / 開頭的 URL 路徑，等於檔案系統
+  // 根目錄），永遠不存在，導致每一頁、每次建置都重新轉檔。改查實際輸出檔。
+  if (fs.existsSync(outputFile)) {
     return dest;
   }
+  // 優先讀 source tree：`_site/` 的複本由 passthrough copy 產生，與 HTML
+  // transform 並行執行，讀它可能撞到半寫入的檔案（同 img-dim.js 的做法）。
+  const sourceFile = "." + filename;
+  const inputFile = fs.existsSync(sourceFile)
+    ? sourceFile
+    : join("_site", filename);
+  // passthrough copy 可能還沒建立輸出目錄，先確保存在。
+  fs.mkdirSync(dirname(outputFile), { recursive: true });
   const command = shell([
     pathToFfmpeg,
     // See https://engineering.giphy.com/how-to-make-gifs-with-ffmpeg/
@@ -39,16 +74,21 @@ exports.gif2mp4 = async function (filename) {
     "-v",
     "error",
     "-i",
-    join("_site", filename),
+    inputFile,
     "-filter_complex",
-    "[0:v] fps=15",
+    // yuv420p 要求偶數寬高：2021 年 huli 停用 gif2mp4 的原因正是
+    // 874x615（奇數高）的 GIF 讓 libx264 以
+    // "height not divisible by 2" 失敗。scale 表達式同時
+    // (1) 把寬度上限鎖在 MAX_WIDTH、(2) 保證寬高皆為偶數（-2 = 依比例
+    // 自動算出最接近的偶數高）。
+    `[0:v] fps=15,scale='trunc(min(iw,${MAX_WIDTH})/2)*2':-2`,
     "-vsync",
     0,
     "-f",
     "mp4",
     "-pix_fmt",
     "yuv420p",
-    join("_site", dest),
+    outputFile,
   ]);
   try {
     await exec(command);
@@ -56,7 +96,7 @@ exports.gif2mp4 = async function (filename) {
     throw new Error(`Failed executing ${command} with ${e.stderr}`);
   }
   return dest;
-};
+}
 
 function mp4Name(filename) {
   return filename.replace(/\.\w+$/, (_) => ".mp4");

--- a/test/test-image-pipeline.js
+++ b/test/test-image-pipeline.js
@@ -60,6 +60,34 @@ describe("image build pipeline", () => {
     assert.equal(sources[0].getAttribute("sizes"), "64px");
   });
 
+  it("converts GIFs to <video> — including odd-height GIFs that broke the 2021 build", async function () {
+    // react.gif 是 874x615（奇數高）：正是 2021 年讓 ffmpeg 以
+    // "height not divisible by 2" 失敗、導致 gif2mp4 被整個停用的檔案。
+    // 用它當 fixture，確保 scale 濾鏡修正不會回歸。
+    this.timeout(30000);
+    const output = await transform(
+      '<!doctype html><p><img alt="React demo" src="/img/posts/clay/react.gif"></p>',
+      "_site/gif-test/index.html"
+    );
+    const doc = new JSDOM(output, { virtualConsole: quietConsole }).window.document;
+    assert.equal(doc.querySelector("img"), null, "The <img> should be replaced");
+    const video = doc.querySelector("video");
+    assert.ok(video, "Expected the GIF to be swapped for a <video>");
+    assert.equal(video.getAttribute("src"), "/img/posts/clay/react.mp4");
+    assert.equal(video.getAttribute("width"), "874");
+    assert.equal(video.getAttribute("height"), "615");
+    for (const attr of ["autoplay", "muted", "loop", "playsinline"]) {
+      assert.ok(video.hasAttribute(attr), `Expected ${attr} on the <video>`);
+    }
+    assert.equal(video.getAttribute("aria-label"), "React demo");
+    assert.equal(video.getAttribute("alt"), null);
+
+    const fs = require("fs");
+    const mp4 = "_site/img/posts/clay/react.mp4";
+    assert.ok(fs.existsSync(mp4), `Expected ${mp4} to be written`);
+    assert.ok(fs.statSync(mp4).size > 0, `Expected ${mp4} to be non-empty`);
+  });
+
   it("caps small local avatars at 96px without downsizing larger avatars", async () => {
     const output = await transform(
       '<!doctype html><img class="avatar avatar-small" alt="" src="/img/authors/tian.jpg">',


### PR DESCRIPTION
## 背景與目的

首要目標是 90% 讀者的體驗（SEO 為次要，本改動對 SEO 中性）：動畫 GIF 是全站最重的資產，逐幀解碼耗 CPU/電量、又無硬體加速。上游（Google `eleventy-high-performance-blog`）本就內建 GIF→MP4 轉檔，但被停用至今。本 PR 修正根因後恢復轉檔，8 支 GIF 的總下載量從 **20.4 MB 降到 5.35 MB（-73.8%）**。

## 改動內容（含考古發現）

**考古**：`git log --follow` 顯示 `// note: disable gif2mp4 by huli` + early return **自 2021-07-04 初始 commit 就存在**（huli 從上游匯入時即停用，非後來才關）。根因不是建置時間或 Netlify 記憶體，而是 **`img/posts/{clay,cwc329,huli}/react.gif` 為 874×615（奇數高）**：libx264 的 `yuv420p` 要求偶數寬高，轉檔以 `height not divisible by 2` 直接失敗。

**修根因、不是拆防護**：
| 項目 | 改動 |
| --- | --- |
| 奇數寬高失敗 | `video-gif.js` scale 濾鏡 `scale='trunc(min(iw,1280)/2)*2':-2`，同時鎖寬度上限 1280 並保證寬高皆偶數 |
| 快取永遠 miss | 舊碼拿 URL 路徑（`/img/...`）當檔案系統路徑檢查 `existsSync`，永遠不存在→每頁每次重轉。改查實際輸出檔 `_site/<dest>` |
| 輸出位置 | `mp4Name()` 產物寫入 `_site/`（非 source tree），輸入優先讀 source 避開 passthrough 半寫入檔 |
| i18n 重複轉檔 | 同一 GIF 被多語言頁引用，以 in-flight promise Map 去重，每次建置每檔最多轉一次 |
| 標記 | `<video autoplay muted loop playsinline>`，保留原 `width/height/class/style`，`aria-label` 取自原 `alt`（無 alt 則不加、移除 `alt`） |

## 爆炸半徑（受影響頁面）

全域 transform，但只有含**本地** GIF 的頁面改變（`https://` 遠端 GIF 走既有 remote-skip，不轉）。`git diff -rq` 實測僅下列 **8 頁 img→video ＋ 8 個新增 MP4**，無其他檔案變動、原 GIF 仍 passthrough 保留為 fallback：

| 頁面 | 涉及 GIF |
| --- | --- |
| `posts/ruofan/vue-infinite-scroll/` | observe、event |
| `posts/ruofan/next-auth/` | next-login |
| `posts/ruofan/svelte/` | svelte、xstate |
| `posts/ruofan/scroll-driven-animations/` | animation-1、animation-2 |
| `posts/benben/15-raycast-101/`（＋ `en/`、`ja/`、`zh-CN/` 共 4 語言） | 15-wrapped |

> `posts/xiang/debug-case-01`、`ga-basic` 的 GIF 以絕對 `https://` URL 引用，視為遠端不轉（維持現狀）。

## 驗證證據

**黃金輸出比對** `node scripts/diff-site.js <pre> <post>`：
> 黃金輸出比對：兩份 _site 的 SEO 相關輸出完全相同，無差異。

原始檔案級 `diff -rq` 只有上表 8 頁 HTML 變動 ＋ 8 個 MP4 新增，符合預期。

**建置時間**（lock 保護、前景、各一次 clean build）：
| | eleventy real |
| --- | --- |
| 恢復前（gif2mp4 停用） | 60.30 s |
| 恢復後 | 72.99 s |
| 倍率 | **1.21x**（未達 2x 門檻） |

→ 未達 2x，且 in-flight 去重已解決同檔多頁重轉；`npm run clean` 每次清 `_site`，跨建置持久快取無意義，故**不另做 mtime/hash 快取**（依實測數據決定）。

**體積表**（source GIF → 輸出 MP4）：
| GIF | 原始 | MP4 | 縮減 |
| --- | ---: | ---: | ---: |
| observe | 5.75 MB | 1.05 MB | 81.8% |
| next-login | 5.11 MB | 0.99 MB | 80.7% |
| event | 2.55 MB | 0.37 MB | 85.4% |
| 15-wrapped | 2.30 MB | 0.89 MB | 61.4% |
| animation-2 | 2.80 MB | 1.51 MB | 45.8% |
| animation-1 | 0.98 MB | 0.09 MB | 90.3% |
| svelte | 0.77 MB | 0.23 MB | 70.4% |
| xstate | 0.14 MB | 0.21 MB | **-52.4%** |
| **合計** | **20.4 MB** | **5.35 MB** | **73.8%** |

**測試**：擴充 `test/test-image-pipeline.js`，新增用 react.gif（874×615 奇數高，正是 2021 失敗檔）當 fixture 的防回歸測試，驗證 img→video、`width/height/aria-label`、`autoplay muted loop playsinline`、MP4 實際落地。全套 **173 passing**。

## 有意不做

- **xstate.gif（143 KB→218 KB 變大）**：小尺寸低複雜度 GIF 轉 H.264 因 keyframe/容器開銷反而略大。全站淨值大幅為負（省 15 MB），且 MP4 仍免除 GIF 逐幀解碼、可硬體加速，體驗仍較佳，故不為單一小檔加「取兩者較小」分支，保持 transform 簡單。列入後續觀察。
- **遠端 `https://` GIF（xiang、benben hackmd 圖）不處理**：沿用既有 remote-skip，不在建置期抓取外部資源。
- **未改動 `react.gif` 三處來源檔**：目前無任何線上文章引用它，僅作測試 fixture。

## 後續

- 可評估對「MP4 比原 GIF 大」的資產自動 fallback 回 GIF（目前僅 xstate 一例，效益有限）。
- 可考慮把奇數尺寸資產（react.gif）於來源端正規化，或補 `poster` 提升首幀體驗。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
