### PR TITLE
[Stack 3/3] 前端錯誤 beacon

### DIFF
--- a/functions/error-log.js
+++ b/functions/error-log.js
@@ -1,0 +1,74 @@
+"use strict";
+
+// Front-end error beacon sink.
+//
+// Receives the JSON that src/main.js's error beacon sends via navigator
+// .sendBeacon, writes a sanitized one-line record to the Netlify function
+// logs, and returns 204 with an empty body. It NEVER echoes the input back
+// (no reflection surface), validates/truncates every field, and persists
+// nothing beyond the log line. No PII is expected or stored — only technical
+// fields (message/source/line/col/stack/path/UA).
+
+const LIMITS = {
+  message: 500,
+  source: 500,
+  stack: 2000,
+  path: 300,
+  ua: 300,
+};
+
+function str(value, max) {
+  if (typeof value !== "string") return "";
+  return value.length > max ? value.slice(0, max) : value;
+}
+
+function nonNegInt(value) {
+  const n = typeof value === "number" ? value : parseInt(value, 10);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
+}
+
+// Exported so the sanitizer can be unit-tested without HTTP plumbing.
+function sanitize(data) {
+  return {
+    ts: new Date().toISOString(),
+    message: str(data.message, LIMITS.message),
+    source: str(data.source, LIMITS.source),
+    line: nonNegInt(data.line),
+    col: nonNegInt(data.col),
+    stack: str(data.stack, LIMITS.stack),
+    path: str(data.path, LIMITS.path),
+    ua: str(data.ua, LIMITS.ua),
+  };
+}
+
+exports.sanitize = sanitize;
+exports.LIMITS = LIMITS;
+
+exports.handler = async function handler(event) {
+  // Only accept the beacon POST. Anything else is a no-op.
+  if (!event || event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "" };
+  }
+
+  let data;
+  try {
+    data = JSON.parse(event.body || "{}");
+  } catch (e) {
+    // Malformed payload: acknowledge quietly, don't log attacker-controlled noise.
+    return { statusCode: 204, body: "" };
+  }
+
+  // A useful report must at least carry a message string.
+  if (!data || typeof data !== "object" || typeof data.message !== "string" || !data.message) {
+    return { statusCode: 204, body: "" };
+  }
+
+  const record = sanitize(data);
+
+  // Netlify captures stdout into the function logs; that is the whole sink.
+  // eslint-disable-next-line no-console
+  console.log("[client-error] " + JSON.stringify(record));
+
+  // 204 No Content: nothing is reflected back to the caller.
+  return { statusCode: 204, body: "" };
+};

--- a/src/main.js
+++ b/src/main.js
@@ -589,3 +589,69 @@ document.body.addEventListener(
     });
   });
 })();
+
+// ── Front-end error beacon ──────────────────────────────────────────────
+// Report uncaught errors and unhandled promise rejections to a Netlify
+// function via sendBeacon (fire-and-forget; survives the page unloading).
+// We send only technical fields — no PII. Cross-origin "Script error." is
+// opaque and useless, so it is dropped. Reports are deduped per session and
+// capped per pageview so a looping error can't flood the sink.
+(function () {
+  if (!navigator.sendBeacon) return;
+  var ENDPOINT = "/.netlify/functions/error-log";
+  var MAX_PER_PAGEVIEW = 5;
+  var STACK_MAX = 2000;
+  var sent = 0;
+  var seen = {};
+
+  function truncate(s, n) {
+    if (typeof s !== "string") return "";
+    return s.length > n ? s.slice(0, n) : s;
+  }
+
+  function report(payload) {
+    if (sent >= MAX_PER_PAGEVIEW) return;
+    var key = payload.message + "|" + payload.source + "|" + payload.line;
+    if (seen[key]) return;
+    seen[key] = true;
+    sent++;
+    try {
+      var blob = new Blob([JSON.stringify(payload)], {
+        type: "application/json",
+      });
+      navigator.sendBeacon(ENDPOINT, blob);
+    } catch (e) {}
+  }
+
+  addEventListener("error", function (e) {
+    // Cross-origin script errors are reported opaquely as "Script error."
+    // with no usable source — nothing actionable, so drop them. Resource
+    // load failures (img/script) fire without e.error and e.lineno; skip
+    // those too, we only want script exceptions.
+    if (!e.message || e.message === "Script error.") return;
+    if (!e.error && !e.lineno) return;
+    report({
+      message: truncate(e.message, 500),
+      source: truncate(e.filename || "", 500),
+      line: e.lineno || 0,
+      col: e.colno || 0,
+      stack: truncate((e.error && e.error.stack) || "", STACK_MAX),
+      path: location.pathname,
+      ua: truncate(navigator.userAgent, 300),
+    });
+  });
+
+  addEventListener("unhandledrejection", function (e) {
+    var reason = e.reason;
+    var msg = reason && reason.message ? reason.message : String(reason);
+    report({
+      message: truncate("Unhandled rejection: " + msg, 500),
+      source: "",
+      line: 0,
+      col: 0,
+      stack: truncate((reason && reason.stack) || "", STACK_MAX),
+      path: location.pathname,
+      ua: truncate(navigator.userAgent, 300),
+    });
+  });
+})();

--- a/test/test-error-beacon.js
+++ b/test/test-error-beacon.js
@@ -1,0 +1,183 @@
+"use strict";
+
+// 前端錯誤 beacon 的測試，分兩部分：
+// 1) functions/error-log.js handler：直接以假的 Netlify event 呼叫，驗證
+//    方法檢查、輸入驗證/截斷、回 204、且絕不把輸入反射回 body。
+// 2) 客戶端 beacon：把打包後的 js/min.js 載入 jsdom，stub sendBeacon，
+//    觸發假的 error / unhandledrejection，驗證送出的 payload、去重與上限。
+//    （手法同 test-umami-events.js / test-copy-code.js。）
+
+const assert = require("assert").strict;
+const fs = require("fs");
+const path = require("path");
+const { JSDOM, VirtualConsole } = require("jsdom");
+
+const handlerMod = require("../functions/error-log.js");
+const BUNDLE = path.resolve(__dirname, "..", "js", "min.js");
+
+function post(body) {
+  return { httpMethod: "POST", body: typeof body === "string" ? body : JSON.stringify(body) };
+}
+
+describe("error-log Netlify function handler", function () {
+  it("rejects non-POST with 405 and no body", async () => {
+    const res = await handlerMod.handler({ httpMethod: "GET" });
+    assert.equal(res.statusCode, 405);
+    assert.equal(res.body, "");
+  });
+
+  it("returns 204 with an empty body on a valid report (no reflection)", async () => {
+    const payload = { message: "boom", source: "https://x/a.js", line: 4, col: 2, path: "/posts/x/" };
+    const res = await handlerMod.handler(post(payload));
+    assert.equal(res.statusCode, 204);
+    assert.equal(res.body, "");
+    // The handler must never echo attacker-controlled input back.
+    assert.ok(!res.body.includes("boom"));
+  });
+
+  it("acknowledges malformed JSON and missing message with 204", async () => {
+    const bad = await handlerMod.handler(post("{not json"));
+    assert.equal(bad.statusCode, 204);
+    const noMsg = await handlerMod.handler(post({ source: "x.js" }));
+    assert.equal(noMsg.statusCode, 204);
+  });
+
+  it("truncates over-long fields and coerces numeric fields", () => {
+    const rec = handlerMod.sanitize({
+      message: "m".repeat(9000),
+      stack: "s".repeat(9000),
+      ua: "u".repeat(9000),
+      line: "17",
+      col: -5,
+    });
+    assert.equal(rec.message.length, handlerMod.LIMITS.message);
+    assert.equal(rec.stack.length, handlerMod.LIMITS.stack);
+    assert.equal(rec.ua.length, handlerMod.LIMITS.ua);
+    assert.equal(rec.line, 17);
+    assert.equal(rec.col, 0); // negative coerced to 0
+    assert.ok(typeof rec.ts === "string");
+  });
+});
+
+// ── client beacon (js/min.js in jsdom) ──────────────────────────────────
+
+function loadPage() {
+  const dom = new JSDOM(
+    `<!doctype html><html lang="zh-TW"><head></head><body class="tmpl-home">
+    <header><nav aria-label="primary"><div id="nav">
+      <p class="site-title"><a href="/">EB</a></p></div>
+      <div id="reading-progress"></div></nav>
+    <dialog id="message" data-ui="{}"></dialog></header>
+    <main id="main"></main></body></html>`,
+    {
+      url: "https://blog.errorbaker.tw/posts/example/",
+      runScripts: "outside-only",
+      pretendToBeVisual: true,
+      virtualConsole: new VirtualConsole(),
+    }
+  );
+  const { window } = dom;
+  const beacons = [];
+  // jsdom 15's Blob has no .text(); shim Blob to capture the raw string parts
+  // so we can assert on the JSON the client actually serialized.
+  window.Blob = class {
+    constructor(parts, opts) {
+      this._text = (parts || []).join("");
+      this.type = (opts && opts.type) || "";
+    }
+  };
+  // sendBeacon must exist BEFORE the bundle runs (the beacon block early-returns
+  // when it is absent). Capture the JSON body of each call.
+  window.navigator.sendBeacon = function (url, blob) {
+    beacons.push({ url: url, body: blob && blob._text });
+    return true;
+  };
+  window.ResizeObserver = class {
+    observe() {}
+    disconnect() {}
+  };
+  window.eval(fs.readFileSync(BUNDLE, "utf8"));
+  return { dom, window, beacons };
+}
+
+function fireError(window, opts) {
+  const ev = new window.ErrorEvent("error", opts);
+  window.dispatchEvent(ev);
+}
+
+function beaconJson(beacon) {
+  return JSON.parse(beacon.body);
+}
+
+describe("client error beacon (js/min.js in jsdom)", function () {
+  this.timeout(5000);
+
+  it("beacons an uncaught error to the error-log endpoint with sanitized fields", async () => {
+    const { window, beacons } = loadPage();
+    fireError(window, {
+      message: "ReferenceError: x is not defined",
+      filename: "https://blog.errorbaker.tw/js/min.js",
+      lineno: 12,
+      colno: 5,
+      error: new window.Error("ReferenceError: x is not defined"),
+    });
+    assert.equal(beacons.length, 1);
+    assert.ok(beacons[0].url.endsWith("/.netlify/functions/error-log"));
+    const body = beaconJson(beacons[0]);
+    assert.equal(body.message, "ReferenceError: x is not defined");
+    assert.equal(body.line, 12);
+    assert.equal(body.col, 5);
+    assert.equal(body.path, "/posts/example/");
+    assert.ok(typeof body.ua === "string");
+    window.close();
+  });
+
+  it('ignores cross-origin "Script error."', () => {
+    const { window, beacons } = loadPage();
+    fireError(window, { message: "Script error.", filename: "", lineno: 0, colno: 0 });
+    assert.equal(beacons.length, 0);
+    window.close();
+  });
+
+  it("dedupes identical errors within a session", () => {
+    const { window, beacons } = loadPage();
+    const opts = {
+      message: "TypeError: boom",
+      filename: "a.js",
+      lineno: 3,
+      colno: 1,
+      error: new window.Error("TypeError: boom"),
+    };
+    fireError(window, opts);
+    fireError(window, opts);
+    fireError(window, opts);
+    assert.equal(beacons.length, 1);
+    window.close();
+  });
+
+  it("caps reports at 5 per pageview", () => {
+    const { window, beacons } = loadPage();
+    for (let i = 0; i < 8; i++) {
+      fireError(window, {
+        message: "Err " + i,
+        filename: "a.js",
+        lineno: i,
+        colno: 1,
+        error: new window.Error("Err " + i),
+      });
+    }
+    assert.equal(beacons.length, 5);
+    window.close();
+  });
+
+  it("beacons unhandled promise rejections", async () => {
+    const { window, beacons } = loadPage();
+    const ev = new window.Event("unhandledrejection");
+    ev.reason = new window.Error("promise blew up");
+    window.dispatchEvent(ev);
+    assert.equal(beacons.length, 1);
+    const body = beaconJson(beacons[0]);
+    assert.ok(body.message.indexOf("Unhandled rejection: promise blew up") === 0);
+    window.close();
+  });
+});


### PR DESCRIPTION
> Stacked on #251（Stack 2/3），其底層為 #248（Stack 1/3）。請依序 review／合併 #248 → #251 → 本 PR；本 PR 的 diff 以 `feat/a2b-copy-code` 為基底。

## 背景與目的

站上目前沒有前端錯誤的可見度：讀者端的 JS 例外只留在各自瀏覽器裡。本 PR 加一條輕量 beacon，把未捕捉的錯誤送到 Netlify function 記到 log，便於發現線上壞掉的頁面。為 `src/main.js` 系列第 3/3。

## 改動內容

- `src/main.js`：監聽 `error` 與 `unhandledrejection`，以 `navigator.sendBeacon('/.netlify/functions/error-log', JSON)` 送出。
  - payload：`message / source / line / col / stack`（截斷 ~2KB）`/ path / UA` —— 皆技術欄位，**無 PII**。
  - 忽略跨來源不透明的 `"Script error."` 與資源載入錯誤（無 `error`/`lineno`）。
  - 同一 session 去重（`message|source|line`）、每次瀏覽上限 **5** 筆，避免錯誤迴圈灌爆 sink。
  - `sendBeacon` 不存在時整段早退，絕不影響頁面。
- `functions/error-log.js`（新）：
  - 非 POST → 405；JSON 解析失敗或缺 `message` → 204（不記錄攻擊者可控噪音）。
  - 驗證/截斷每個欄位後 `console.log` 寫入 Netlify function logs。
  - 回 **204 空 body、絕不反射輸入**；不持久化任何資料。

## 爆炸半徑

- `netlify.toml` 早已設定 `functions = "functions/"`（此前目錄不存在）；新增檔案即掛上 `/.netlify/functions/error-log`。
- `.eleventyignore` 已含 `functions`，且 templateFormats 不含 `js`，故 Eleventy 不會把此檔當模板 → 無 HTML 輸出改動。
- 純附加監聽 + fire-and-forget beacon，對既有互動零影響；上限/去重防迴圈。
- Bundle 成長：gzip **+317B**（相對 Stack 2/3）；整個系列相對 main 累計 **+746B**（< 1KB）。
- 無 PII。

## 驗證證據

- 全量 `npm run build` 於 build-lock 下 **RC=0，191 passing**（含新測試 9 項）。
- 新增 `test/test-error-beacon.js`：
  - **handler（node 直呼）**：非 POST→405；合法回報→204 且 body 為空、不含輸入字串；壞 JSON / 缺 message→204；欄位截斷至上限、`line:"17"`→17、`col:-5`→0。
  - **client beacon（jsdom 載入 js/min.js，stub `sendBeacon`）**：真實例外送到 `…/error-log`，payload 帶正確 `message/line/col/path/ua`；`"Script error."` 不送；同錯誤去重為 1；8 次錯誤上限 5；`unhandledrejection` 正確送出。
  - 9 passing。
- handler 於測試中實際輸出一行 `[client-error] {…}`（即 Netlify log 記錄形式）。

## 有意不做

- 未接任何第三方錯誤服務（Sentry 等）——先用 Netlify function logs 的最小 sink，避免新增外部相依與隱私面。
- 未送使用者輸入、cookie、localStorage 或完整 URL query，僅 `pathname`。
- 未做 server 端 rate-limit（client 已有 per-pageview 上限）；如需再加。

## 後續

- 系列完成（1/3 #248、2/3 #251、3/3 本 PR）。合併後可在 Netlify function logs 觀察 `[client-error]`，必要時再接告警。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
