### PR TITLE
ci(review): 加 1h 上限 + 模型改 mimo-v2.5 + 統一輸出格式

### DIFF
--- a/.github/REVIEW_FORMAT.md
+++ b/.github/REVIEW_FORMAT.md
@@ -1,0 +1,63 @@
+# Code Review Output Format
+
+Every `opencode-review` comment MUST follow this structure so reviews are
+consistent and scannable across PRs. Omit any empty section — **except Verdict
+and Summary, which are always present.**
+
+The opencode action appends the session/run link automatically; do **not** add
+a footer.
+
+---
+
+## Template
+
+```
+## Code Review
+
+**Verdict:** <LGTM | Request changes | Needs discussion> — <one sentence why>
+
+<1–2 sentence summary: what the change does and your overall assessment>
+
+### Findings
+
+Highest severity first, one per line, in exactly this form:
+
+- **[Blocker]** `path/file.ext:LINE` — <concrete problem> → <suggested fix>
+- **[Major]**   `path/file.ext:LINE` — <concrete problem> → <suggested fix>
+- **[Nit]**     `path/file.ext:LINE` — <concrete problem> → <suggested fix>
+
+If there are no findings, write exactly: ✅ No issues found.
+
+### Verified OK
+
+- <things you checked and confirmed correct, so the next reviewer does not
+  re-flag them — especially code that looks suspicious but is actually handled>
+
+### Tests & Build
+
+<one line: `npm test` / `npm run build` pass | fail | N/A>
+```
+
+---
+
+## Severity definitions
+
+| Tag | Meaning |
+|-----|---------|
+| **[Blocker]** | Correctness or security bug; unsafe to merge as-is. |
+| **[Major]** | A real issue; should fix before or soon after merge. |
+| **[Nit]** | Style, naming, minor cleanup; optional. |
+
+---
+
+## Rules
+
+- **Always cite `file:line`.** No vague findings like "somewhere in the auth layer".
+- **One finding per bullet**, keep each to 1–2 lines.
+- **Do not invent issues to fill space.** A clean, correct diff → `✅ No issues found.` is a complete, valid review.
+- **No severity inflation.** A missing JSDoc is never `[Blocker]`; a single `any` in a test fixture is never `[Blocker]`.
+- For translation PRs (`posts/`), keep the Verdict line and `[Blocker]`/`[Major]`/`[Nit]` tags, but use these section names instead of the generic ones:
+  - `### Frontmatter & AGENTS.md Compliance`
+  - `### Findings`
+  - `### Verified OK` *(not defects — esp. JP/zh-CN character forms correct per `REVIEW-PITFALLS.md`)*
+  - `### Tests & Build`

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -14,6 +14,10 @@ jobs:
     # Human-pushed commits still get reviewed.
     if: github.actor != 'opencode-agent[bot]'
     runs-on: ubuntu-latest
+    # A normal review finishes in a few minutes; cap the job so a runaway
+    # agent loop (e.g. PR #247 ran 4h35m / 1.1k model calls) can't bill the
+    # opencode-go balance dry before it's cancelled.
+    timeout-minutes: 60
     permissions:
       id-token: write
       contents: read
@@ -82,5 +86,5 @@ jobs:
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
         with:
-          model: opencode-go/qwen3.7-plus
+          model: opencode-go/mimo-v2.5
           prompt: ${{ steps.prompt.outputs.value }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -61,7 +61,11 @@ jobs:
               echo '6. Untranslated prose: markdown link text [text](url) and <img alt="..."> should be translated — except external article titles (preserve verbatim).'
               echo '7. Chinese idioms / slang literally carried into Japanese (e.g. 香る for "很香", 麗麗 for "煩瑣") — flag for re-translation.'
               echo ''
-              echo 'Keep the review concrete and concise. Output a markdown summary with sections: Frontmatter & AGENTS.md Compliance, Issues Found (by severity), Not defects (verified correct).'
+              echo 'Output format: read .github/REVIEW_FORMAT.md and follow it exactly — same `## Code Review` title, Verdict line, and [Blocker] / [Major] / [Nit] tags — but use these translation-specific sections instead of the generic ones:'
+              echo '- ### Frontmatter & AGENTS.md Compliance'
+              echo '- ### Findings (same severity tags)'
+              echo '- ### Verified OK (not defects — esp. JP/zh-CN character forms correct per REVIEW-PITFALLS.md)'
+              echo '- ### Tests & Build'
               echo 'PROMPT_END'
             } >> "$GITHUB_OUTPUT"
           else
@@ -76,7 +80,9 @@ jobs:
               echo '- Security, typos, dead code, obvious regressions'
               echo '- Consistency with surrounding code style'
               echo ''
-              echo 'Keep the review concrete and concise. Skip the translation/AGENTS.md checks entirely.'
+              echo 'Skip the translation/AGENTS.md checks entirely.'
+              echo ''
+              echo 'Output format: read .github/REVIEW_FORMAT.md and follow it exactly. Always start with `## Code Review` and a `**Verdict:**` line (LGTM / Request changes / Needs discussion); tag every finding [Blocker] / [Major] / [Nit] with a file:line.'
               echo 'PROMPT_END'
             } >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
三項強化 `opencode-review`，動機都來自今天（7/20）的 review 事故分析。

## 1. `timeout-minutes: 60`（1 小時上限）

原本無設定（Actions 預設 6 小時）。**PR #247 的 review 失控跑了 4h35m、1,189 次 model 呼叫**才被取消，是今天 ~\$12 帳單的主因，也把 opencode-go 週額度打穿。一般 review 數分鐘即結束，1 小時已是極寬鬆上限。

## 2. model `qwen3.7-plus` → `mimo-v2.5`

mimo-v2.5 額度較大，避免動輒撞週額度上限（今天 3 個 run 報 `GoUsageLimitError`）。

> `opencode.yml` **不動**，維持 `qwen3.7-plus`。

## 3. 統一輸出格式（`.github/REVIEW_FORMAT.md`）

現況每篇 review 格式都不同：

| PR | 標題 | Verdict | section 風格 | 嚴重度標記 |
|----|------|---------|-------------|-----------|
| #252 | `## Code Review` | 無 | `**Bold**:` inline | 無 |
| #249 | `## Code Review: <title>` | `**Verdict: LGTM**` | `### H3` | 無 |
| #248 | `## Code Review: <title>` | `**Verdict: LGTM**` | `### H3` | 無 |

新增 `.github/REVIEW_FORMAT.md` 作為**唯一格式來源**，兩條 prompt 分支都改為「讀取並遵循該檔」。模板強制四個一致性錨點：

- 固定標題 `## Code Review`
- 一行 **Verdict**（`LGTM` / `Request changes` / `Needs discussion`）
- 嚴重度標記 `[Blocker]` / `[Major]` / `[Nit]` ＋ `file:line`
- **Verified OK** 段（列已確認正確的項，防下次 review 重複 flag）

> 為什麼放獨立檔而非塞進 YAML：沿用本 prompt 既有「讀 `AGENTS.md` / `REVIEW-PITFALLS.md`」的可運作模式（agent 確實會讀），且 markdown 的 backtick／`**`／emoji 不必在單引號 `echo` 裡轉義。翻譯 PR（`posts/`）改用專屬 section 名（Frontmatter 合規等），但 Verdict 與嚴重度標記與一般 review 一致。

## 檔案

- `opencode-review.yml`：＋`timeout-minutes`、改 model、兩分支 prompt 引用格式檔
- `.github/REVIEW_FORMAT.md`：新增（模板＋嚴重度定義＋規則）

## 驗證

- YAML 以 Ruby psych 解析通過；`opencode.yml` 未被改動。
- 本 PR 一合併（或在此分支上觸發）即可自我驗證——review 會讀到新的 `REVIEW_FORMAT.md` 並套用。