### PR TITLE
拆除 Eleventy 0.12 permalink 與 draft workaround（3a+3c，零行為變更）

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -55,7 +55,6 @@ const markdownItAnchor = require("markdown-it-anchor");
 const CleanCSS = require("clean-css");
 const { buildAuthorStats } = require("./_11ty/authorStats");
 const activeLanguages = require("./_11ty/activeLanguages");
-const isDraftFrontmatter = require("./_11ty/draftFlag");
 const { buildAiCrawlRules } = require("./_11ty/aiCrawlPolicy");
 const { commentCountsByPath } = require("./_11ty/discussions");
 const { CSS_FILES } = require("./_11ty/css-bundle");
@@ -305,36 +304,23 @@ module.exports = function (eleventyConfig) {
   // `ELEVENTY_ENV=development eleventy` emit orphan draft pages (permalink
   // gate said dev, collection gate said production).
   const IS_DEVELOPMENT = require("./_data/isdevelopment.js")();
-  const draftCache = new Map();
 
   const postLang = (item) => (item.data && item.data.lang) || DEFAULT_LANG;
-  const isDraft = (item) => {
-    if (!item) return false;
-    if (item.data && (item.data.draft === true || item.data.draft === "true")) {
-      return true;
-    }
-
-    // Eleventy 0.12 constructs custom collections before global computed data
-    // has finished. Read the source frontmatter as a deterministic fallback so
-    // drafts can never leak into feeds, hreflang, or sitemap collections.
-    const inputPath = item.inputPath;
-    if (!inputPath || !inputPath.endsWith(".md")) return false;
-    // Cache only for one-shot builds: a --serve rebuild must observe draft
-    // toggles in frontmatter, so dev reads the file every time.
-    if (!IS_DEVELOPMENT && draftCache.has(inputPath)) {
-      return draftCache.get(inputPath);
-    }
-    let draft = false;
-    try {
-      const raw = fs.readFileSync(inputPath, "utf8");
-      const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-      draft = Boolean(match && isDraftFrontmatter(match[1]));
-    } catch (error) {
-      throw new Error(`Unable to inspect draft state for ${inputPath}: ${error.message}`);
-    }
-    if (!IS_DEVELOPMENT) draftCache.set(inputPath, draft);
-    return draft;
-  };
+  // Eleventy 3.x resolves the full data cascade before it constructs custom
+  // collections, so `item.data.draft` is reliably populated here — drafts never
+  // leak into feeds, hreflang, or sitemap collections. Eleventy 0.12 built
+  // collections before global computed data finished, which forced a fallback
+  // that re-read and regex-parsed each source file's frontmatter (cached via a
+  // draftCache); that fallback is removed in the 3.x cleanup. The shared
+  // frontmatter predicate _11ty/draftFlag.js is still used by
+  // _11ty/activeLanguages.js and _11ty/search-index.js, which parse raw files
+  // outside Eleventy's data cascade.
+  const isDraft = (item) =>
+    Boolean(
+      item &&
+        item.data &&
+        (item.data.draft === true || item.data.draft === "true")
+    );
   const isVisible = (item) => !isDraft(item) || IS_DEVELOPMENT;
   // Only strip suffixes that are actual site languages, so a legitimately
   // dotted slug (e.g. `intro.v2.md`) keeps its full key.

--- a/_data/eleventyComputed.js
+++ b/_data/eleventyComputed.js
@@ -20,15 +20,12 @@ module.exports = {
       return false;
     }
     // The localized shells are paginated templates whose front-matter
-    // permalink is itself a template ("/{{ alang }}/about/"). Eleventy 0.12
-    // does NOT re-render a permalink returned from computed data, so passing
-    // `data.permalink` through verbatim collapses every active shell page onto
-    // one empty output path (DuplicatePermalinkOutputError). Build the concrete
-    // URL from the pagination alias instead.
-    const shellPermalink = localizedShellPermalink(data);
-    if (shellPermalink) {
-      return shellPermalink;
-    }
+    // permalink is itself a template ("/{{ alang }}/about/"). Eleventy 3.x
+    // re-renders a permalink template returned from computed data, so passing
+    // `data.permalink` through verbatim resolves each shell's own front-matter
+    // permalink per pagination page. (Eleventy 0.12 did NOT re-render it, which
+    // forced an explicit `localizedShellPermalink()` helper here — removed in
+    // the 3.x cleanup; see git history if it ever needs to come back.)
     return data.permalink;
   },
   eleventyExcludeFromCollections: (data) => {
@@ -41,40 +38,6 @@ module.exports = {
     return data.eleventyExcludeFromCollections || false;
   },
 };
-
-/**
- * Concrete permalink for a localized shell page, derived from its pagination
- * alias. Must stay in sync with the shells' front-matter permalink templates.
- * Returns null for non-shell pages (and for shells whose alias is not yet
- * available), letting the caller fall back to `data.permalink`.
- */
-function localizedShellPermalink(data) {
-  const inputPath = (data.page && data.page.inputPath) || "";
-  if (/home-i18n\.njk$/.test(inputPath) && data.hlang) {
-    return `/${data.hlang}/`;
-  }
-  if (/about-i18n\.njk$/.test(inputPath) && data.alang) {
-    return `/${data.alang}/about/`;
-  }
-  if (/404-i18n\.njk$/.test(inputPath) && data.notFoundLang) {
-    return `/${data.notFoundLang}/404.html`;
-  }
-  if (/feed\/feed-i18n\.njk$/.test(inputPath) && data.flang) {
-    return `/${data.flang}/feed/feed.xml`;
-  }
-  if (/feed\/json-i18n\.njk$/.test(inputPath) && data.flang) {
-    return `/${data.flang}/feed/feed.json`;
-  }
-  if (
-    /author-langs\.njk$/.test(inputPath) &&
-    data.ap &&
-    data.ap.lang &&
-    data.ap.author
-  ) {
-    return `/${data.ap.lang}/posts/${data.ap.author}/`;
-  }
-  return null;
-}
 
 /**
  * A localized shell page (home/About/feeds/author) is active only when its

--- a/test/test-production-output.js
+++ b/test/test-production-output.js
@@ -180,9 +180,11 @@ describe("production output boundaries", () => {
       permalink: "/{{ ap.lang }}/posts/{{ ap.author }}/",
     };
 
+    // Active shell → the front-matter permalink template is passed through for
+    // Eleventy 3.x to re-render per pagination page; inactive shell → false.
     assert.equal(
       computedData.permalink({ ...base, ap: { lang: "en", author: "tian" } }),
-      "/en/posts/tian/"
+      "/{{ ap.lang }}/posts/{{ ap.author }}/"
     );
     assert.equal(
       computedData.permalink({ ...base, ap: { lang: "ja", author: "tian" } }),
@@ -196,25 +198,28 @@ describe("production output boundaries", () => {
       {
         inputPath: "./feed/feed-i18n.njk",
         raw: "/{{ flang }}/feed/feed.xml",
-        expected: "/en/feed/feed.xml",
       },
       {
         inputPath: "./feed/json-i18n.njk",
         raw: "/{{ flang }}/feed/feed.json",
-        expected: "/en/feed/feed.json",
       },
     ];
-    for (const { inputPath, raw, expected } of cases) {
+    for (const { inputPath, raw } of cases) {
       const base = { page: { inputPath }, activeLangs, permalink: raw };
-      assert.equal(computedData.permalink({ ...base, flang: "en" }), expected);
+      // Active language → template passed through verbatim (Eleventy 3.x
+      // re-renders it); inactive language → false, so no page is emitted.
+      assert.equal(computedData.permalink({ ...base, flang: "en" }), raw);
       assert.equal(computedData.permalink({ ...base, flang: "ja" }), false);
     }
   });
 
-  // Eleventy 0.12 does not re-render a permalink string returned from
-  // computed data, so active shells must yield concrete URLs — echoing the
-  // raw front-matter template collapses them all onto one empty output path.
-  it("renders concrete permalinks for active localized shells", () => {
+  // Eleventy 3.x re-renders a permalink template returned from computed data,
+  // so an active shell simply passes its own front-matter permalink template
+  // through and Eleventy resolves it per pagination page. (Eleventy 0.12 did
+  // NOT re-render it, which forced an explicit concrete-URL helper here; the
+  // concrete output is now asserted end-to-end by the sitemap/existence tests
+  // above.)
+  it("passes each active localized shell's permalink template through", () => {
     const activeLangs = ["zh-TW", "en"];
     assert.equal(
       computedData.permalink({
@@ -223,7 +228,7 @@ describe("production output boundaries", () => {
         hlang: "en",
         permalink: "/{{ hlang }}/",
       }),
-      "/en/"
+      "/{{ hlang }}/"
     );
     assert.equal(
       computedData.permalink({
@@ -232,7 +237,17 @@ describe("production output boundaries", () => {
         alang: "en",
         permalink: "/{{ alang }}/about/",
       }),
-      "/en/about/"
+      "/{{ alang }}/about/"
+    );
+    // An inactive shell still yields false regardless of the raw template.
+    assert.equal(
+      computedData.permalink({
+        page: { inputPath: "./home-i18n.njk" },
+        activeLangs,
+        hlang: "ja",
+        permalink: "/{{ hlang }}/",
+      }),
+      false
     );
   });
 });


### PR DESCRIPTION
## 背景與目的

main 已升級至 Eleventy 3.1.6。本站有多處 workaround 是為了遷就 Eleventy 0.12 的特定行為而存在。本 PR 拆除其中兩個確認在 3.x 已不需要的 workaround，並以黃金輸出比對（golden diff）逐一證明零行為變更。

方法論：每個 workaround 先嘗試移除 → 用 `scripts/diff-site.js` 對 main 比對 → 空報告才保留移除；若比對非空或 build 失敗，代表 3.x 仍需該 workaround，則還原並記錄。

## 改動內容

### Stage 3a — 移除 `localizedShellPermalink` 手動組路徑（`_data/eleventyComputed.js`）
- 0.12 不會重新渲染 computed data 回傳的 permalink 樣板，因此先前需依 pagination alias 手動組出每個語系殼頁（home / about / feeds / 404 / author-langs）的具體 URL，否則所有殼頁會塌成同一空路徑（DuplicatePermalinkOutputError）。
- 3.x 會重新渲染 computed permalink，殼頁自身 front-matter 的 `/{{ hlang }}/` 等樣板會逐頁正確解析。`permalink` 只保留 draft gate + `localizedShellIsActive` gate，最後直接回傳 `data.permalink`。
- 佐證：`tags-list-i18n.njk` 在 main 上早已直接放行 `data.permalink`（未經舊 helper 處理）且建置正常。

### Stage 3c — 移除 `isDraft` 重讀檔案 fallback（`.eleventy.js`）
- 0.12 在 global computed data 完成前就建構 custom collections，`item.data.draft` 可能尚未填好，草稿會漏進 feed / hreflang / sitemap；先前以 `readFileSync` + regex 重解析 frontmatter（並用 `draftCache` 快取）作為保險。
- 3.x 會先解析完整 data cascade 才建構 custom collections，`item.data.draft` 在此可靠可用，fallback 為死碼。一併移除 `draftCache` 與此處專用的 `draftFlag` require。
- **保留** `_11ty/draftFlag.js`：仍被 `_11ty/activeLanguages.js` 與 `_11ty/search-index.js` 使用（兩者在 data cascade 之外自行讀原始檔）。

### 測試對齊
- `test/test-production-output.js` 原斷言殼頁 permalink「回傳具體 URL」為 0.12 契約，改為斷言「回傳原始樣板、inactive 為 false」。具體 URL 產出改由同檔既有的 sitemap／輸出存在性測試端到端把關。

## 爆炸半徑
- `_data/eleventyComputed.js`、`.eleventy.js`、`test/test-production-output.js`。
- 影響面：i18n 殼頁 URL 產生、草稿在各 collection（feed / sitemap / hreflang）的排除。
- 皆以 production 建置的黃金輸出比對驗證無 SEO 輸出變更；334 個 HTML 頁數與 main 一致。

## 驗證證據（golden diff 空報告 + draft/permalink fixture）
- **Stage 3a**：production 建置，`node scripts/diff-site.js <ref> _site` →「兩份 _site 的 SEO 相關輸出完全相同，無差異」（exit 0），無 DuplicatePermalinkOutputError；`/en /ja /zh-cn` 的 home / about / feed(xml+json) / 404 / tags / author-langs 殼頁 URL 全數存在且正確。
- **Stage 3c**：以暫時性 zh-TW 草稿 fixture（`draft: true`，事後移除）驗證：
  - production：fixture 不在 `_site`、`sitemap.xml`（0 筆）、`feed/feed.xml`（0 筆）；黃金輸出比對對 main 為空。
  - development（`ELEVENTY_ENV=development`）：fixture 出現在 `_site` 與 `sitemap.xml`（1 筆）。
- **回歸測試**：`mocha test/test*.js` 全數通過（192 passing），含更新後的殼頁 permalink 契約測試。

## 有意不做（列出 3.x 仍需而保留的 workaround）
- **`localizedShellIsActive`（`_data/eleventyComputed.js`）維持讀 `activeLangs` 全域資料而非 `collections.*`**：其註解記載 0.12 會把讀取 `data.collections.*` 的 computed 項目延後到第二輪（此時 paginated URL 已定），故改讀全域資料。本 PR 未驗證 3.x 是否已解除此限制，保守保留；屬另一條獨立 workaround，不在本 PR 範圍。
- **`_11ty/draftFlag.js` 及其在 `activeLanguages.js` / `search-index.js` 的用途**：這些是在 Eleventy data cascade 之外自行讀原始檔的路徑，與 3.x 的 `item.data` 無關，維持不動。

## 後續
- 若日後要清 `localizedShellIsActive` 的 collections 延後 workaround，需另開 PR 並以相同黃金比對驗證。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
